### PR TITLE
Fix JSON compatibility with MRI Ruby 2.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development, :test do
   gem "nifty-generators"
 end
 
-gem 'json'
+gem 'json', '~> 2.0'
 gem 'haml'
 gem 'haml-rails'
 gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.3)
+    json (2.0.2)
     kgio (2.11.0)
     libv8 (3.16.14.17)
     linecache (1.3.1)
@@ -106,9 +106,9 @@ GEM
     omniauth-openid (1.0.1)
       omniauth (~> 1.0)
       rack-openid (~> 1.3.1)
-    omniauth-twitter (1.2.1)
-      json (~> 1.3)
-      omniauth-oauth (~> 1.1)
+    omniauth-twitter (1.1.0)
+      multi_json (~> 1.3)
+      omniauth-oauth (~> 1.0)
     orm_adapter (0.5.0)
     pg (0.19.0)
     polyglot (0.3.5)
@@ -146,8 +146,7 @@ GEM
       thor (>= 0.14.6, < 2.0)
     raindrops (0.17.0)
     rake (12.0.0)
-    rdoc (3.12.2)
-      json (~> 1.4)
+    rdoc (3.9.5)
     ref (2.0.0)
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
@@ -202,7 +201,7 @@ DEPENDENCIES
   haml-rails
   high_voltage (~> 2.1.0)
   jquery-rails
-  json
+  json (~> 2.0)
   modernizr-rails!
   nifty-generators
   omniauth
@@ -221,4 +220,4 @@ DEPENDENCIES
   unicorn
 
 BUNDLED WITH
-   1.13.6
+   1.13.7


### PR DESCRIPTION
## Summary
This patch updates the JSON gem to a version compatible with Ruby 2.4.0. In addition, it was necessary to update the Bundler resolution for omniauth-twitter and sass-rails, as they too had a fixed dependency on the unsupported version of the JSON gem.

## See Also
https://github.com/flori/json/issues/303