### PR TITLE
feat(PasswordsView): add button to copy password in clipboard

### DIFF
--- a/app/assets/stylesheets/passwords.css.scss
+++ b/app/assets/stylesheets/passwords.css.scss
@@ -64,7 +64,7 @@ input#url {
   box-shadow: inset 0 1px 2px rgba(0,0,0,0.075);
 }
 
-button.btn {
+button.btn.btn-link {
   box-sizing: border-box;
   position: relative;
   display: inline-block;
@@ -74,6 +74,17 @@ button.btn {
   min-height: 36px;
   border-radius: 0px 3px 3px 0px;
   padding: 0;
+}
+
+button.btn.btn-copy {
+  margin-top: 20px;
+  display: inline-block;
+  border: 1px solid #003300;
+  cursor: pointer;
+  background: #006600;
+  color: #ffffff;
+  vertical-align: middle;
+  border-radius: 3px 3px 3px 3px;
 }
 
 /* This is a decent font to display passwords as L, l, 0, o, i, I are fairly distinguishable */

--- a/app/views/passwords/show.html.haml
+++ b/app/views/passwords/show.html.haml
@@ -19,7 +19,7 @@
         %p.url
           %div.input_group
             %input#url{ :value => "#{request.url}", :spellcheck => "false", :onfocus => '$(this).focus(); $(this).select();', :onclick => '$(this).select();', :readonly => true }
-            %button.btn{ "data-clipboard-target" => "#url" }
+            %button.btn.btn-link{ "data-clipboard-target" => "#url" }
               = image_tag('button_up.png')
         %span.note
           This note won't be shown again...
@@ -31,9 +31,8 @@
     %div.payload.spoiler#pass<
       = @payload
 
-    %p Copy Password to Clipboard:
-    %button.btn{ "data-clipboard-target" => "#pass" }
-      = image_tag('button_up.png')
+    %button.btn.btn-copy{ "data-clipboard-target" => "#pass" }
+      %p Copy Password to Clipboard
 
     %p.pwinstructions
       Please obtain and securely store this password elsewhere, ideally in a password manager.

--- a/app/views/passwords/show.html.haml
+++ b/app/views/passwords/show.html.haml
@@ -28,8 +28,12 @@
     %p
       Your password is...
 
-    %div.payload.spoiler<
+    %div.payload.spoiler#pass<
       = @payload
+
+    %p Copy Password to Clipboard:
+    %button.btn{ "data-clipboard-target" => "#pass" }
+      = image_tag('button_up.png')
 
     %p.pwinstructions
       Please obtain and securely store this password elsewhere, ideally in a password manager.


### PR DESCRIPTION
# Add button to copy to clipboard

I think there were a misunderstanding on Issue #52, "Copy to clipboard" button on first password view is to copy link of the password, not the password itself. I think @todd-a-jacobs thought about adding a "Copy to Clipboard" button but for the password, which I did in this PR.

- ✨ Add button to copy password to the clipboard without revealing it, increasing safety of the password against lookup upon user's shoulder.

## Linked PR/Issue
#52

## Migration
NO