### PR TITLE
Slack App Directory Support

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -38,5 +38,16 @@ DELETABLE_BY_VIEWER_PASSWORDS = ENV.fetch('DELETABLE_BY_VIEWER_PASSWORDS', 'true
 #
 DELETABLE_BY_VIEWER_DEFAULT = ENV.fetch('DELETABLE_BY_VIEWER_DEFAULT', 'true') == 'true'
 
+# SLACK_CLIENT_ID
+#
+# PasswordPusher is listed in the Slack application integration directory.
+# This requires the app to be aware of a Slack client ID.  This is used
+# in the Slack integration installation process (see /slack_direct_install).
+#
+# Users wishing to create their own Slack integrations that point to their
+# own indipendently hosted versions of PasswordPusher can set this environment
+# variable.  e.g. For slack integrations that don't use pwpush.com
+SLACK_CLIENT_ID = ENV.fetch('SLACK_CLIENT_ID', "pwpush: NotSetInEnv")
+
 # Initialize the rails application
 PasswordPusher::Application.initialize!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 PasswordPusher::Application.routes.draw do
   resources :p, :controller => :passwords, :as => :passwords, :except => [ :index, :edit, :update ]
   resources :c, :controller => :commands, :as => :commands, :allow => [ :create ]
+  get '/slack_direct_install', to: redirect("https://slack.com/oauth/authorize?client_id=#{ENV['SLACK_CLIENT_ID']}", status: 302)
   root :to => 'passwords#new'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 PasswordPusher::Application.routes.draw do
   resources :p, :controller => :passwords, :as => :passwords, :except => [ :index, :edit, :update ]
   resources :c, :controller => :commands, :as => :commands, :allow => [ :create ]
-  get '/slack_direct_install', to: redirect("https://slack.com/oauth/authorize?client_id=#{ENV['SLACK_CLIENT_ID']}", status: 302)
+  get '/slack_direct_install', to: redirect("https://slack.com/oauth/authorize?client_id=#{SLACK_CLIENT_ID}", status: 302)
   root :to => 'passwords#new'
 end


### PR DESCRIPTION
We're adding PasswordPusher to the Slack application directory.

These are the additions required to support this.

With these changes, users can point their own slack app integrations to their own instances of PasswordPusher as well.