### PR TITLE
Add basic Travis-CI configuration file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+rvm:
+  - 2.3.3
+  - 2.4.0
+  - rbx-3.69
+branches:
+  only:
+    - master
+bundler_args: --without production


### PR DESCRIPTION
- Provide a configuration file for integrating the repository with
  Travis-CI.
- Caveats:
    - There are no tests yet.
    - There are gems which should be moved to a production block, as
      they aren't needed for testing.
    - The repository must be configured to use the Travis-CI webhook
      before it will actually run.

Integrating this patch will partially address #46.