### PR TITLE
Feature: use HTTPS scheme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 # source 'https://repo.fury.io/pglombardo/'
 
 gem 'rails', '~> 3.2'

--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ gem 'json'
 gem 'haml'
 gem 'haml-rails'
 gem 'therubyracer'
-gem 'ezcrypto', :git => 'git://github.com/pglombardo/ezcrypto.git'
-gem 'modernizr-rails', :git => 'git://github.com/russfrisch/modernizr-rails.git'
+gem 'ezcrypto', :git => 'https://github.com/pglombardo/ezcrypto.git'
+gem 'modernizr-rails', :git => 'https://github.com/russfrisch/modernizr-rails.git'
 gem "high_voltage", '~> 2.1.0'
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
-  remote: git://github.com/pglombardo/ezcrypto.git
+  remote: https://github.com/pglombardo/ezcrypto.git
   revision: f816b64dcbccfb9b7687b484352d3f03fc954dce
   specs:
     ezcrypto (0.7.2)
 
 GIT
-  remote: git://github.com/russfrisch/modernizr-rails.git
+  remote: https://github.com/russfrisch/modernizr-rails.git
   revision: 614d36431ac449624dd273d189cfa6103e84741d
   specs:
     modernizr-rails (2.8.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actionmailer (3.2.22.5)
       actionpack (= 3.2.22.5)


### PR DESCRIPTION
Fix warnings about insecure protocols, and ensure that gems are downloaded over SSL-protected links. These patches should not impact application behavior in any way, other than to increase security when using Bundler.