### PR TITLE
Don't expose password to link previewers

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,13 +4,14 @@
     %title PasswordPusher
     = csrf_meta_tags
     = stylesheet_link_tag    "application"
+    %meta{:name => "description", :content => "PasswordPusher is an application to securely communicate passwords over the web. Links to passwords expire after a certain number of views and/or time has passed."}
     %link{ :rel => "shortcut icon",    :href => asset_path("favicon.ico"), :type => "image/x-icon" }
     %link{ :rel => "apple-touch-icon", :href => asset_path("apple-touch-icon-iphone.png") }
     %link{ :rel => "apple-touch-icon", :sizes => "72x72",   :href => asset_path("apple-touch-icon-ipad.png") }
     %link{ :rel => "apple-touch-icon", :sizes => "114x114", :href => asset_path("apple-touch-icon-iphone4.png") }
     %link{ :rel => "apple-touch-icon", :sizes => "144x144", :href => asset_path("apple-touch-icon-ipad3.png") }
     :javascript
-      // Set up the yepnope (Modernizr.load) directives... 
+      // Set up the yepnope (Modernizr.load) directives...
       Modernizr.load([
       {
           // Test if Input Range is supported using Modernizr


### PR DESCRIPTION
A chat client I use has link previews, and it kinda defeats the purpose of the website:
![image](https://cloud.githubusercontent.com/assets/1190097/26372339/e3ff7366-3fba-11e7-9463-3db44e354a26.png)

It looks for the meta tag `description`, and failing to find that it toString()'s the body, resulting in what you see.

Adding something like `<meta name="description" content="A password pushing website">` to the html output would help mitigate this issue.