### PR TITLE
Updated Encryption Strategy with Lockbox

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -7,22 +7,30 @@ See also `config/environment.rb`.
 
 ## Application Encryption
 
-These variables set the encryption key and salt used with EZCrypto library to write passwords to the database.  If not set, the application will use default values.
+Password Pusher encrypts sensitive data in the database. This requires a randomly generated encryption key for each application instance.
 
-| Variable | Description |
-| --------- | ------------------ |
-| CRYPT_KEY | Set the encryption key for the application |
-| CRYPT_SALT | And the salt |
+To set a custom encryption key for your application, set the environment variable `PWPUSH_MASTER_KEY`:
 
-To generate a new key and salt, you can use any sufficiently random string or generate one with the application:
+    PWPUSH_MASTER_KEY=0c110f7f9d93d2122f36debf8a24bf835f33f248681714776b336849b801f693
+
+### Generate a New Encryption Key
+
+Key generation can be done through the [helper tool](https://pwpush.com/pages/generate_key) or on the command line in the application source using `Lockbox.generate_key`:
 
 ```ruby
-bundle exec rails console
-key = EzCrypto::Key.generate
-key.encode
+bundle
+rails c
+Lockbox.generate_key
 ```
 
-You can read more about [EzCrypto here](https://github.com/pglombardo/ezcrypto).
+Notes:
+
+* If an encryption key isn't provided, a default key will be used.
+* The best security for private instances of Password Pusher is to use your own custom encryption key although it is not required.
+* The risk in using the default key is lessened if you keep your instance secure and your push expirations short. e.g. 1 day/1 view versus 100 days/100 views.
+* Once a push expires, all encrypted data is deleted.
+* Changing an encryption key where old pushes already exist will make those older pushes unreadable. In other words, the payloads will be garbled. New pushes going forward will work fine.
+
 
 ## Application Defaults
 

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem 'rack-attack'
 # gem 'therubyracer'
 #
 gem 'ezcrypto', :git => 'https://github.com/pglombardo/ezcrypto.git'
+gem 'lockbox'
 gem 'high_voltage'
 gem 'kramdown', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     locale (2.1.3)
+    lockbox (0.6.6)
     loofah (2.12.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -396,6 +397,7 @@ DEPENDENCIES
   json (~> 2.0)
   kramdown
   listen
+  lockbox
   mail_form
   minitest
   minitest-rails

--- a/app.json
+++ b/app.json
@@ -12,12 +12,8 @@
   },
   "env": {
     "BUNDLE_WITHOUT": "development:test:private",
-    "CRYPT_KEY": {
-      "description": "CRYPT key",
-      "generator": "secret"
-    },
-    "CRYPT_SALT": {
-      "description": "CRYPT salt",
+    "PWPUSH_MASTER_KEY": {
+      "description": "Application Encryption Key",
       "generator": "secret"
     },
     "WEB_CONCURRENCY": {
@@ -58,6 +54,14 @@
     },
     "DELETABLE_PASSWORDS_DEFAULT": {
       "description": "When the option DELETABLE_PASSWORDS_ENABLED is set to true, this option does two things: 1. Sets the default check state for the \"Allow viewers to optionally delete password before expiration\" checkbox. 2. Sets the default value for newly pushed passwords if unspecified (such as with a json request)",
+      "value": "true"
+    },
+    "RETRIEVAL_STEP_ENABLED": {
+      "description": "An option to require an extra click through to get to the actual password?",
+      "value": "true"
+    },
+    "RETRIEVAL_STEP_DEFAULT": {
+      "description": "The default value for the 1-click retrieval step option.",
       "value": "true"
     }
   }

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -37,7 +37,7 @@ class PasswordsController < ApplicationController
       end
       return
     else
-      @payload = @password.decrypt(@password.payload)
+      @payload = @password.payload.nil? ? @password.decrypt(@password.payload_legacy) : @password.payload
     end
 
     log_view(@password)
@@ -87,7 +87,7 @@ class PasswordsController < ApplicationController
     @password.url_token = rand(36**16).to_s(36)
     create_detect_deletable_by_viewer(@password, params)
     create_detect_retrieval_step(@password, params)
-    @password.payload = @password.encrypt(params[:password][:payload])
+    @password.payload = params[:password][:payload]
 
     unless params[:password].fetch(:note, '').blank?
       @password.note = @password.encrypt(params[:password][:note])

--- a/app/views/pages/generate_key.html.erb
+++ b/app/views/pages/generate_key.html.erb
@@ -2,7 +2,7 @@
 
 <h4 class='mb-3'><%= _('Generate an Encryption Key') %></h4>
 
-<p>
+<p class='text-muted'>
 <%= _('This page is used as a helper tool to generate a random encryption key for privately hosted instances of Password Pusher.') %>
 </p>
 
@@ -76,3 +76,6 @@
 </p>
 
 
+<p>
+See also the Password Pusher <a href='https://github.com/pglombardo/PasswordPusher/blob/master/Configuration.md' target='_blank'>Configuration documentation</a>.
+</p>

--- a/app/views/pages/generate_key.html.erb
+++ b/app/views/pages/generate_key.html.erb
@@ -3,11 +3,15 @@
 <h4 class='mb-3'><%= _('Generate an Encryption Key') %></h4>
 
 <p>
+<%= _('This page is used as a helper tool to generate a random encryption key for privately hosted instances of Password Pusher.') %>
+</p>
+
+<p>
 <%= _('Password Pusher encrypts sensitive data in the database.  This requires a randomly generated encryption key for each application instance.') %>
 </p>
 
 <p>
-<%= _('This page is used as a helper tool to generate a random encryption key for privately hosted instances of Password Pusher.') %>  
+<%= _('You can use the randomly generated code below to configure your Password Pusher instance.') %>
 </p>
 
 <p>
@@ -36,22 +40,22 @@
         <em class="bi bi-clipboard-check"></em>
     </button>
 </div>
-        
+
 <p>
 <em><%= _('Reload this page to re-generate a new key.') %></em>
 </p>
 
 <p>
-<%= _('Notes:') %>  
+<%= _('Notes:') %>
 <ul>
     <li>
         <%= _('If an encryption key isn\'t provided, a default key will be used.') %>
     </li>
     <li>
-        <%= _('The best security is to use your own custom encryption key although it is not required.') %>
+        <%= _('The best security for private instances of Password Pusher is to use your own custom encryption key although it is not required.') %>
     </li>
     <li>
-        <%= _('The risk in using the default key is lessened if you keep your instance secure and keep your push expirations short.  e.g.  1 day/1 view versus 100 days/100 views.') %>
+        <%= _('The risk in using the default key is lessened if you keep your instance secure and your push expirations short.  e.g.  1 day/1 view versus 100 days/100 views.') %>
     </li>
     <li>
         <%= _('Once a push expires, all encrypted data is deleted.') %>
@@ -60,7 +64,7 @@
         <%= _('Changing an encryption key where old pushes already exist will make those older pushes unreadable.  In other words, the payloads will be garbled.  New pushes going forward will work fine.') %>
     </li>
     <li>
-        <%= _('Key generation can also be done from the command line in the application source by executing: ') %>  
+        <%= _('Key generation can also be done from the command line in the application source by executing: ') %>
         <code>Lockbox.generate_key</code>.
         <pre><code>
         > bundle

--- a/app/views/pages/generate_key.html.erb
+++ b/app/views/pages/generate_key.html.erb
@@ -1,0 +1,74 @@
+<% title(_('Generate Key')) %>
+
+<h4 class='mb-3'><%= _('Generate an Encryption Key') %></h4>
+
+<p>
+<%= _('Password Pusher encrypts sensitive data in the database.  This requires a randomly generated encryption key for each application instance.') %>
+</p>
+
+<p>
+<%= _('This page is used as a helper tool to generate a random encryption key for privately hosted instances of Password Pusher.') %>  
+</p>
+
+<p>
+</p>
+
+<% new_master_key = Lockbox.generate_key %>
+
+<p class='lead my-3'><%= _('Generated Encryption Key') %></p>
+<div class='input-group mb-3'>
+    <input class='form-control' id='generated_key' value="<%= new_master_key %>" spellcheck='false' readonly='true'>
+    <button id='copy-to-clipboard-button' class='input-group-text btn-success'
+            data-clipboard-target='#generated_key' alt="<%= _('Copy to Clipboard') %>">
+        <em class="bi bi-clipboard-check"></em>
+    </button>
+</div>
+
+<p>
+<%= _('You can apply this key to your application by setting the environment variable') %>
+<code>PWPUSH_MASTER_KEY</code>.
+</p>
+
+<div class='input-group mb-3'>
+    <input class='form-control' id='env_key' value="PWPUSH_MASTER_KEY=<%= new_master_key %>" spellcheck='false' readonly='true'>
+    <button id='copy-to-clipboard-button-2' class='input-group-text btn-success'
+            data-clipboard-target='#env_key' alt="<%= _('Copy to Clipboard') %>">
+        <em class="bi bi-clipboard-check"></em>
+    </button>
+</div>
+        
+<p>
+<em><%= _('Reload this page to re-generate a new key.') %></em>
+</p>
+
+<p>
+<%= _('Notes:') %>  
+<ul>
+    <li>
+        <%= _('If an encryption key isn\'t provided, a default key will be used.') %>
+    </li>
+    <li>
+        <%= _('The best security is to use your own custom encryption key although it is not required.') %>
+    </li>
+    <li>
+        <%= _('The risk in using the default key is lessened if you keep your instance secure and keep your push expirations short.  e.g.  1 day/1 view versus 100 days/100 views.') %>
+    </li>
+    <li>
+        <%= _('Once a push expires, all encrypted data is deleted.') %>
+    </li>
+    <li>
+        <%= _('Changing an encryption key where old pushes already exist will make those older pushes unreadable.  In other words, the payloads will be garbled.  New pushes going forward will work fine.') %>
+    </li>
+    <li>
+        <%= _('Key generation can also be done from the command line in the application source by executing: ') %>  
+        <code>Lockbox.generate_key</code>.
+        <pre><code>
+        > bundle
+        > rails c
+        > Lockbox.generate_key
+        </code></pre>
+    </li>
+</ul>
+</p>
+
+

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -23,6 +23,7 @@
             <li class="dropdown-item"><%= link_to _('Tools'), page_path('tools'), class: 'nav-link px-2 text-muted' %></li>
             <li class="dropdown-item"><%= link_to _('Source Code'), 'https://github.com/pglombardo/PasswordPusher', class: 'nav-link px-2 text-muted', target: '_blank' %></li>
             <li class="dropdown-item"><%= link_to _('Docker Containers'), 'https://hub.docker.com/u/pglombardo', class: 'nav-link px-2 text-muted', target: '_blank' %></li>
+            <li class="dropdown-item"><%= link_to _('Key Generator'), page_path('generate_key'), class: 'nav-link px-2 text-muted' %></li>
           </ul>
         </li>
         <li class="nav-item dropdown">

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,7 +3,7 @@
 # Load the Rails application.
 require_relative 'application'
 
-# If deploying PasswordPusher yourself, you should change these CRYPT values.
+# DEPRECATED: These encryption keys are legacy and will be removed in a future version
 CRYPT_KEY = ENV.fetch('CRYPT_KEY', '}s-#2R0^/+2wEXc47\$9Eb')
 CRYPT_SALT = ENV.fetch('CRYPT_SALT', ',2_%4?[+:3774>f')
 

--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Application Encryption Key
+#
+# Set the environment variable PWPUSH_MASTER_KEY to set your encryption key.
+#
+# Example:
+#   export PWPUSH_MASTER_KEY=749b1022e1cb83fb04f3022eacaf3bfef60c6d47f83e6fb41f534a05fc69929f
+#
+# If this environment variable is not set, a default encryption key will be used.
+#
+# Changing an encryption key where old pushes already exist will make those older pushes
+# unreadable.  In other words, the payloads will be garbled.  New pushes going forward
+# will work fine.
+#
+# The best security is to use your own custom encryption key.  Any risk in using the default
+# key is lessened if you keep your instance secure and limit your push expirations versus
+# longer living pushes.  e.g.  1 day/1 view versus 100 days/100 views.
+#
+# To generate a new encryption key, run the following:
+#   > rails c
+#   > Lockbox.gnerate_key
+#
+# or go to https://pwpush.com/generate_key
+#
+Lockbox.master_key = ENV.fetch('PWPUSH_MASTER_KEY', '749b1022e1cb83fb04f3022eacaf3bfef60c6d47f83e6fb41f534a05fc69929f')

--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -21,6 +21,6 @@
 #   > rails c
 #   > Lockbox.gnerate_key
 #
-# or go to https://pwpush.com/generate_key
+# or go to https://pwpush.com/pages/generate_key
 #
 Lockbox.master_key = ENV.fetch('PWPUSH_MASTER_KEY', '749b1022e1cb83fb04f3022eacaf3bfef60c6d47f83e6fb41f534a05fc69929f')

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -5,5 +5,3 @@
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
 Rails.application.secrets.secret_key_base = ENV['SECRET_KEY_BASE'] || 'b7efd5d3d967b3b669d439c371329cc990616b9dd47bf02c42dedb3c74a9d54e30dfd52323480623acc92fdec88b79d2cf9e211b1fd8a946d008c4e1f3162b28'
-# FIXME
-# PasswordPusher::Application.config.secret_key_base =

--- a/db/migrate/20211104102822_add_payload_ciphertext_to_password.rb
+++ b/db/migrate/20211104102822_add_payload_ciphertext_to_password.rb
@@ -1,0 +1,8 @@
+class AddPayloadCiphertextToPassword < ActiveRecord::Migration[6.1]
+  def change
+    # Column for new lockbox encryption
+    add_column :passwords, :payload_ciphertext, :text
+    # Rename legacy encryption column
+    rename_column :passwords, :payload, :payload_legacy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_04_164136) do
+ActiveRecord::Schema.define(version: 2021_11_04_102822) do
 
   create_table "passwords", force: :cascade do |t|
-    t.text "payload"
+    t.text "payload_legacy"
     t.integer "expire_after_days"
     t.integer "expire_after_views"
     t.boolean "expired", default: false
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2021_10_04_164136) do
     t.boolean "retrieval_step", default: false
     t.datetime "expired_on"
     t.text "note", default: ""
+    t.text "payload_ciphertext"
     t.index ["url_token"], name: "index_passwords_on_url_token", unique: true
     t.index ["user_id"], name: "index_passwords_on_user_id"
   end


### PR DESCRIPTION
Password Pusher has been using ezcrypto which has worked well but it is a bit aged and untouched for quite a while.

The new strategy will use [lockbox and its AES-GCM](https://github.com/ankane/lockbox#aes-gcm) algorithm.

Lockbox also provides a tighter integration which means simpler code for pwpush.

The migration strategy is simple in that we start using the new encryption strategy for all new pushes.  For legacy pushes (which live a maximum of 90 days), just fall back to the legacy strategy.

Eventually (after 3 months or longer), I'll remove the legacy ezcrypto strategy entirely.