### PR TITLE
Fix: Workaround for Rails 6 + Ruby 3.1 bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,9 +89,14 @@ gem 'config'
 gem 'route_translator', '>= 12.1.0'
 gem 'translation'
 gem 'mail_form', '>= 1.9.0'
-gem 'net-smtp'
 gem 'apipie-rails'
 gem 'simple_token_authentication', '~> 1.0'
+
+# Fix for https://github.com/pglombardo/PasswordPusher/issues/397
+# In place until Rails 7.0.1 upgrade
+gem 'net-smtp', require: false
+gem 'net-imap', require: false
+gem 'net-pop', require: false
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,14 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     msgpack (1.5.6)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -333,6 +341,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.4)
+    strscan (3.0.4)
     text (1.3.1)
     thor (1.2.1)
     tilt (2.0.11)
@@ -395,6 +404,8 @@ DEPENDENCIES
   minitest
   minitest-rails (>= 6.1.0)
   minitest-reporters
+  net-imap
+  net-pop
   net-smtp
   oj
   pg

--- a/gemfiles/Gemfile-mysql
+++ b/gemfiles/Gemfile-mysql
@@ -90,9 +90,14 @@ gem 'config'
 gem 'route_translator'
 gem 'translation'
 gem 'mail_form'
-gem 'net-smtp'
 gem 'apipie-rails'
 gem 'simple_token_authentication', '~> 1.0'
+
+# Fix for https://github.com/pglombardo/PasswordPusher/issues/397
+# In place until Rails 7.0.1 upgrade
+gem 'net-smtp', require: false
+gem 'net-imap', require: false
+gem 'net-pop', require: false
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/gemfiles/Gemfile-mysql.lock
+++ b/gemfiles/Gemfile-mysql.lock
@@ -198,6 +198,14 @@ GEM
       ruby-progressbar
     msgpack (1.5.6)
     mysql2 (0.5.4)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -333,6 +341,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.4)
+    strscan (3.0.4)
     text (1.3.1)
     thor (1.2.1)
     tilt (2.0.11)
@@ -396,6 +405,8 @@ DEPENDENCIES
   minitest-rails
   minitest-reporters
   mysql2
+  net-imap
+  net-pop
   net-smtp
   oj
   pry-byebug


### PR DESCRIPTION
Fixed #397

https://github.com/rails/rails/pull/44083
https://stackoverflow.com/questions/70500220/rails-7-ruby-3-1-loaderror-cannot-load-such-file-net-smtp
