### PR TITLE
Fix "no such file or directory" for entrypoint.sh

### DIFF
--- a/containerization/passwordpusher-postgres/Dockerfile
+++ b/containerization/passwordpusher-postgres/Dockerfile
@@ -33,4 +33,6 @@ RUN chmod -R u+x ${APP_ROOT} && \
 
 USER 1001
 WORKDIR ${APP_ROOT}
-ENTRYPOINT ["containerization/passwordpusher-postgres/entrypoint.sh"]
+
+ADD entrypoint.sh ${APP_ROOT}
+ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
ERROR: for passwordpusher  Cannot start service passwordpusher: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"containerization/passwordpusher-postgres/entrypoint.sh\": stat containerization/passwordpusher-postgres/entrypoint.sh: no such file or directory": unknown
ERROR: Encountered errors while bringing up the project.