### PR TITLE
Added containerization folder structure + postgres persistent storage…

### DIFF
--- a/containerization/README.md
+++ b/containerization/README.md
@@ -1,0 +1,23 @@
+## Build/prerequisites details:
+All the builds and tests on host machine were done using rpm packages (no pip packages) :
+  - CentOS Linux release 7.4.1708 (Core)
+  - docker-client-1.13.1-53.git774336d.el7.centos.x86_64
+  - docker-compose-1.9.0-5.el7.noarch (maximum 2.1 template version)
+
+## You can run passwordpusher containerized in many scenarios:
+
+##### passwordpusher-ephemeral
+This scenario runs the app in a single container using sqlite3 with no persistent storage (if you recreate the container the data is lost); best if don't care too much about the data and and looking for simplicity in deployment
+  - this image works also with openshift/kubernetes (without persistent storage)
+  - docker image located here: docker.io/sfarosu/passwordpusher-ephemeral
+  - run it with: docker run -p 5000:5000 -d docker.io/sfarosu/passwordpusher-ephemeral
+
+##### passwordpusher-postgres
+This scenario uses docker-compose and runs the app using 2 containers on a single host (passwordpusher and postgres); persistent storage for postgres is assured by using a volume on the host machine
+  - if you want to change the postgres credentials, change them in Dockerfile (env DATABASE_URL), and in docker-compose file; lastly, rebuild the image then run the updated docker-composer
+  - run it with: docker-compose up -d (daemonized)
+  - stop it with: docker-compose down
+  - your postgres data will be saved on the host machine in /var/lib/postgresql/data
+
+##### passwordpusher-postgres (external database)
+If you want to use passwordpusher with an external/existing postgres server, edit in the dockerfile the "DATABASE_URL" env var and rebuild the image (provided you have gave it a proper user / permissions, at first start it will create a new database and it's schema using rake db:migrate/see entrypoint.sh file)

--- a/containerization/passwordpusher-ephemeral/Dockerfile
+++ b/containerization/passwordpusher-ephemeral/Dockerfile
@@ -1,0 +1,34 @@
+FROM docker.io/ubuntu:18.04
+
+# Use the following 2 env variables if you need proxy support in your environment
+#ENV https_proxy=http://10.0.2.2:3128
+#ENV http_proxy=http://10.0.2.2:3128
+
+ENV APP_ROOT=/opt/PasswordPusher
+ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
+RUN ln -fs /usr/share/zoneinfo/Europe/Paris > /etc/localtime
+RUN apt-get update -qq && \
+    apt-get install -y --assume-yes build-essential git curl ruby2.5 ruby2.5-dev tzdata sqlite3 ruby-sqlite3 libsqlite3-dev zlib1g-dev && \
+    cd /opt && \
+    git clone https://github.com/pglombardo/PasswordPusher.git && \
+    touch ${APP_ROOT}/log/private.log && \
+    cd ${APP_ROOT} && \
+    gem install bundler && \
+    gem install thor && \
+    chown -R 1001:root ${APP_ROOT}
+
+EXPOSE 5000
+
+USER 1001
+WORKDIR ${APP_ROOT}
+RUN bundle install --without development production test --deployment && \
+    bundle exec rake assets:precompile && \
+    RAILS_ENV=private bundle exec rake db:setup
+
+USER root
+RUN chmod -R u+x ${APP_ROOT} && \
+    chgrp -R 0 ${APP_ROOT} && \
+    chmod -R g=u ${APP_ROOT} /etc/passwd
+
+USER 1001
+ENTRYPOINT [ "bundle", "exec", "foreman", "start", "internalweb" ]

--- a/containerization/passwordpusher-postgres/Dockerfile
+++ b/containerization/passwordpusher-postgres/Dockerfile
@@ -1,0 +1,37 @@
+FROM docker.io/ubuntu:18.04
+
+# Use the following 2 env variables if you need proxy support in your environment
+#ENV https_proxy=http://10.0.2.2:3128
+#ENV http_proxy=http://10.0.2.2:3128
+ENV APP_ROOT=/opt/PasswordPusher
+ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
+ENV DATABASE_URL=postgresql://passwordpusher_user:passwordpusher_passwd@postgres:5432/passwordpusher_db
+
+RUN ln -fs /usr/share/zoneinfo/Europe/Paris > /etc/localtime
+RUN apt-get update -qq && \
+    apt-get install -y --assume-yes build-essential libpq-dev git curl ruby2.5 ruby2.5-dev tzdata sqlite3 ruby-sqlite3 libsqlite3-dev zlib1g-dev && \
+    cd /opt && \
+    #git clone https://github.com/pglombardo/PasswordPusher.git && \
+    git clone https://github.com/sfarosu/PasswordPusher.git && \
+    touch ${APP_ROOT}/log/production.log && \
+    cd ${APP_ROOT} && \
+    gem install bundler && \
+    gem install thor && \
+    chown -R 1001:root ${APP_ROOT}
+
+EXPOSE 5000
+
+USER 1001
+WORKDIR ${APP_ROOT}
+RUN bundle install --without development private test --deployment && \
+    bundle exec rake assets:precompile && \
+    RAILS_ENV=production
+
+USER root
+RUN chmod -R u+x ${APP_ROOT} && \
+    chgrp -R 0 ${APP_ROOT} && \
+    chmod -R g=u ${APP_ROOT} /etc/passwd
+
+USER 1001
+WORKDIR ${APP_ROOT}
+ENTRYPOINT ["containerization/passwordpusher-postgres/entrypoint.sh"]

--- a/containerization/passwordpusher-postgres/docker-compose.yaml
+++ b/containerization/passwordpusher-postgres/docker-compose.yaml
@@ -1,0 +1,21 @@
+version: '2.1'
+services:
+
+  postgres:
+    image: docker.io/postgres:10
+    volumes:
+      - /var/lib/postgresql/data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: passwordpusher_user
+      POSTGRES_PASSWORD: passwordpusher_passwd
+      POSTGRES_DB: passwordpusher_db
+
+  passwordpusher:
+    image: docker.io/sfarosu/passwordpusher-postgres
+    #build: .
+    ports:
+      - "5000:5000"
+    depends_on:
+      - postgres

--- a/containerization/passwordpusher-postgres/entrypoint.sh
+++ b/containerization/passwordpusher-postgres/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+RAILS_ENV=production bundle exec rake db:migrate
+bundle exec foreman start web
+
+exec "$@"


### PR DESCRIPTION
Hello, it's me again :)

As you will see, this pull will bring the "containerization" folder where i propose we keep all docker related stuff like "passwordpusher-ephemeral", "passwordpusher-postgres" and later "passwordpusher-openshift".

New stuff:
- directory structure
- README.md file under containerization/  (can be improved)
- slimed down the images with about 100mb
- passwordpusher-ephemeral has it's own folder/category and it's the one using just sqlite3
- passwordpusher-postgres is using docker-compose to launch both password pusher and postgres in separate containers and saves data on host machine in /var/lib/postgresql/data 

On your side you should do the following changes:
- accept the pull so your repo has the containerization folder
- build the passwordpusher-ephemeral image on your machine and push it to your docker.io account
- update the /containerization/README.md file lines 12 and 13 with the correct images
- delete the Dockerfile from the root of the repo as it's replaced by new dir structure
- in the file /containerization/passwordpusher-postgres/Dockerfile after the containerization folder exists in your repo, you should delete line 15 wich refers to my repo and uncomment line 14
- build the passwordpusher-postgres image on your machine and push it to your docker.io account
- in the file  /containerization/passwordpusher-postgres/docker-compose.yaml update line 16 with your docker.io image

I know it's alot of stuff, but this way everything will point to the project not to my repo/docker.io.