### PR TITLE
SMTP: Add extended config options

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,10 +43,22 @@ Rails.application.configure do
     user_name: Settings.mail.smtp_user_name,
     password: Settings.mail.smtp_password,
     authentication: Settings.mail.smtp_authentication,
-    enable_starttls_auto: Settings.mail.smtp_starttls,
+    enable_starttls_auto: Settings.mail.smtp_enable_starttls_auto,
     open_timeout: Settings.mail.smtp_open_timeout,
     read_timeout: Settings.mail.smtp_read_timeout
   }
+
+  if Settings.mail.smtp_domain
+    config.action_mailer.smtp_settings[:domain] = Settings.mail.smtp_domain
+  end
+
+  if Settings.mail.smtp_openssl_verify_mode
+    config.action_mailer.smtp_settings[:openssl_verify_mode] = Settings.mail.smtp_openssl_verify_mode.to_sym
+  end
+
+  if Settings.mail.smtp_enable_starttls
+    config.action_mailer.smtp_settings[:enable_starttls] = Settings.mail.smtp_enable_starttls
+  end
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/private.rb
+++ b/config/environments/private.rb
@@ -29,8 +29,20 @@ PasswordPusher::Application.configure do
     user_name: Settings.mail.smtp_user_name,
     password: Settings.mail.smtp_password,
     authentication: Settings.mail.smtp_authentication,
-    enable_starttls_auto: Settings.mail.smtp_starttls,
+    enable_starttls_auto: Settings.mail.smtp_enable_starttls_auto,
     open_timeout: Settings.mail.smtp_open_timeout,
     read_timeout: Settings.mail.smtp_read_timeout
   }
+
+  if Settings.mail.smtp_domain
+    config.action_mailer.smtp_settings[:domain] = Settings.mail.smtp_domain
+  end
+
+  if Settings.mail.smtp_openssl_verify_mode
+    config.action_mailer.smtp_settings[:openssl_verify_mode] = Settings.mail.smtp_openssl_verify_mode.to_sym
+  end
+
+  if Settings.mail.smtp_enable_starttls
+    config.action_mailer.smtp_settings[:enable_starttls] = Settings.mail.smtp_enable_starttls
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,10 +80,22 @@ Rails.application.configure do
     user_name: Settings.mail.smtp_user_name,
     password: Settings.mail.smtp_password,
     authentication: Settings.mail.smtp_authentication,
-    enable_starttls_auto: Settings.mail.smtp_starttls,
+    enable_starttls_auto: Settings.mail.smtp_enable_starttls_auto,
     open_timeout: Settings.mail.smtp_open_timeout,
     read_timeout: Settings.mail.smtp_read_timeout
   }
+
+  if Settings.mail.smtp_domain
+    config.action_mailer.smtp_settings[:domain] = Settings.mail.smtp_domain
+  end
+
+  if Settings.mail.smtp_openssl_verify_mode
+    config.action_mailer.smtp_settings[:openssl_verify_mode] = Settings.mail.smtp_openssl_verify_mode.to_sym
+  end
+
+  if Settings.mail.smtp_enable_starttls
+    config.action_mailer.smtp_settings[:enable_starttls] = Settings.mail.smtp_enable_starttls
+  end
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -185,6 +185,11 @@ throttling:
 # for things such as forgot password, unlock account, confirm account etc.
 # If `enable_logins` is set to true above, the following _are required_ to be
 # filled out with valid values.
+#
+# These values are passed through to ActionMailer configuration.  The documentation
+# for ActionMailer is at:
+# https://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration
+#
 mail:
   # Email delivery errors will be shown in the application
   # Environment Variable Override: PWP__MAIL__RAISE_DELIVERY_ERRORS='false'
@@ -202,6 +207,10 @@ mail:
   # Environment Variable Override: PWP__MAIL__SMTP_PASSWORD='something@&#$'
   # smtp_password: ''
 
+  # If you need to specify a HELO domain, you can do it here.
+  # Environment Variable Override: PWP__MAIL__SMTP_DOMAIN='xyz.dev'
+  # smtp_domain: ''
+
   # Port of the SMTP server
   # Environment Variable Override: PWP__MAIL__SMTP_PORT='587'
   smtp_port: 587
@@ -217,7 +226,11 @@ mail:
 
   # Use STARTTLS when connecting to your SMTP server and fail if unsupported.
   # Environment Variable Override: PWP__MAIL__SMTP_STARTTLS='true'
-  smtp_starttls: true
+  # smtp_starttls: false
+
+  # Detects if STARTTLS is enabled in your SMTP server and starts to use it. Defaults to true.
+  # Environment Variable Override: PWP__MAIL__SMTP_ENABLE_STARTTLS_AUTO='false'
+  smtp_enable_starttls_auto: true
 
   # Number of seconds to wait while attempting to open a connection.
   # Environment Variable Override: PWP__MAIL__SMTP_OPEN_TIMEOUT='10'
@@ -226,6 +239,12 @@ mail:
   # Number of seconds to wait until timing-out a read(2) call.
   # Environment Variable Override: PWP__MAIL__SMTP_READ_TIMEOUT='10'
   smtp_read_timeout: 10
+
+  # When using TLS, you can set how OpenSSL checks the certificate. This is
+  # useful if you need to validate a self-signed and/or a wildcard certificate.
+  # This can be one of the OpenSSL verify constants, :none or :peer
+  # Environment Variable Override: PWP__MAIL__SMTP_OPENSSL_VERIFY_MODE='none'
+  # smtp_openssl_verify_mode: 'peer'
 
   # Configure the e-mail address which will be shown as 'From' in emails
   # See config/initializers/devise.rb where this is used


### PR DESCRIPTION
Fixed #385 

To disable SSL cert verification, you can set `PWP__MAIL__SMTP_OPENSSL_VERIFY_MODE='none'` or modify and overlay `config/settings.yml`