### PR TITLE
SecureRandom: Better URL token generation

### DIFF
--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class CommandsController < ApplicationController
   # Some random images featuring Stan (Instana)
   STAN_URLS = [

--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -60,7 +60,7 @@ class CommandsController < ApplicationController
     @key = EzCrypto::Key.with_password CRYPT_KEY, CRYPT_SALT
     @password.payload = @key.encrypt64(secret)
 
-    @password.url_token = rand(36**16).to_s(36)
+    @password.url_token = SecureRandom.urlsafe_base64(rand(8..14)).downcase
     @password.validate!
 
     if @password.save

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class PasswordsController < ApplicationController
   helper PasswordsHelper
 

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -84,7 +84,7 @@ class PasswordsController < ApplicationController
     @password.expire_after_views = params[:password].fetch(:expire_after_views,
                                                            EXPIRE_AFTER_VIEWS_DEFAULT)
     @password.user_id = current_user.id if user_signed_in?
-    @password.url_token = rand(36**16).to_s(36)
+    @password.url_token = SecureRandom.urlsafe_base64(rand(8..14)).downcase
 
     create_detect_deletable_by_viewer(@password, params)
     create_detect_retrieval_step(@password, params)


### PR DESCRIPTION
Initiated from #251 and #48, this PR switches to `SecureRandom` for token generation with a random (8..14) token length.

This increases the complexity of guessing tokens.  Combined with the installed rate limiter and short expiration dates, the risk is further limited.

In the extreme case where a token may be guessed, make sure to push passwords only.  Don't include what they go to.
