### PR TITLE
End of the Oregon Trail

### DIFF
--- a/app/views/passwords/show.html.haml
+++ b/app/views/passwords/show.html.haml
@@ -36,8 +36,8 @@
           Don't believe me?  Go ahead.  Hit reload...
     %p
       Your password is...
-  
-    %div.payload.spoiler
+
+    %div.payload.spoiler<
       = @payload
 
     %p


### PR DESCRIPTION
This is a fix for: https://github.com/pglombardo/PasswordPusher/issues/15

The password show page's html was being rendered from Haml as:

```
<div title="Click to reveal completely" style="cursor: pointer;" class="payload spoiler">
  mybadpassword
</div>
```

Firefox and IE weren't liking this when you would highlight the password to copy it and paste it somewhere else. They would copy that extra newline, that **trail**ing white space after `mybadpassword` and before `</div>`, and you would end up pasting `mybadpassword<space>` if you weren't careful.

I learned [here](http://haml.info/docs/yardoc/file.REFERENCE.html#whitespace_removal__and_) that you can just strip out excess white space within a container with one simple character. Pretty slick (this is my first time using Haml).

After the fix, the html will end up like this:
`<div title="Click to reveal completely" style="cursor: pointer;" class="payload spoiler">mybadpassword</div>`

![](https://i.ytimg.com/vi/YjPL9jwDdhA/hqdefault.jpg)
