### PR TITLE
Add the possibility to configure some settings using ENV-variables

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,10 +12,53 @@
   },
   "env": {
     "BUNDLE_WITHOUT": "development:test:private",
+    "CRYPT_KEY": {
+      "description": "CRYPT key",
+      "generator": "secret"
+    },
+    "CRYPT_SALT": {
+      "description": "CRYPT salt",
+      "generator": "secret"
+    },
     "WEB_CONCURRENCY": {
       "description": "The number of processes to run.",
       "value": "3"
-    }
+    },
+    "PAYLOAD_INITIAL_TEXT": {
+      "description": "The initial text for the input field",
+      "value": "Enter the Password to be Shared"
+    },
+    "EXPIRE_AFTER_DAYS_DEFAULT": {
+      "description": "Default value for expire after days",
+      "value": "7"
+    },
+    "EXPIRE_AFTER_DAYS_MIN": {
+      "description": "Expire after days minimum value",
+      "value": "1"
+    },
+    "EXPIRE_AFTER_DAYS_MAX": {
+      "description": "Expire after days maximum value",
+      "value": "90"
+    },
+    "EXPIRE_AFTER_VIEWS_DEFAULT": {
+      "description": "Expire after views default value",
+      "value": "5"
+    },
+    "EXPIRE_AFTER_VIEWS_MIN": {
+      "description": "Expire after views minimum value",
+      "value": "1"
+    },
+    "EXPIRE_AFTER_VIEWS_MAX": {
+      "description": "Expire after views maximum value",
+      "value": "100"
+    },
+    "DELETABLE_BY_VIEWER_PASSWORDS": {
+      "description": "When true, passwords will have a link to optionally delete the password being viewed. When pushing a new password, this option will also add a checkbox to conditionally enable/disable this feature on a per-password basis.",
+      "value": "true"
+    },
+    "DELETABLE_BY_VIEWER_DEFAULT": {
+      "description": "When the option DELETABLE_BY_VIEWER_PASSWORDS is set to true, this option does two things: 1. Sets the default check state for the \"Allow viewers to optionally delete password before expiration\" checkbox. 2. Sets the default value for newly pushed passwords if unspecified (such as with a json request)",
+      "value": "true"
+    },
   }
 }
-

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,21 +1,21 @@
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 
-PAYLOAD_INITIAL_TEXT = 'Enter the Password to be Shared'
+PAYLOAD_INITIAL_TEXT = ENV.fetch('PAYLOAD_INITIAL_TEXT', 'Enter the Password to be Shared')
 
 # If deploying PasswordPusher yourself, you should change these CRYPT values.
-CRYPT_KEY = '}s-#2R0^/+2wEXc47\$9Eb'
-CRYPT_SALT = ',2_%4?[+:3774>f'
+CRYPT_KEY = ENV.fetch('CRYPT_KEY', '}s-#2R0^/+2wEXc47\$9Eb')
+CRYPT_SALT = ENV.fetch('CRYPT_SALT', ',2_%4?[+:3774>f')
 
 # Controls the "Expire After Days" form settings in Password#new
-EXPIRE_AFTER_DAYS_DEFAULT = 7
-EXPIRE_AFTER_DAYS_MIN = 1
-EXPIRE_AFTER_DAYS_MAX = 90
+EXPIRE_AFTER_DAYS_DEFAULT = Integer(ENV.fetch('EXPIRE_AFTER_DAYS_DEFAULT', 7))
+EXPIRE_AFTER_DAYS_MIN = Integer(ENV.fetch('EXPIRE_AFTER_DAYS_MIN', 1))
+EXPIRE_AFTER_DAYS_MAX = Integer(ENV.fetch('EXPIRE_AFTER_DAYS_MAX', 90))
 
 # Controls the "Expire After Views" form settings in Password#new
-EXPIRE_AFTER_VIEWS_DEFAULT = 5
-EXPIRE_AFTER_VIEWS_MIN = 1
-EXPIRE_AFTER_VIEWS_MAX = 100
+EXPIRE_AFTER_VIEWS_DEFAULT = Integer(ENV.fetch('EXPIRE_AFTER_VIEWS_DEFAULT', 5))
+EXPIRE_AFTER_VIEWS_MIN = Integer(ENV.fetch('EXPIRE_AFTER_VIEWS_MIN', 1))
+EXPIRE_AFTER_VIEWS_MAX = Integer(ENV.fetch('EXPIRE_AFTER_VIEWS_MAX', 100))
 
 # DELETABLE_BY_VIEWER_PASSWORDS
 # Can passwords be deleted by viewers?
@@ -25,7 +25,7 @@ EXPIRE_AFTER_VIEWS_MAX = 100
 # When pushing a new password, this option will also add a
 # checkbox to conditionally enable/disable this feature on
 # a per-password basis.
-DELETABLE_BY_VIEWER_PASSWORDS = true
+DELETABLE_BY_VIEWER_PASSWORDS = ENV.fetch('DELETABLE_BY_VIEWER_PASSWORDS', 'true') == 'true'
 
 # DELETABLE_BY_VIEWER_DEFAULT
 #
@@ -36,7 +36,7 @@ DELETABLE_BY_VIEWER_PASSWORDS = true
 #   2. Sets the default value for newly pushed passwords if
 #       if unspecified (such as with a json request)
 #
-DELETABLE_BY_VIEWER_DEFAULT = true
+DELETABLE_BY_VIEWER_DEFAULT = ENV.fetch('DELETABLE_BY_VIEWER_DEFAULT', 'true') == 'true'
 
 # Initialize the rails application
 PasswordPusher::Application.initialize!


### PR DESCRIPTION
These constants can now be configured from ENV-variables (all of them still have default values):

- `PAYLOAD_INITIAL_TEXT`
- `CRYPT_KEY`
- `CRYPT_SALT`
- `EXPIRE_AFTER_DAYS_DEFAULT`
- `EXPIRE_AFTER_DAYS_MIN`
- `EXPIRE_AFTER_DAYS_MAX`
- `EXPIRE_AFTER_VIEWS_DEFAULT`
- `EXPIRE_AFTER_VIEWS_MIN`
- `EXPIRE_AFTER_VIEWS_MAX`
- `DELETABLE_BY_VIEWER_PASSWORDS`
- `DELETABLE_BY_VIEWER_DEFAULT`