### PR TITLE
Fixing RCE and XSS vuln

### DIFF
--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -70,7 +70,7 @@ class CommandsController < ApplicationController
                 "#{request.env["rack.url_scheme"]}://#{request.env['HTTP_HOST']}/p/#{@password.url_token}"
       render :text => message, :layout => false
     else
-      render :text => @password.errors, :layout => false
+      render :simple => @password.errors, :layout => false
     end
   end
 end

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,5 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :marshal
+# Marshal has a known RCE vulnerability. Use :json instead.
+Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
Changing serializer to :json will prevent Remote Code Execution exploiting marshals serializer vulnerability.

render: text => @password.errors may lead to Cross Site Scripting (found by Brakeman). Using render :simple will prevent it.
