### PR TITLE
Better styling of the secret link & button to copy to clipboard.

### DIFF
--- a/app/assets/stylesheets/passwords.css.scss
+++ b/app/assets/stylesheets/passwords.css.scss
@@ -45,16 +45,36 @@ span.note { color: #808080; }
 span.tip { font-style: italic; }
 p.notes a:link, p.notes a:visited, p.notes a:hover, p.notes a:active { font-size: .9em; }
 
-p.url { vertical-align: top; margin: 0;}
+p.url { vertical-align: top; margin: 5px;}
 
-p.url input {
-  border: 1px solid #808080;
-  text-align: center;
-  width: 400px;
-  font-size: .8em;
+div.input_group {
+  box-sizing: border-box;
 }
 
-p.url span.clippy {}
+input#url {
+  box-sizing: border-box;
+  position: relative;
+  border: 1px solid #ccc;
+  border-radius: 3px 0px 0px 3px;
+  text-align: center;
+  vertical-align: middle;
+  width: 400px;
+  font-size: 13px;
+  min-height: 36px;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.075);
+}
+
+button.btn {
+  box-sizing: border-box;
+  position: relative;
+  display: inline-block;
+  margin-left: -4px;
+  border: 1px solid #d5d5d5;
+  vertical-align: middle;
+  min-height: 36px;
+  border-radius: 0px 3px 3px 0px;
+  padding: 0;
+}
 
 /* This is a decent font to display passwords as L, l, 0, o, i, I are fairly distinguishable */
 @import url(https://fonts.googleapis.com/css?family=PT+Mono);

--- a/app/views/passwords/show.html.haml
+++ b/app/views/passwords/show.html.haml
@@ -17,11 +17,10 @@
       .share_note
         == This is your password.  Use this secret link to share it:
         %p.url
-          %input#url{ :value => "#{request.url}", :spellcheck => "false", :onfocus => '$(this).focus(); $(this).select();', :onclick => '$(this).select();', :readonly => true }
-          %span#clip_data{ :style => 'display: none;' }= request.url
-          %span.btn#clippy{ :'data-clipboard-target' => '#url' }
-            = image_tag('button_up.png')
-        %br/
+          %div.input_group
+            %input#url{ :value => "#{request.url}", :spellcheck => "false", :onfocus => '$(this).focus(); $(this).select();', :onclick => '$(this).select();', :readonly => true }
+            %button.btn{ "data-clipboard-target" => "#url" }
+              = image_tag('button_up.png')
         %span.note
           This note won't be shown again...
           %br/


### PR DESCRIPTION
Improved styling of the input box and copy to clipboard button.

![screen shot 2017-10-23 at 10 49 21](https://user-images.githubusercontent.com/395132/31880158-01f96730-b7e0-11e7-8f4b-99757b581fbf.png)
