### PR TITLE
Added Openshift template with buildconfig + updated the openshift docs

### DIFF
--- a/containerization/README.md
+++ b/containerization/README.md
@@ -16,7 +16,7 @@ This scenario runs the app in a single container using sqlite3 with no persisten
   - this image works also with [OpenShift](https://openshift.com/) and [Kubernetes](https://kubernetes.io/) (without persistent storage)
   - docker image located here: [docker.io/pglombardo/pwpush-ephemeral](https://hub.docker.com/r/pglombardo/pwpush-ephemeral/)
   - run it with: `docker run -p 5000:5000 -d docker.io/pglombardo/pwpush-ephemeral`
-  
+
 [https://hub.docker.com/r/pglombardo/pwpush-ephemeral/](https://hub.docker.com/r/pglombardo/pwpush-ephemeral/)
 
 ##### pwpush-postgres
@@ -44,6 +44,18 @@ _Provided you provided the correct user credentials, on first boot it will creat
 
 ##### pwpush-openshift
 
-TBD
-
-https://hub.docker.com/r/pglombardo/pwpush-openshift/
+You can run passwordpusher in openshift in 2 ways:
+  - ephemeral (with no persistent storage): `oc new-app docker.io/pglombardo/pwpush-ephemeral:1.0`
+  - from an openshift template/buildconfig/deploymentconfig and postgresql persistent from the official openshift template:
+    ```
+    oc login https://your_openshift_url
+    oc new-project passwordpusher
+    cd ~ && git clone https://github.com/pglombardo/PasswordPusher.git && cd ~/PasswordPusher/containerization/passwordpusher-openshift
+    oc create -f template-with-buildconfig.yaml
+    oc new-app postgresql-persistent -p MEMORY_LIMIT=512Mi -p NAMESPACE=openshift -p DATABASE_SERVICE_NAME=postgresql -p POSTGRESQL_USER=passwordpusher_user -p POSTGRESQL_PASSWORD=passwordpusher_passwd -p POSTGRESQL_DATABASE=passwordpusher_db -p VOLUME_CAPACITY=1Gi -p POSTGRESQL_VERSION=9.5
+    oc new-app --template=passwordpusher
+    ```
+OpenShift observations:
+- your cluster needs persistent storage for postgresql to save the data
+- if you want the passwordpusher template to be available to ALL the projects (Other category in the catalog) in the cluster you need to create the template in the openshift namespace: `oc create -f template-with-buildconfig.yaml -n openshift`
+- if you want to change the postgresql credentials, modify the DATABASE_URL env variable in the ~/PasswordPusher/containerization/passwordpusher-openshift/dockerfile and also update the credentials when you launch the postgresql installation a few lines above

--- a/containerization/passwordpusher-openshift/template-with-buildconfig.yaml
+++ b/containerization/passwordpusher-openshift/template-with-buildconfig.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: passwordpusher
+  annotations:
+    openshift.io/display-name: "Passwordpusher"
+    description: "send passwords securely over web"
+    iconClass: "icon-rails"
+    tags: "utility"
+parameters:
+labels:
+  template: passwordpusher
+  app: passwordpusher
+
+
+objects:
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: passwordpusher
+    labels:
+      app: passwordpusher
+  spec:
+    selector:
+      app: passwordpusher
+    ports:
+    - name: passwordpusher-service
+      port: 443
+      protocol: TCP
+      targetPort: 5000
+
+
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: passwordpusher
+    labels:
+      app: passwordpusher
+  spec:
+    to:
+      name: passwordpusher
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/display-name: passwordpusher
+    name: passwordpusher
+
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: passwordpusher
+  spec:
+    runPolicy: Serial
+    triggers:
+      - type: ConfigChange
+    source:
+      git:
+        uri: https://github.com/pglombardo/PasswordPusher.git
+    strategy:
+      dockerStrategy:
+        dockerfilePath: containerization/passwordpusher-openshift/Dockerfile
+    output:
+      to:
+        kind: ImageStreamTag
+        name: passwordpusher:latest
+
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: passwordpusher
+    labels:
+      app: passwordpusher
+  spec:
+    replicas: 1
+    triggers:
+      - type: ConfigChange
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - passwordpusher
+          from:
+            kind: ImageStreamTag
+            name: passwordpusher:latest
+    strategy:
+      type: Rolling
+    revisionHistoryLimit: 1
+    template:
+      metadata:
+        labels:
+          app: passwordpusher
+      spec:
+        containers:
+        - name: passwordpusher
+          image: passwordpusher:latest
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - touch
+                - /tmp/health
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 5000
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 2Gi
+        restartPolicy: Always


### PR DESCRIPTION
Hello, got some new goodies :)

New stuff:
- Complete openshift template with all the objects needed to build and deploy passwordpusher.
- Documentation on how to install on openshift.

To do:
- Delete from docker.io the pglombardo/pwpush-openshift repository as we will use a buildconfig so we can build directly in openshift (images will be stored in an imagestream in openshift's repo).
- Delete from the git repo the PasswordPusher/containerization/passwordpusher-openshift/template-with-image.yaml file for the reason above.
- Getting an error after your last commit when running bundle install --without development private test --deployment &&     bundle exec rake assets:precompile && RAILS_ENV=production 
"You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.
The dependencies in your gemfile changed
You have added to the Gemfile:
\* instana
You have deleted from the Gemfile:
\* sys-proctable (< 1.2.0)"

