### PR TITLE
Add CORS allow for JSON API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development, :test do
   gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 
+gem 'rack-cors'
 gem 'rack-attack'
 
 # OSX: ../src/utils.h:33:10: fatal error: 'climits' file not found

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
     rack (2.2.3)
     rack-attack (6.5.0)
       rack (>= 1.0, < 3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rack-throttle (0.7.0)
@@ -262,6 +264,7 @@ DEPENDENCIES
   pry-byebug
   puma
   rack-attack
+  rack-cors
   rack-throttle
   rack-timeout
   rails (~> 5.2.0)
@@ -281,4 +284,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.14
+   2.2.16

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,7 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+    resource '/p.json', headers: :any, methods: [:post]
+  end
+end
+


### PR DESCRIPTION
Sets the _Access-Control-Allow-Origin: *_ header on POST requests to the _p.json_ endpoint.
This allows the JSON API to be used for password creation from a web app hosted on a different domain.