### PR TITLE
Fix copy url button

### DIFF
--- a/app/assets/javascripts/passwords.js
+++ b/app/assets/javascripts/passwords.js
@@ -27,6 +27,11 @@ $(document).ready(function() {
     }, 2000);
     e.clearSelection();
   });
+  
+  var clipboard_url = new ClipboardJS('.url-to-clipboard');
+  clipboard_url.on('success', function(e) {
+    var clipboardBtn = document.getElementById("url-button")
+  });
 
   days = $.cookie('pwpush_days');
   views = $.cookie('pwpush_views');

--- a/app/views/passwords/show.html.haml
+++ b/app/views/passwords/show.html.haml
@@ -17,7 +17,7 @@
       == This is your password.  Use this secret link to share it:
       %div.input_group
         %input#url{ :value => "#{request.url}", :spellcheck => "false", :onfocus => '$(this).focus(); $(this).select();', :onclick => '$(this).select();', :readonly => true }
-        %button.btn.btn-link{ "data-clipboard-target" => "#url" }
+        %button#url-button.url-to-clipboard{ "data-clipboard-target" => "#url" }
           = image_tag('button_up.png')
       %span.note
         This note won't be shown again...


### PR DESCRIPTION
The button for copying the URL after creating a new secret is not working. [#145 ](https://github.com/pglombardo/PasswordPusher/issues/145#issue-677148014)
I'm not a javascript guy but this PR fixed it for me.
