### PR TITLE
Force SSL URLs

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -32,6 +32,12 @@ class PasswordsController < ApplicationController
 
     expires_now
 
+    if ENV.key?('FORCE_SSL') && !request.ssl?
+      @request_url = request.url.gsub(/http/i, "https")
+    else
+      @request_url = request.url
+    end
+
     respond_to do |format|
       format.html # show.html.erb
       format.json { render :json => @password }

--- a/app/views/passwords/show.html.haml
+++ b/app/views/passwords/show.html.haml
@@ -16,7 +16,7 @@
     .share_note
       == This is your password.  Use this secret link to share it:
       %div.input_group
-        %input#secret_url{ :value => "#{request.url}", :spellcheck => "false", :readonly => true }
+        %input#secret_url{ :value => "#{@request_url}", :spellcheck => "false", :readonly => true }
         %button.copy-secret-url{ "data-clipboard-target" => "#secret_url" }
           = image_tag('button_up.png')
       %span.note


### PR DESCRIPTION
This still needs testing across platforms and clouds.

If you set the environment variable `FORCE_SSL=true`, it will enable `config.force_ssl=true` AND force the password show page to use an `https` URL for the password.  This happens even if you are not running an SSL server and nothing on port 443.

I'll update with what I find after testing a bit.

![Schermata 2021-02-15 alle 00 00 33](https://user-images.githubusercontent.com/395132/107891790-1a40f280-6f21-11eb-815a-a2caf2c78d01.png)
