### PR TITLE
Migrations: Remove default value for note

### DIFF
--- a/db/migrate/20210913083515_add_note_to_password.rb
+++ b/db/migrate/20210913083515_add_note_to_password.rb
@@ -1,5 +1,5 @@
 class AddNoteToPassword < ActiveRecord::Migration[6.1]
   def change
-    add_column :passwords, :note, :text, default: ''
+    add_column :passwords, :note, :text
   end
 end


### PR DESCRIPTION
This default value breaks MySQL and is entirely unnecessary.

Fixes #245
