### PR TITLE
JSON API: Add original payload and days/views remaining

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -88,14 +88,19 @@ class PasswordsController < ApplicationController
 
     # Encrypt the passwords
     @key = EzCrypto::Key.with_password CRYPT_KEY, CRYPT_SALT
-    @password.payload = @key.encrypt64(params[:password][:payload])
+    clear_password = params[:password][:payload]
+    @password.payload = @key.encrypt64(clear_password)
 
     @password.validate!
 
     respond_to do |format|
       if @password.save
         format.html { redirect_to @password, :notice => "The password has been pushed." }
-        format.json { render :json => @password, :status => :created }
+        format.json {
+          # For JSON, return the password record with the original clear text password back to the user
+          @password.payload = clear_password
+          render :json => @password, :status => :created
+        }
       else
         format.html { render :action => "new" }
         format.json { render :json => @password.errors, :status => :unprocessable_entity }

--- a/app/models/password.rb
+++ b/app/models/password.rb
@@ -18,6 +18,14 @@ class Password < ApplicationRecord
     [(self.expire_after_views - self.views.count), 0].max
   end
 
+  # Override to_json so that we can add in <days_remaining> and <views_remaining>
+  def to_json(*args)
+    attr_hash = self.attributes
+    attr_hash["days_remaining"] = self.days_remaining
+    attr_hash["views_remaining"] = self.views_remaining
+    attr_hash.to_json
+  end
+
   ##
   # validate!
   #

--- a/app/models/password.rb
+++ b/app/models/password.rb
@@ -18,9 +18,16 @@ class Password < ApplicationRecord
     [(self.expire_after_views - self.views.count), 0].max
   end
 
-  # Override to_json so that we can add in <days_remaining> and <views_remaining>
+  # Override to_json so that we can add in <days_remaining>, <views_remaining>
+  # and show the clear password
   def to_json(*args)
     attr_hash = self.attributes
+
+    if !self.expired and !self.payload.nil?
+      key = EzCrypto::Key.with_password CRYPT_KEY, CRYPT_SALT
+      attr_hash["payload"] = key.decrypt64(attr_hash["payload"])
+    end
+
     attr_hash["days_remaining"] = self.days_remaining
     attr_hash["views_remaining"] = self.views_remaining
     attr_hash.to_json

--- a/test/integration/password_creation_test.rb
+++ b/test/integration/password_creation_test.rb
@@ -16,11 +16,21 @@ class PasswordCreationTest < ActionDispatch::IntegrationTest
     assert(div.length == 1)
     assert(div.first.content.include?('Use this secret link'))
 
+    # Assert that the right password is in the page
+    divs = css_select "div#pass"
+    assert(divs)
+    assert(divs.first.content.include?('testpw'))
+
     # Reload the password page, we should not have the first view share note
     get request.url
     assert_response :success
     assert_select "p", "Your password is..."
     div = css_select "div.share_note"
     assert(div.length == 0)
+
+    # Assert that the right password is in the page
+    divs = css_select "div#pass"
+    assert(divs)
+    assert(divs.first.content.include?('testpw'))
   end
 end

--- a/test/integration/password_json_creation_test.rb
+++ b/test/integration/password_json_creation_test.rb
@@ -8,6 +8,7 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
     assert res.key?("id")
     assert res.key?("payload")
+    assert_equal "testpw", res["payload"]
     assert res.key?("url_token")
     assert res.key?("first_view")
     assert_equal true, res["first_view"]
@@ -17,6 +18,10 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal false, res["deleted"]
     assert res.key?("deletable_by_viewer")
     assert_equal false, res["deletable_by_viewer"]
+    assert res.key?("days_remaining")
+    assert_equal EXPIRE_AFTER_DAYS_DEFAULT, res["days_remaining"]
+    assert res.key?("views_remaining")
+    assert_equal EXPIRE_AFTER_VIEWS_DEFAULT, res["views_remaining"]
 
     # These should be default values since we didn't specify them in the params
     assert res.key?("expire_after_days")
@@ -32,6 +37,9 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
     assert res.key?("id")
 
+    assert res.key?("days_remaining")
+    assert_equal 1, res["days_remaining"]
+
     assert res.key?("expire_after_days")
     assert_equal 1, res['expire_after_days']
   end
@@ -42,6 +50,9 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
 
     res = JSON.parse(@response.body)
     assert res.key?("id")
+
+    assert res.key?("views_remaining")
+    assert_equal 5, res["views_remaining"]
 
     assert res.key?("expire_after_days")
     assert_equal 5, res['expire_after_views']

--- a/test/integration/password_json_deletion_test.rb
+++ b/test/integration/password_json_deletion_test.rb
@@ -15,6 +15,10 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal false, res["deleted"]
     assert res.key?("deletable_by_viewer")
     assert_equal false, res["deletable_by_viewer"]
+    assert res.key?("days_remaining")
+    assert_equal EXPIRE_AFTER_DAYS_DEFAULT, res["days_remaining"]
+    assert res.key?("views_remaining")
+    assert_equal EXPIRE_AFTER_VIEWS_DEFAULT, res["views_remaining"]
 
     # Get the new password via json e.g. /p/<url_token>.json
     delete "/p/" + res["url_token"] + ".json"
