### PR TITLE
Use :hybrid cookie serialization

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,5 +2,9 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-# Marshal has a known RCE vulnerability. Use :json instead.
-Rails.application.config.action_dispatch.cookies_serializer = :json
+#
+# Marshal has a potential RCE vulnerability.
+# If we switch directly to :json, app can 500 on cookie deserialization for old cookies
+# Use :hybrid for now and aim for :json eventually.
+# https://github.com/presidentbeef/brakeman/issues/1316
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid


### PR DESCRIPTION
The original value of `Rails.application.config.action_dispatch.cookies_serializer` was `:marshal`.  Updating this setting to `:json` caused application errors triggered by failed cookie deserialization for returning users.

This change was originally initiated from https://github.com/pglombardo/PasswordPusher/pull/147 in response to warning from [brakeman](https://github.com/presidentbeef/brakeman).

![Screen Shot 2020-09-05 at 11 09 56 AM](https://user-images.githubusercontent.com/395132/92301959-5c283e80-ef68-11ea-8420-94bc8ae35f19.png)

But after some investigation it seems which CVE this addresses isn't even clear - it seems that the threat is theoretical: https://github.com/presidentbeef/brakeman/issues/1316

We could just invalidate all pre-existing user cookies by changing the secret key base, but this would require every person running a self-hosted version of PasswordPusher to perform this manual task (which is a hassle and unlikely to happen).  In which case, all those users would get 500/cookie serialization errors.

So to limit disruption, we are going with `:hybrid` which will default to JSON serialization but support `:marshal` for older pre-existing cookies.
