### PR TITLE
fix(settings): variable name did not reflect parameter

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -104,7 +104,7 @@ This can be done with the following environment variables:
 | --------- | ------------------ | --- |
 | PWP__BRAND__TITLE | Title for the site. | `Password Pusher` |
 | PWP__BRAND__TAGLINE | Tagline for the site.  | `Go Ahead.  Email Another Password.` |
-| PWP__BRAND__SHOW_FOOTER | On/Off switch for the footer menu. | `true` |
+| PWP__BRAND__SHOW_FOOTER_MENU | On/Off switch for the footer menu. | `true` |
 | PWP__BRAND__LIGHT_LOGO | Site logo image for the light theme. | `media/img/logo-transparent-sm-bare.png` |
 | PWP__BRAND__DARK_LOGO | Site logo image for the dark theme. | `media/img/logo-transparent-sm-bare.png` |
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,19 +9,19 @@ brand:
   ### Site Title
   #
   # Environment variable override: PWP__BRAND__TITLE='Acme Corp.'
-  # 
+  #
   # title: 'Password Pusher'
 
   ### Site Tagline
-  # 
+  #
   # Environment variable override: PWP__BRAND__TAGLINE='Security First'
-  # 
+  #
   # tagline: 'Go Ahead.  Email Another Password.'
 
   ### Show Footer Menu Toggle
   #
-  # Environment variable override: PWP__BRAND__SHOW_FOOTER='true'
-  # 
+  # Environment variable override: PWP__BRAND__SHOW_FOOTER_MENU='true'
+  #
   show_footer_menu: true
 
   ### Site logo
@@ -34,7 +34,7 @@ brand:
   #
   # Environment variable override: PWP__BRAND__LIGHT_LOGO='https://mys3bucket.amazonaws.com/a/lea+giuliana.png'
   # Environment variable override: PWP__BRAND__DARK_LOGO='https://mys3bucket.amazonaws.com/a/lea+giuliana.png'
-  # 
+  #
   # light_logo: 'media/img/logo-transparent-sm-bare.png'
   # dark_logo: 'media/img/logo-transparent-sm-dark-bare.png'
 


### PR DESCRIPTION
The inserted environment variable did not conform to the
option in the settings file.  This should fix the issue
of not having the footer be hidden when setting the value
to false.