### PR TITLE
Use Ruby 3.0.2 to avoid bootsnap bug

### DIFF
--- a/containers/docker/pwpush-mysql/Dockerfile
+++ b/containers/docker/pwpush-mysql/Dockerfile
@@ -1,5 +1,5 @@
 # pwpush-mysql
-FROM ruby:3.0.3
+FROM ruby:3.0.2
 
 LABEL maintainer='pglombardo@hey.com'
 


### PR DESCRIPTION
The pwpush-mysql Docker image is hitting a [bootsnap bug](https://github.com/Shopify/bootsnap/issues/378) with Ruby 3.0.3.  We'll downgrade to Ruby 3.0.2 until the issue is resolved.