### PR TITLE
Change clicktotweet URL to use https

### DIFF
--- a/app/views/pages/faq.html.haml
+++ b/app/views/pages/faq.html.haml
@@ -88,7 +88,7 @@
   %p
     Tweet or share Password Pusher.
   %a{ :target => "_blank", :href => "http://ctt.ec/dapfb", :alt => "Tweet: PasswordPusher - A better way to share passwords than email #sysadmin #technology #netsec http://ctt.ec/dapfb+" }
-    =image_tag 'http://clicktotweet.com/img/tweet-graphic-4.png'
+    =image_tag 'https://clicktotweet.com/img/tweet-graphic-4.png'
 
 .about_content
   %div{ :style => 'float: left; font-size: .8em; margin-bottom: 50px;' }

--- a/app/views/pages/faq.html.haml
+++ b/app/views/pages/faq.html.haml
@@ -87,7 +87,7 @@
 
   %p
     Tweet or share Password Pusher.
-  %a{ :target => "_blank", :href => "http://ctt.ec/dapfb", :alt => "Tweet: PasswordPusher - A better way to share passwords than email #sysadmin #technology #netsec http://ctt.ec/dapfb+" }
+  %a{ :target => "_blank", :href => "https://ctt.ec/dapfb", :alt => "Tweet: PasswordPusher - A better way to share passwords than email #sysadmin #technology #netsec https://ctt.ec/dapfb+" }
     =image_tag 'https://clicktotweet.com/img/tweet-graphic-4.png'
 
 .about_content


### PR DESCRIPTION
The pwpush FAQ page doesn't have a full green lock in chrome. I think that's because this clicktotweet graphic is served over HTTP. You should change the URL to point to HTTPS instead. Disclaimer: I haven't tested this change except to verify that the image URL works.