### PR TITLE
update migrations to devise 2.0 schema style

### DIFF
--- a/db/migrate/20120102210558_devise_create_users.rb
+++ b/db/migrate/20120102210558_devise_create_users.rb
@@ -1,16 +1,45 @@
 class DeviseCreateUsers < ActiveRecord::Migration
   def change
     create_table(:users) do |t|
-      t.database_authenticatable :null => false
-      t.recoverable
-      t.rememberable
-      t.trackable
-
-      # t.encryptable
-      # t.confirmable
       # t.lockable :lock_strategy => :failed_attempts, :unlock_strategy => :both
       # t.token_authenticatable
 
+      ## Database authenticatable
+      t.string :email,              :null => false, :default => ""
+      t.string :encrypted_password, :null => false, :default => ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, :default => 0
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
+
+      ## Encryptable
+      # t.string :password_salt
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0 # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      # Token authenticatable
+      # t.string :authentication_token
+
+      ## Invitable
+      # t.string :invitation_token
 
       t.timestamps
     end

--- a/db/migrate/20120129211750_add_lockable_to_users.rb
+++ b/db/migrate/20120129211750_add_lockable_to_users.rb
@@ -1,7 +1,9 @@
 class AddLockableToUsers < ActiveRecord::Migration
   def change
     change_table :users do |t|
-          t.lockable :lock_strategy => :failed_attempts, :unlock_strategy => :both
+          t.integer  :failed_attempts, :default => 0 # Only if lock strategy is :failed_attempts
+          t.string   :unlock_token # Only if unlock strategy is :email or :both
+          t.datetime :locked_at
     end
     add_index :users, :unlock_token, :unique => true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,8 +19,8 @@ ActiveRecord::Schema.define(:version => 20121105144421) do
     t.integer  "expire_after_views"
     t.boolean  "expired",            :default => false
     t.string   "url_token"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                            :null => false
+    t.datetime "updated_at",                            :null => false
     t.integer  "user_id"
     t.boolean  "deleted",            :default => false
   end
@@ -34,27 +34,27 @@ ActiveRecord::Schema.define(:version => 20121105144421) do
     t.string   "table"
     t.integer  "month",      :limit => 2
     t.integer  "year",       :limit => 5
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",              :null => false
+    t.datetime "updated_at",              :null => false
   end
 
   add_index "rails_admin_histories", ["item", "table", "month", "year"], :name => "index_rails_admin_histories"
 
   create_table "users", :force => true do |t|
-    t.string   "email",                                 :default => "",    :null => false
-    t.string   "encrypted_password",     :limit => 128, :default => "",    :null => false
+    t.string   "email",                  :default => "",    :null => false
+    t.string   "encrypted_password",     :default => "",    :null => false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                         :default => 0
+    t.integer  "sign_in_count",          :default => 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.boolean  "admin",                                 :default => false
-    t.integer  "failed_attempts",                       :default => 0
+    t.datetime "created_at",                                :null => false
+    t.datetime "updated_at",                                :null => false
+    t.boolean  "admin",                  :default => false
+    t.integer  "failed_attempts",        :default => 0
     t.string   "unlock_token"
     t.datetime "locked_at"
   end
@@ -69,8 +69,8 @@ ActiveRecord::Schema.define(:version => 20121105144421) do
     t.string   "user_agent"
     t.string   "referrer"
     t.boolean  "successful"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",  :null => false
+    t.datetime "updated_at",  :null => false
   end
 
 end


### PR DESCRIPTION
Updated the the migrations (including db/schema.rb) to match the devise 2.0 schema style found at https://github.com/plataformatec/devise/wiki/How-To%3a-Upgrade-to-Devise-2.0-migration-schema-style

I am suggesting this change since the https://github.com/pglombardo/PasswordPusher/blob/master/Gemfile.lock#L73 is using a devise 2.0+ version and was not working for a brand new setup unless these changes were made.
