### PR TITLE
Use defined image version for pwpush-postgres

### DIFF
--- a/containerization/passwordpusher-postgres/docker-compose.yaml
+++ b/containerization/passwordpusher-postgres/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       POSTGRES_DB: passwordpusher_db
 
   passwordpusher:
-    image: docker.io/pglombardo/pwpush-postgres
+    image: docker.io/pglombardo/pwpush-postgres:1.0
     #build: .
     ports:
       - "5000:5000"


### PR DESCRIPTION
The dockerhub repo doesnt have a  "latest" version. So, to run a docker-compose, use defined version 1.0 .

ERROR MESSAGE:
 "Pulling passwordpusher (pglombardo/pwpush-postgres:latest)...
ERROR: manifest for pglombardo/pwpush-postgres:latest not found"