### PR TITLE
Version limit Docker containers to Ruby 3.1

### DIFF
--- a/containers/docker/pwpush-ephemeral/Dockerfile
+++ b/containers/docker/pwpush-ephemeral/Dockerfile
@@ -1,5 +1,5 @@
 # pwpush-ephemeral
-FROM ruby:3-slim
+FROM ruby:3.1-slim
 
 LABEL maintainer='pglombardo@hey.com'
 

--- a/containers/docker/pwpush-mysql/Dockerfile
+++ b/containers/docker/pwpush-mysql/Dockerfile
@@ -1,5 +1,5 @@
 # pwpush-mysql
-FROM ruby:3-slim
+FROM ruby:3.1-slim
 
 LABEL maintainer='pglombardo@hey.com'
 

--- a/containers/docker/pwpush-postgres/Dockerfile
+++ b/containers/docker/pwpush-postgres/Dockerfile
@@ -1,5 +1,5 @@
 # pwpush-postgres
-FROM ruby:3-slim
+FROM ruby:3.1-slim
 
 LABEL maintainer='pglombardo@hey.com'
 


### PR DESCRIPTION
## Description

Version limit the docker containers because nokogiri doesn't yet support
v3.2.

From [this action](https://github.com/pglombardo/PasswordPusher/actions/runs/3790398090/jobs/6445312306):
```
#18 6.627 nokogiri-1.13.10-x86_64-linux requires ruby version < 3.2.dev, >= 2.6, which is
#18 6.627 incompatible with the current version, 3.2.0
```
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