@@ -31,6 +35,10 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal true, res["deleted"]
     assert res.key?("deletable_by_viewer")
     assert_equal false, res["deletable_by_viewer"]
+    assert res.key?("days_remaining")
+    assert_equal EXPIRE_AFTER_DAYS_DEFAULT, res["days_remaining"]
+    assert res.key?("views_remaining")
+    assert_equal EXPIRE_AFTER_VIEWS_DEFAULT, res["views_remaining"]
 
     # Now try to retrieve the password again
     get "/p/" + res["url_token"] + ".json"
@@ -47,5 +55,9 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal true, res["deleted"]
     assert res.key?("deletable_by_viewer")
     assert_equal false, res["deletable_by_viewer"]
+    assert res.key?("days_remaining")
+    assert_equal EXPIRE_AFTER_DAYS_DEFAULT, res["days_remaining"]
+    assert res.key?("views_remaining")
+    assert_equal EXPIRE_AFTER_VIEWS_DEFAULT, res["views_remaining"]
   end
 end

--- a/test/integration/password_json_retrieval_test.rb
+++ b/test/integration/password_json_retrieval_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+
+class PasswordJsonRetrievalTest < ActionDispatch::IntegrationTest
+  def test_view_expiration
+    post "/p.json", params: { :password => { payload: "testpw", expire_after_views: 2, first_view: false  }}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("id")
+    assert res.key?("payload")
+    assert_equal "testpw", res["payload"]
+    assert res.key?("url_token")
+    assert res.key?("first_view")
+    assert_equal false, res["first_view"]
+    assert res.key?("expired")
+    assert_equal false, res["expired"]
+    assert res.key?("deleted")
+    assert_equal false, res["deleted"]
+    assert res.key?("deletable_by_viewer")
+    assert_equal false, res["deletable_by_viewer"]
+    assert res.key?("days_remaining")
+    assert_equal 2, res["views_remaining"]
+    assert res.key?("expire_after_days")
+    assert_equal 2, res['expire_after_views']
+
+    # Now try to retrieve the password for the first time
+    get "/p/" + res["url_token"] + ".json"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("views_remaining")
+    assert_equal 1, res["views_remaining"]
+    assert res.key?("expire_after_views")
+    assert_equal 2, res['expire_after_views']
+
+    # ...and the second view
+    get "/p/" + res["url_token"] + ".json"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("views_remaining")
+    assert_equal 0, res["views_remaining"]
+    assert res.key?("expire_after_views")
+    assert_equal 2, res['expire_after_views']
+
+    # With the third view, we should have an expired password
+    get "/p/" + res["url_token"] + ".json"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("expired")
+    assert_equal true, res["expired"]
+    assert res.key?("payload")
+    assert_nil res["payload"]
+    assert res.key?("views_remaining")
+    assert_equal 0, res["views_remaining"]
+    assert res.key?("expire_after_views")
+    assert_equal 2, res['expire_after_views']
+  end
+end

--- a/test/integration/password_json_retrieval_test.rb
+++ b/test/integration/password_json_retrieval_test.rb
@@ -28,6 +28,12 @@ class PasswordJsonRetrievalTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     res = JSON.parse(@response.body)
+    assert res.key?("expired")
+    assert_equal false, res["expired"]
+    assert res.key?("deleted")
+    assert_equal false, res["deleted"]
+    assert res.key?("payload")
+    assert_equal "testpw", res["payload"]
     assert res.key?("views_remaining")
     assert_equal 1, res["views_remaining"]
     assert res.key?("expire_after_views")
@@ -38,6 +44,12 @@ class PasswordJsonRetrievalTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     res = JSON.parse(@response.body)
+    assert res.key?("expired")
+    assert_equal false, res["expired"]
+    assert res.key?("deleted")
+    assert_equal false, res["deleted"]
+    assert res.key?("payload")
+    assert_equal "testpw", res["payload"]
     assert res.key?("views_remaining")
     assert_equal 0, res["views_remaining"]
     assert res.key?("expire_after_views")
@@ -50,6 +62,8 @@ class PasswordJsonRetrievalTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
     assert res.key?("expired")
     assert_equal true, res["expired"]
+    assert res.key?("deleted")
+    assert_equal false, res["deleted"]
     assert res.key?("payload")
     assert_nil res["payload"]
     assert res.key?("views_remaining")


### PR DESCRIPTION
This PR adds:

* JSON POST requests now return the original password in the JSON body
  (instead of the encrypted version which was useless)
* All JSON response bodies now include `days_remaining` and
  `views_remaining`

```
{
  "id": 13,
  "payload": "mypassword", # <----------------
  "expire_after_days": 2,
  "expire_after_views": 10,
  "expired": false,
  "url_token": "vqz3wty1ygt8yc2u",
  "created_at": "2020-07-27T09:31:25.256Z",
  "updated_at": "2020-07-27T09:32:48.002Z",
  "user_id": null,
  "deleted": false,
  "first_view": false,
  "deletable_by_viewer": false,
  "days_remaining": 2, # <----------------
  "views_remaining": 6 # <----------------
}
```

This fixes #119 although I'm not going to utilize `updated_at` right now because eventually I want to expose the list of views in the UI which will show when they occurred.