### PR TITLE
Revert Docker container images to ruby:3.0.3

### DIFF
--- a/containers/docker/pwpush-ephemeral/Dockerfile
+++ b/containers/docker/pwpush-ephemeral/Dockerfile
@@ -1,5 +1,5 @@
 # pwpush-ephemeral
-FROM ruby:3.1.0
+FROM ruby:3.0.3
 
 LABEL maintainer='pglombardo@hey.com'
 

--- a/containers/docker/pwpush-mysql/Dockerfile
+++ b/containers/docker/pwpush-mysql/Dockerfile
@@ -1,5 +1,5 @@
 # pwpush-mysql
-FROM ruby:3.1.0
+FROM ruby:3.0.3
 
 LABEL maintainer='pglombardo@hey.com'
 

--- a/containers/docker/pwpush-openshift/Dockerfile
+++ b/containers/docker/pwpush-openshift/Dockerfile
@@ -1,5 +1,5 @@
 # pwpush-postgres
-FROM ruby:3.1.0
+FROM ruby:3.0.3
 
 LABEL maintainer='pglombardo@hey.com'
 

--- a/containers/docker/pwpush-postgres/Dockerfile
+++ b/containers/docker/pwpush-postgres/Dockerfile
@@ -1,5 +1,5 @@
 # pwpush-postgres
-FROM ruby:3.1.0
+FROM ruby:3.0.3
 
 LABEL maintainer='pglombardo@hey.com'
 


### PR DESCRIPTION
Fixes #296 

3.1.0 has some incompatibilities it seems.   Reverting to the previous minor revision.