### PR TITLE
Revert "Remove Node.js and Yarn from Docker containers"

### DIFF
--- a/containers/docker/pwpush-ephemeral/Dockerfile
+++ b/containers/docker/pwpush-ephemeral/Dockerfile
@@ -8,8 +8,12 @@ ENV PATH=${APP_ROOT}:${PATH} HOME=${APP_ROOT}
 
 RUN apt-get update && apt-get install -y curl ca-certificates gnupg
 
+# Required to get the Node.js yarn tool
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
 # Required packages
-RUN apt-get update && apt-get install -qq -y --assume-yes build-essential apt-utils libpq-dev git curl tzdata libsqlite3-0 libsqlite3-dev zlib1g-dev
+RUN apt-get update && apt-get install -qq -y --assume-yes build-essential apt-utils libpq-dev git curl tzdata libsqlite3-0 libsqlite3-dev zlib1g-dev nodejs yarn
 
 RUN mkdir -p ${APP_ROOT}
 ADD ./ ${APP_ROOT}/
@@ -27,6 +31,7 @@ RUN bundle config set without 'development production test'
 RUN bundle config set deployment 'true'
 
 RUN bundle install
+RUN yarn install
 RUN bundle exec rails assets:precompile
 RUN bundle exec rake db:setup
 

--- a/containers/docker/pwpush-mysql/Dockerfile
+++ b/containers/docker/pwpush-mysql/Dockerfile
@@ -9,9 +9,13 @@ ENV DATABASE_URL=mysql2://passwordpusher_user:passwordpusher_passwd@mysql:3306/p
 
 RUN apt-get update && apt-get install -y curl ca-certificates gnupg
 
+# Required to get the Node.js yarn tool
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
 # Required packages
 RUN apt-get update -qq && \
-    apt-get install -qq -y --assume-yes build-essential apt-utils git curl tzdata zlib1g-dev default-libmysqlclient-dev
+    apt-get install -qq -y --assume-yes build-essential apt-utils git curl tzdata zlib1g-dev nodejs yarn default-libmysqlclient-dev
 
 RUN mkdir -p ${APP_ROOT}
 ADD ./ ${APP_ROOT}/
@@ -29,6 +33,7 @@ RUN bundle config set without 'development private test'
 RUN bundle config set deployment 'true'
 
 RUN bundle install
+RUN yarn install
 RUN bundle exec rails assets:precompile
 
 ENTRYPOINT ["containers/docker/pwpush-mysql/entrypoint.sh"]

--- a/containers/docker/pwpush-openshift/Dockerfile
+++ b/containers/docker/pwpush-openshift/Dockerfile
@@ -1,4 +1,4 @@
-# pwpush-openshift
+# pwpush-postgres
 FROM ruby:3-slim
 
 LABEL maintainer='pglombardo@hey.com'
@@ -9,8 +9,12 @@ ENV DATABASE_URL=postgresql://passwordpusher_user:passwordpusher_passwd@postgres
 
 RUN apt-get update && apt-get install -y curl ca-certificates gnupg
 
+# Required to get the Node.js yarn tool
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
 RUN apt-get update -qq && \
-    apt-get install -qq -y --assume-yes build-essential apt-utils libpq-dev git curl tzdata libsqlite3-0 libsqlite3-dev zlib1g-dev && \
+    apt-get install -qq -y --assume-yes build-essential apt-utils libpq-dev git curl tzdata libsqlite3-0 libsqlite3-dev zlib1g-dev nodejs yarn && \
     cd /opt && \
     git clone https://github.com/pglombardo/PasswordPusher.git && \
     touch ${APP_ROOT}/log/production.log
@@ -28,6 +32,7 @@ RUN bundle config set without 'development private test'
 RUN bundle config set deployment 'true'
 
 RUN bundle install
+RUN yarn install
 RUN bundle exec rails assets:precompile
 
 ENTRYPOINT ["containers/docker/pwpush-postgres/entrypoint.sh"]

--- a/containers/docker/pwpush-postgres/Dockerfile
+++ b/containers/docker/pwpush-postgres/Dockerfile
@@ -9,9 +9,13 @@ ENV DATABASE_URL=postgres://passwordpusher_user:passwordpusher_passwd@postgres:5
 
 RUN apt-get update && apt-get install -y curl ca-certificates gnupg
 
+# Required to get the Node.js yarn tool
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
 # Required packages
 RUN apt-get update -qq && \
-    apt-get install -qq -y --assume-yes build-essential apt-utils libpq-dev git curl tzdata zlib1g-dev
+    apt-get install -qq -y --assume-yes build-essential apt-utils libpq-dev git curl tzdata zlib1g-dev nodejs yarn
 
 RUN mkdir -p ${APP_ROOT}
 ADD ./ ${APP_ROOT}/
@@ -28,6 +32,7 @@ RUN bundle config set without 'development private test'
 RUN bundle config set deployment 'true'
 
 RUN bundle install
+RUN yarn install
 RUN bundle exec rails assets:precompile
 
 ENTRYPOINT ["containers/docker/pwpush-postgres/entrypoint.sh"]


### PR DESCRIPTION
Reverts pglombardo/PasswordPusher#649

Node.js is required for asset compilation.  Using a gem based v8 engine is more trouble than it's worth.  Reverting this change.