### PR TITLE
Fix JSON encoding of uncommon characters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem 'sprockets', '~>3.0'
 gem 'foreman'
 gem 'jquery-rails'
 gem 'puma'
+gem 'oj'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
+    oj (3.13.0)
     pg (0.21.0)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -252,6 +253,7 @@ DEPENDENCIES
   minitest
   minitest-rails
   minitest-reporters
+  oj
   pg (~> 0.21)
   pry-byebug
   puma

--- a/app/models/password.rb
+++ b/app/models/password.rb
@@ -37,7 +37,7 @@ class Password < ApplicationRecord
 
     attr_hash['days_remaining'] = days_remaining
     attr_hash['views_remaining'] = views_remaining
-    attr_hash.to_json
+    Oj.dump attr_hash
   end
 
   ##

--- a/test/integration/password_json_creation_test.rb
+++ b/test/integration/password_json_creation_test.rb
@@ -28,6 +28,33 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal EXPIRE_AFTER_VIEWS_DEFAULT, res['expire_after_views']
   end
 
+  def test_json_creation_with_uncommon_characters
+    post '/p.json', params: { password: { payload: '£¬' } }
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?('id')
+    assert res.key?('payload')
+    assert_equal '£¬', res['payload']
+    assert res.key?('url_token')
+    assert res.key?('expired')
+    assert_equal false, res['expired']
+    assert res.key?('deleted')
+    assert_equal false, res['deleted']
+    assert res.key?('deletable_by_viewer')
+    assert_equal DELETABLE_BY_VIEWER_DEFAULT, res['deletable_by_viewer']
+    assert res.key?('days_remaining')
+    assert_equal EXPIRE_AFTER_DAYS_DEFAULT, res['days_remaining']
+    assert res.key?('views_remaining')
+    assert_equal EXPIRE_AFTER_VIEWS_DEFAULT, res['views_remaining']
+
+    # These should be default values since we didn't specify them in the params
+    assert res.key?('expire_after_days')
+    assert_equal EXPIRE_AFTER_DAYS_DEFAULT, res['expire_after_days']
+    assert res.key?('expire_after_views')
+    assert_equal EXPIRE_AFTER_VIEWS_DEFAULT, res['expire_after_views']
+  end
+
   def test_deletable_by_viewer
     post '/p.json', params: { password: { payload: 'testpw', deletable_by_viewer: 'true' } }
     assert_response :success


### PR DESCRIPTION
As reported in #204, JSON encoding is choking on certain characters.  To resolve we switch the Oj gem which has better semantics/handling and also gives us a performance boost.

Fixes #204 