### PR TITLE
pwpush-mysql: Update to default Mariadb data path

### DIFF
--- a/containers/docker/pwpush-mysql/docker-compose.yaml
+++ b/containers/docker/pwpush-mysql/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       MARIADB_DATABASE: 'passwordpusher_db'
       MARIADB_RANDOM_ROOT_PASSWORD: 'yes'
     volumes:
-      - /var/lib/pwpush-mysql/data:/var/lib/pwpush-mysql/data
+      - /var/lib/pwpush-mysql/data:/var/lib/mysql
 
   pwpush:
     image: docker.io/pglombardo/pwpush-mysql:release


### PR DESCRIPTION
Fixes #368 

https://hub.docker.com/_/mariadb