### PR TITLE
kubernetes documentation and deploy manifests

### DIFF
--- a/docker/kubernetes/ephemeral_deploy.yaml
+++ b/docker/kubernetes/ephemeral_deploy.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: pwpush
+    component: ingress-controller
+    type: nginx
+  name: pwpush
+  namespace: pwpush
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: pwpush
+      component: ingress-controller
+      type: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: pwpush
+        component: ingress-controller
+        type: nginx
+    spec:
+      containers:
+      - image: docker.io/pglombardo/pwpush-ephemeral
+        imagePullPolicy: Always
+        name: pwpush
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+...

--- a/docker/kubernetes/ingress.yaml
+++ b/docker/kubernetes/ingress.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+  labels:
+    app: pwpush
+    component: ingress-controller
+    type: nginx
+  name: pwpush-ingress
+  namespace: pwpush
+spec:
+  rules:
+  - host: pwpush.domain.tld
+    http:
+      paths:
+      - backend:
+          serviceName: pwpush-http
+          servicePort: 5100
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - pwpush.domain.tld
+    secretName: pwpush.domain.tld
+...

--- a/docker/kubernetes/namespace.yaml
+++ b/docker/kubernetes/namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pwpush
+...

--- a/docker/kubernetes/persistent_deploy.yaml
+++ b/docker/kubernetes/persistent_deploy.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: pwpush
+    component: ingress-controller
+    type: nginx
+  name: pwpush
+  namespace: pwpush
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: pwpush
+      component: ingress-controller
+      type: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: pwpush
+        component: ingress-controller
+        type: nginx
+    spec:
+      containers:
+      - image: docker.io/pglombardo/pwpush-postgres
+        imagePullPolicy: Always
+        name: pwpush
+        env:
+          - name: DATABASE_URL
+            value: postgres://passwordpusher_user:passwordpusher_passwd@localhost:5432/passwordpusher_db
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      - image: docker.io/postgres:10
+        imagePullPolicy: Always
+        name: postgres
+        env:
+          - name: POSTGRES_USER
+            value: passwordpusher_user
+          - name: POSTGRES_PASSWORD
+            value: passwordpusher_passwd
+          - name: POSTGRES_DB
+            value: passwordpusher_db
+        volumeMounts:
+          - name: pwpush-database-data
+            mountPath: /var/lib/postgresql/data
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      volumes:
+      - name: pwpush-database-data
+        persistentVolumeClaim:
+          claimName: pwpush-data-pvc
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/docker/kubernetes/pv.yaml
+++ b/docker/kubernetes/pv.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+  name: pwpush-data-pv
+spec:
+  accessModes:
+  - ReadWriteMany
+  capacity:
+    storage: 1Gi
+  hostPath:
+    path: /your/path/here
+    type: DirectoryOrCreate
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-path
+  volumeMode: Filesystem
+...

--- a/docker/kubernetes/pvc.yaml
+++ b/docker/kubernetes/pvc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pwpush-data-pvc
+  namespace: pwpush
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: local-path
+  volumeMode: Filesystem
+  volumeName: pwpush-data-pv
+...

--- a/docker/kubernetes/service.yaml
+++ b/docker/kubernetes/service.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: pwpush
+    component: ingress-controller
+    type: nginx
+  name: pwpush-http
+  namespace: pwpush
+spec:
+  ports:
+  - name: pwpush-http
+    port: 5100
+    protocol: TCP
+    targetPort: 5100
+  selector:
+    app: pwpush
+    component: ingress-controller
+    type: nginx
+  sessionAffinity: None
+  type: ClusterIP
+...

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,51 @@
+# Installation through Kubernetes
+
+Installing Password Pusher should be simple. For Kubernetes installations, the repository includes a bundle of manifests configured to set up a working copy of Password Pusher.
+
+Kubernetes clusters are complex and may differ a lot. The bundled manifests expects the following:
+- `nginx ingress-controller` deployed for the cluster or namespace
+- `cert-manager` installed and configured with a `cluster-issuer` named `letsencrypt-prod`
+
+When deployed, the following kubernetes objects are provisioned:
+* namespace: `pwpush`
+* deployment: `pwpush`
+  * pods:
+    * pwpush
+    * postgres (when using the persistent deploy type)
+* service: `pwpush-http`
+* ingress: `pwpush-ingress`
+* certificate: `pwpush.domain.tld` (will be renamed accordingly if following the documented steps in [deploy](#deploy)
+
+# Deploy
+
+Since Password Pusher supports both ephemeral and database-backed installations, instructions (and manifests) vary. See [Ephemeral](#ephemeral) & [Persistent](#persistent)
+
+For both types of deploys, the configured ingress maps to the URL `pwpush.domain.tld` and cert-manager requires that domain be correctly mapped to your cluster for the letsencrypt certificates to generate automatically. You probably want to modify that URL which can be done by:
+`sed -i 's|pwpush.domain.tld|pwpush.your.domain.here|g' docker/kubernetes/ingress.yaml`
+
+## Ephemeral
+```
+kubectl apply -f docker/kubernetes/namespace.yaml
+kubectl apply -f docker/kubernetes/ephemeral_deploy.yaml
+kubectl apply -f docker/kubernetes/service.yaml
+kubectl apply -f docker/kubernetes/ingress.yaml
+```
+
+## Persistent
+This type of deploy requires the host path `/nfs/k8s/services/pwpush/data` already mounted on the node(s) expected to run the deployment. Most likely, you will want to modify that path in your own environment or reconfigure the persistent volume to use a different type of volume matching your cluster setup.
+
+Modifications of the host path can be done by:
+`sed -i 's|/nfs/k8s/services/pwpush/data|/your/path/here|g' docker/kubernetes/pv.yaml`
+
+Modifications to the type of volume is left to the reader to implement. The relevant file is `docker/kubernetes/pv.yaml`
+
+Applying all manifests
+```
+kubectl apply -f docker/kubernetes/namespace.yaml
+kubectl apply -f docker/kubernetes/pv.yaml
+kubectl apply -f docker/kubernetes/pvc.yaml
+kubectl apply -f docker/kubernetes/persistent_deploy.yaml
+kubectl apply -f docker/kubernetes/service.yaml
+kubectl apply -f docker/kubernetes/ingress.yaml
+```
+


### PR DESCRIPTION
This is a proposal for inclusion of instructions on how to deploy PasswordPusher to a kubernetes cluster.

I suggest the `docker` folder be renamed to `containerization`, but leaving it as-is for now and await your review/suggestion. Also unsure if the suggested kubernetes folder structure is valid, I just dumped everything kubernetes-related in one folder. Please advice.