### PR TITLE
Remove Foreman from Containers

### DIFF
--- a/containers/docker/pwpush-mysql/entrypoint.sh
+++ b/containers/docker/pwpush-mysql/entrypoint.sh
@@ -2,6 +2,6 @@
 set -e
 
 RAILS_ENV=production bundle exec rake db:migrate
-RAILS_ENV=production bundle exec foreman start web
+RAILS_ENV=production bundle exec puma -C config/puma.rb
 
 exec "$@"

--- a/containers/docker/pwpush-postgres/entrypoint.sh
+++ b/containers/docker/pwpush-postgres/entrypoint.sh
@@ -2,6 +2,6 @@
 set -e
 
 RAILS_ENV=production bundle exec rake db:migrate
-RAILS_ENV=production bundle exec foreman start web
+RAILS_ENV=production bundle exec puma -C config/puma.rb
 
 exec "$@"


### PR DESCRIPTION
Launch the container puma process directly to avoid the recent port
increment issues with the foreman utility.

Fixed #261
