### PR TITLE
Minor typo fix.

### DIFF
--- a/app/views/passwords/show.html.haml
+++ b/app/views/passwords/show.html.haml
@@ -6,7 +6,7 @@
       This password has expired.
     %p
       - if @password.deleted
-        This password was manually deleted by one of it's viewers.
+        This password was manually deleted by one of its viewers.
       - elsif @password.views_remaining == 0
         == The password has hit its maximum view count: #{@password.expire_after_views}.
       - elsif @password.days_remaining == 0


### PR DESCRIPTION
Changed “it’s” to “its”, since when used with an apostrophe, “it’s” is
a contraction for “it is”, not a possessive.