### PR TITLE
Allow for the Default Language to be changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ foreman start internalweb
 
 Then view the site @ [http://localhost:5100/](http://localhost:5100/).
 
+# Internationalization
+
+Password Pusher is currently available in **13 languages** with more languages being added often.
+
+From within the application, the language is selectable from menu.  Out of the box and before any language menu selection is done, the default language for the application is English.
+
+## Changing the Default Language
+
+The default language can be changed by setting an environment variable with the appropriate language code:
+
+    PWP__DEFAULT_LOCALE=es
+
+For more details, a list of supported language codes and further explanation, see the bottom of this [configuration file](https://github.com/pglombardo/PasswordPusher/blob/master/config/settings.yml).
+
 # 📼 Credits
 
 ## Translators

--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ Then view the site @ [http://localhost:5100/](http://localhost:5100/).
 
 # Internationalization
 
-Password Pusher is currently available in **13 languages** with more languages being added often.
+Password Pusher is currently available in **13 languages** with more languages being added often as volunteers apply.
 
-From within the application, the language is selectable from menu.  Out of the box and before any language menu selection is done, the default language for the application is English.
+From within the application, the language is selectable from a language menu.  Out of the box and before any language menu selection is done, the default language for the application is English.
 
 ## Changing the Default Language
 

--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -2,7 +2,7 @@
 I18n.available_locales = %i[ca da de en es fr it nl no pl pt-BR sr sv]
 
 # Set default locale to something other than :en
-I18n.default_locale = :en
+I18n.default_locale = Settings.default_locale
 
 TranslationIO.configure do |config|
   config.api_key        = 'cc6a66a15e02433aa9d0afeb39835b8c'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,6 @@ Rails.application.routes.draw do
     get '/slack_direct_install', to: redirect("https://slack.com/oauth/authorize?client_id=#{SLACK_CLIENT_ID}&scope=commands", status: 302)
     get '/pages/*id' => 'pages#show', as: :page, format: false
     resources :feedbacks, only: %i[new create]
-    root to: 'passwords#new'
+    root to: 'passwords#new', :locale => I18n.default_locale
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -51,3 +51,9 @@ language_codes:
   sr: 'Српски'
   sv: 'Svenska'
 
+# The default language for the application.  This must be one of the
+# valid/supported language codes from the list above.
+# Example: default_locale: :es
+# Environment Variable Override: PWP__DEFAULT_LOCALE='es'
+default_locale: :en
+

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,9 +4,10 @@
 # this new config gem, then we'll migrate entirely to the new Settings
 # format for private instances too.
 
-# Logins are not yet supported in private instances yet due to a bit more support work
-# that needs to be done first.
-#   e.g. how to hook up an email MTA.  Coming soon.
+# Logins are disabled by default since they require an MTA (email) server
+# available to send emails through.
+# For instructions on how to enable logins, see this page:
+# https://github.com/pglombardo/PasswordPusher/discussions/276
 enable_logins: false
 
 # The domain (without protocol) where this instance is hosted
@@ -36,6 +37,10 @@ mail:
   # See config/initializers/devise.rb where this is used
   # mailer_sender: '"Password Pusher" <pglombardo@pwpush.com>'
 
+# List of supported languages indexed by language code.  This is used
+# to build the in application language menu.
+#
+# <language code>: '<language name>'
 language_codes:
   ca: 'Català'
   da: 'Dansk'


### PR DESCRIPTION
Fixes #267 

Password Pusher supports 13 languages that is selectable by an in-app menu.  The default language is English (until a language menu item is selected).

This PR adds the `PWP__DEFAULT_LOCALE` environment variable to override the default language.

Instructions added to the front [README page](https://github.com/pglombardo/PasswordPusher/tree/master#internationalization).

For example, setting the following environment variable for the application will make Spanish the default language for the application:

    PWP__DEFAULT_LOCALE=es

