### PR TITLE
Updated Settings: Allow Setting Expiration per Push Type

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -85,20 +85,20 @@ Notes:
 | PWP__DEFAULT_LOCALE | Sets the default language for the application.  See the [documentation](https://github.com/pglombardo/PasswordPusher#internationalization). | `en` |
 | PWP__RELATIVE_ROOT | Runs the application in a subfolder.  e.g. With a value of `pwp` the front page will then be at `https://url/pwp` | `Not set` |
 
-## Push Form Defaults
+## Password Push Expiration Settings
 
 | Environment Variable | Description | Default Value |
 | --------- | ------------------ | --- |
-| PWP__EXPIRE_AFTER_DAYS_DEFAULT | Controls the "Expire After Days" default value in Password#new | `7` |
-| PWP__EXPIRE_AFTER_DAYS_MIN | Controls the "Expire After Days" minimum value in Password#new | `1` |
-| PWP__EXPIRE_AFTER_DAYS_MAX | Controls the "Expire After Days" maximum value in Password#new | `90` |
-| PWP__EXPIRE_AFTER_VIEWS_DEFAULT | Controls the "Expire After Views" default value in Password#new | `5` |
-| PWP__EXPIRE_AFTER_VIEWS_MIN | Controls the "Expire After Views" minimum value in Password#new | `1` |
-| PWP__EXPIRE_AFTER_VIEWS_MAX | Controls the "Expire After Views" maximum value in Password#new | `100` |
-| PWP__ENABLE_DELETABLE_PUSHES | Can passwords be deleted by viewers? When true, passwords will have a link to optionally delete the password being viewed | `false` |
-| PWP__DELETABLE_PASSWORDS_DEFAULT | When the above is `true`, this sets the default value for the option. | `true` |
-| PWP__ENABLE_RETRIEVAL_STEP | When `true`, adds an option to have a preliminary step to retrieve passwords.  | `true` |
-| PWP__RETRIEVAL_STEP_DEFAULT | Sets the default value for the retrieval step for newly created passwords. | `false` |
+| PWP__PW__EXPIRE_AFTER_DAYS_DEFAULT | Controls the "Expire After Days" default value in Password#new | `7` |
+| PWP__PW__EXPIRE_AFTER_DAYS_MIN | Controls the "Expire After Days" minimum value in Password#new | `1` |
+| PWP__PW__EXPIRE_AFTER_DAYS_MAX | Controls the "Expire After Days" maximum value in Password#new | `90` |
+| PWP__PW__EXPIRE_AFTER_VIEWS_DEFAULT | Controls the "Expire After Views" default value in Password#new | `5` |
+| PWP__PW__EXPIRE_AFTER_VIEWS_MIN | Controls the "Expire After Views" minimum value in Password#new | `1` |
+| PWP__PW__EXPIRE_AFTER_VIEWS_MAX | Controls the "Expire After Views" maximum value in Password#new | `100` |
+| PWP__PW__ENABLE_DELETABLE_PUSHES | Can passwords be deleted by viewers? When true, passwords will have a link to optionally delete the password being viewed | `false` |
+| PWP__PW__DELETABLE_PASSWORDS_DEFAULT | When the above is `true`, this sets the default value for the option. | `true` |
+| PWP__PW__ENABLE_RETRIEVAL_STEP | When `true`, adds an option to have a preliminary step to retrieve passwords.  | `true` |
+| PWP__PW__RETRIEVAL_STEP_DEFAULT | Sets the default value for the retrieval step for newly created passwords. | `false` |
 
 # Enabling Logins
 
@@ -162,6 +162,21 @@ This feature can store uploads on local disk (not valid for Docker containers), 
 | PWP__ENABLE_FILE_PUSHES | On/Off switch for File Pushes. | `false` |
 | PWP__FILES__STORAGE | Chooses the storage area for uploaded files. | `local`, `s3`, `gcs` or `as` |
 
+## File Push Expiration Settings
+
+| Environment Variable | Description | Default Value |
+| --------- | ------------------ | --- |
+| PWP__FILES__EXPIRE_AFTER_DAYS_DEFAULT | Controls the "Expire After Days" default value in Password#new | `7` |
+| PWP__FILES__EXPIRE_AFTER_DAYS_MIN | Controls the "Expire After Days" minimum value in Password#new | `1` |
+| PWP__FILES__EXPIRE_AFTER_DAYS_MAX | Controls the "Expire After Days" maximum value in Password#new | `90` |
+| PWP__FILES__EXPIRE_AFTER_VIEWS_DEFAULT | Controls the "Expire After Views" default value in Password#new | `5` |
+| PWP__FILES__EXPIRE_AFTER_VIEWS_MIN | Controls the "Expire After Views" minimum value in Password#new | `1` |
+| PWP__FILES__EXPIRE_AFTER_VIEWS_MAX | Controls the "Expire After Views" maximum value in Password#new | `100` |
+| PWP__FILES__ENABLE_DELETABLE_PUSHES | Can passwords be deleted by viewers? When true, passwords will have a link to optionally delete the password being viewed | `false` |
+| PWP__FILES__DELETABLE_PASSWORDS_DEFAULT | When the above is `true`, this sets the default value for the option. | `true` |
+| PWP__FILES__ENABLE_RETRIEVAL_STEP | When `true`, adds an option to have a preliminary step to retrieve passwords.  | `true` |
+| PWP__FILES__RETRIEVAL_STEP_DEFAULT | Sets the default value for the retrieval step for newly created passwords. | `false` |
+
 ## Local Storage
 
 The default location for local storage is `./storage`.
@@ -203,6 +218,21 @@ Similar to file pushes, URL pushes also require logins to be enabled.
 | Environment Variable | Description | Default |
 | --------- | ------------------ | --- |
 | PWP__ENABLE_URL_PUSHES | On/Off switch for URL Pushes. | `false` |
+
+## URL Push Expiration Settings
+
+| Environment Variable | Description | Default Value |
+| --------- | ------------------ | --- |
+| PWP__URL__EXPIRE_AFTER_DAYS_DEFAULT | Controls the "Expire After Days" default value in Password#new | `7` |
+| PWP__URL__EXPIRE_AFTER_DAYS_MIN | Controls the "Expire After Days" minimum value in Password#new | `1` |
+| PWP__URL__EXPIRE_AFTER_DAYS_MAX | Controls the "Expire After Days" maximum value in Password#new | `90` |
+| PWP__URL__EXPIRE_AFTER_VIEWS_DEFAULT | Controls the "Expire After Views" default value in Password#new | `5` |
+| PWP__URL__EXPIRE_AFTER_VIEWS_MIN | Controls the "Expire After Views" minimum value in Password#new | `1` |
+| PWP__URL__EXPIRE_AFTER_VIEWS_MAX | Controls the "Expire After Views" maximum value in Password#new | `100` |
+| PWP__URL__ENABLE_DELETABLE_PUSHES | Can passwords be deleted by viewers? When true, passwords will have a link to optionally delete the password being viewed | `false` |
+| PWP__URL__DELETABLE_PASSWORDS_DEFAULT | When the above is `true`, this sets the default value for the option. | `true` |
+| PWP__URL__ENABLE_RETRIEVAL_STEP | When `true`, adds an option to have a preliminary step to retrieve passwords.  | `true` |
+| PWP__URL__RETRIEVAL_STEP_DEFAULT | Sets the default value for the retrieval step for newly created passwords. | `false` |
 
 # Rebranding
 

--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -50,14 +50,14 @@ class CommandsController < ApplicationController
       return
     end
 
-    days ||= Settings.expire_after_days_default
-    views ||= Settings.expire_after_views_default
-    retrieval = (Settings.enable_retrieval_step && Settings.retrieval_step_default) ? '/r' : ''
+    days ||= Settings.pw.expire_after_days_default
+    views ||= Settings.pw.expire_after_views_default
+    retrieval = (Settings.pw.enable_retrieval_step && Settings.pw.retrieval_step_default) ? '/r' : ''
 
     @password = Password.new
     @password.expire_after_days = days
     @password.expire_after_views = views
-    @password.deletable_by_viewer = Settings.enable_deletable_pushes
+    @password.deletable_by_viewer = Settings.pw.enable_deletable_pushes
 
     @password.payload = secret
 

--- a/app/controllers/file_pushes_controller.rb
+++ b/app/controllers/file_pushes_controller.rb
@@ -138,8 +138,8 @@ class FilePushesController < ApplicationController
 
     @push = FilePush.new
 
-    @push.expire_after_days = params[:file_push].fetch(:expire_after_days, Settings.expire_after_days_default)
-    @push.expire_after_views = params[:file_push].fetch(:expire_after_views, Settings.expire_after_views_default)
+    @push.expire_after_days = params[:file_push].fetch(:expire_after_days, Settings.files.expire_after_days_default)
+    @push.expire_after_views = params[:file_push].fetch(:expire_after_views, Settings.files.expire_after_views_default)
     @push.user_id = current_user.id if user_signed_in?
     @push.url_token = SecureRandom.urlsafe_base64(rand(8..14)).downcase
 
@@ -376,7 +376,7 @@ class FilePushesController < ApplicationController
   # Since determining this value between and HTML forms and JSON API requests can be a bit
   # tricky, we break this out to it's own function.
   def create_detect_retrieval_step(file_push, params)
-    if Settings.enable_retrieval_step == true
+    if Settings.files.enable_retrieval_step == true
       if params[:file_push].key?(:retrieval_step)
         # User form data or json API request: :deletable_by_viewer can
         # be 'on', 'true', 'checked' or 'yes' to indicate a positive
@@ -390,7 +390,7 @@ class FilePushesController < ApplicationController
         else
           # The JSON API is implicit so if it's not specified, use the app
           # configured default
-          file_push.retrieval_step = Settings.retrieval_step_default
+          file_push.retrieval_step = Settings.files.retrieval_step_default
         end
       end
     else
@@ -402,7 +402,7 @@ class FilePushesController < ApplicationController
   # Since determining this value between and HTML forms and JSON API requests can be a bit
   # tricky, we break this out to it's own function.
   def create_detect_deletable_by_viewer(file_push, params)
-    if Settings.enable_deletable_pushes == true
+    if Settings.files.enable_deletable_pushes == true
       if params[:file_push].key?(:deletable_by_viewer)
         # User form data or json API request: :deletable_by_viewer can
         # be 'on', 'true', 'checked' or 'yes' to indicate a positive
@@ -416,7 +416,7 @@ class FilePushesController < ApplicationController
         else
           # The JSON API is implicit so if it's not specified, use the app
           # configured default
-          file_push.deletable_by_viewer = Settings.deletable_pushes_default
+          file_push.deletable_by_viewer = Settings.files.deletable_pushes_default
         end
       end
     else

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -121,8 +121,8 @@ class PasswordsController < ApplicationController
     end
 
     @push = Password.new
-    @push.expire_after_days = params[:password].fetch(:expire_after_days, Settings.expire_after_days_default)
-    @push.expire_after_views = params[:password].fetch(:expire_after_views, Settings.expire_after_views_default)
+    @push.expire_after_days = params[:password].fetch(:expire_after_days, Settings.pw.expire_after_days_default)
+    @push.expire_after_views = params[:password].fetch(:expire_after_views, Settings.pw.expire_after_views_default)
     @push.user_id = current_user.id if user_signed_in?
     @push.url_token = SecureRandom.urlsafe_base64(rand(8..14)).downcase
 
@@ -356,7 +356,7 @@ class PasswordsController < ApplicationController
   # Since determining this value between and HTML forms and JSON API requests can be a bit
   # tricky, we break this out to it's own function.
   def create_detect_retrieval_step(password, params)
-    if Settings.enable_retrieval_step == true
+    if Settings.pw.enable_retrieval_step == true
       if params[:password].key?(:retrieval_step)
         # User form data or json API request: :deletable_by_viewer can
         # be 'on', 'true', 'checked' or 'yes' to indicate a positive
@@ -370,7 +370,7 @@ class PasswordsController < ApplicationController
         else
           # The JSON API is implicit so if it's not specified, use the app
           # configured default
-          password.retrieval_step = Settings.retrieval_step_default
+          password.retrieval_step = Settings.pw.retrieval_step_default
         end
       end
     else
@@ -382,7 +382,7 @@ class PasswordsController < ApplicationController
   # Since determining this value between and HTML forms and JSON API requests can be a bit
   # tricky, we break this out to it's own function.
   def create_detect_deletable_by_viewer(password, params)
-    if Settings.enable_deletable_pushes == true
+    if Settings.pw.enable_deletable_pushes == true
       if params[:password].key?(:deletable_by_viewer)
         # User form data or json API request: :deletable_by_viewer can
         # be 'on', 'true', 'checked' or 'yes' to indicate a positive
@@ -396,7 +396,7 @@ class PasswordsController < ApplicationController
         else
           # The JSON API is implicit so if it's not specified, use the app
           # configured default
-          password.deletable_by_viewer = Settings.deletable_pushes_default
+          password.deletable_by_viewer = Settings.pw.deletable_pushes_default
         end
       end
     else

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -118,8 +118,8 @@ class UrlsController < ApplicationController
       return
     end
 
-    @push.expire_after_days = params[:url].fetch(:expire_after_days, Settings.expire_after_days_default)
-    @push.expire_after_views = params[:url].fetch(:expire_after_views, Settings.expire_after_views_default)
+    @push.expire_after_days = params[:url].fetch(:expire_after_days, Settings.url.expire_after_days_default)
+    @push.expire_after_views = params[:url].fetch(:expire_after_views, Settings.url.expire_after_views_default)
     @push.user_id = current_user.id if user_signed_in?
     @push.url_token = SecureRandom.urlsafe_base64(rand(8..14)).downcase
 
@@ -352,7 +352,7 @@ class UrlsController < ApplicationController
   # Since determining this value between and HTML forms and JSON API requests can be a bit
   # tricky, we break this out to it's own function.
   def create_detect_retrieval_step(url, params)
-    if Settings.enable_retrieval_step == true
+    if Settings.url.enable_retrieval_step == true
       if params[:url].key?(:retrieval_step)
         # User form data or json API request: :deletable_by_viewer can
         # be 'on', 'true', 'checked' or 'yes' to indicate a positive
@@ -366,7 +366,7 @@ class UrlsController < ApplicationController
         else
           # The JSON API is implicit so if it's not specified, use the app
           # configured default
-          url.retrieval_step = Settings.retrieval_step_default
+          url.retrieval_step = Settings.url.retrieval_step_default
         end
       end
     else

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -228,9 +228,8 @@ class UrlsController < ApplicationController
         redirect_to :root, notice: _('That push does not belong to you.')
         return
       end
-    elsif @push.deletable_by_viewer == false
-      # Anonymous user - assure deletable_by_viewer enabled
-      redirect_to :root, notice: _('That push is not deletable by viewers.')
+    else
+      redirect_to :root, notice: _('That push does not belong to you.')
       return
     end
 
@@ -354,14 +353,14 @@ class UrlsController < ApplicationController
   def create_detect_retrieval_step(url, params)
     if Settings.url.enable_retrieval_step == true
       if params[:url].key?(:retrieval_step)
-        # User form data or json API request: :deletable_by_viewer can
+        # User form data or json API request: :retrieval_step can
         # be 'on', 'true', 'checked' or 'yes' to indicate a positive
         user_rs = params[:url][:retrieval_step].to_s.downcase
         url.retrieval_step = %w[on yes checked true].include?(user_rs)
       else
         if request.format.html?
           # HTML Form Checkboxes: when NOT checked the form attribute isn't submitted
-          # at all so we set false - NOT deletable by viewers
+          # at all so we set false - NO retrieval step 
           url.retrieval_step = false
         else
           # The JSON API is implicit so if it's not specified, use the app

--- a/app/models/file_push.rb
+++ b/app/models/file_push.rb
@@ -87,15 +87,15 @@ class FilePush < ApplicationRecord
     return if expired
 
     # Range checking
-    self.expire_after_days  ||= Settings.expire_after_days_default
-    self.expire_after_views ||= Settings.expire_after_views_default
+    self.expire_after_days  ||= Settings.files.expire_after_days_default
+    self.expire_after_views ||= Settings.files.expire_after_views_default
 
-    unless expire_after_days.between?(Settings.expire_after_days_min, Settings.expire_after_days_max)
-      self.expire_after_days = Settings.expire_after_days_default
+    unless expire_after_days.between?(Settings.files.expire_after_days_min, Settings.files.expire_after_days_max)
+      self.expire_after_days = Settings.files.expire_after_days_default
     end
 
-    unless expire_after_views.between?(Settings.expire_after_views_min, Settings.expire_after_views_max)
-      self.expire_after_views = Settings.expire_after_views_default
+    unless expire_after_views.between?(Settings.files.expire_after_views_min, Settings.files.expire_after_views_max)
+      self.expire_after_views = Settings.files.expire_after_views_default
     end
 
     return if new_record?

--- a/app/models/password.rb
+++ b/app/models/password.rb
@@ -77,15 +77,15 @@ class Password < ApplicationRecord
     return if expired
 
     # Range checking
-    self.expire_after_days  ||= Settings.expire_after_days_default
-    self.expire_after_views ||= Settings.expire_after_views_default
+    self.expire_after_days  ||= Settings.pw.expire_after_days_default
+    self.expire_after_views ||= Settings.pw.expire_after_views_default
 
-    unless expire_after_days.between?(Settings.expire_after_days_min, Settings.expire_after_days_max)
-      self.expire_after_days = Settings.expire_after_days_default
+    unless expire_after_days.between?(Settings.pw.expire_after_days_min, Settings.pw.expire_after_days_max)
+      self.expire_after_days = Settings.pw.expire_after_days_default
     end
 
-    unless expire_after_views.between?(Settings.expire_after_views_min, Settings.expire_after_views_max)
-      self.expire_after_views = Settings.expire_after_views_default
+    unless expire_after_views.between?(Settings.pw.expire_after_views_min, Settings.pw.expire_after_views_max)
+      self.expire_after_views = Settings.pw.expire_after_views_default
     end
 
     return if new_record?

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -77,15 +77,15 @@ class Url < ApplicationRecord
     return if expired
 
     # Range checking
-    self.expire_after_days  ||= Settings.expire_after_days_default
-    self.expire_after_views ||= Settings.expire_after_views_default
+    self.expire_after_days  ||= Settings.url.expire_after_days_default
+    self.expire_after_views ||= Settings.url.expire_after_views_default
 
-    unless expire_after_days.between?(Settings.expire_after_days_min, Settings.expire_after_days_max)
-      self.expire_after_days = Settings.expire_after_days_default
+    unless expire_after_days.between?(Settings.url.expire_after_days_min, Settings.url.expire_after_days_max)
+      self.expire_after_days = Settings.url.expire_after_days_default
     end
 
-    unless expire_after_views.between?(Settings.expire_after_views_min, Settings.expire_after_views_max)
-      self.expire_after_views = Settings.expire_after_views_default
+    unless expire_after_views.between?(Settings.url.expire_after_views_min, Settings.url.expire_after_views_max)
+      self.expire_after_views = Settings.url.expire_after_views_default
     end
 
     return if new_record?

--- a/app/views/file_pushes/new.html.erb
+++ b/app/views/file_pushes/new.html.erb
@@ -4,14 +4,14 @@
     data-controller="knobs passwords form"
     data-knobs-lang-day-value=<%= _('Day') %>
     data-knobs-lang-days-value=<%= _('Days') %>
-    data-knobs-default-days-value=<%= Settings.expire_after_days_default %>
+    data-knobs-default-days-value=<%= Settings.files.deletable_pushes_default %>
 
     data-knobs-lang-view-value=<%= _('View') %>
     data-knobs-lang-views-value=<%= _('Views') %>
-    data-knobs-default-views-value=<%= Settings.expire_after_views_default %>
+    data-knobs-default-views-value=<%= Settings.files.expire_after_views_default %>
 
-    data-knobs-default-retrieval-step-value=<%= Settings.retrieval_step_default %>
-    data-knobs-default-deletable-by-viewer-value=<%= Settings.deletable_pushes_default %>
+    data-knobs-default-retrieval-step-value=<%= Settings.files.retrieval_step_default %>
+    data-knobs-default-deletable-by-viewer-value=<%= Settings.files.deletable_pushes_default %>
 
     data-knobs-ga-enabled-value=<%= ENV.key?('GA_ENABLE') %>
 >
@@ -45,11 +45,11 @@
             <div class='row'>
                 <p><%= _('Expire secret link and delete after:') %></p>
                 <div class='col-8'>
-                    <%= range_field_tag("password_expire_after_days", Settings.expire_after_days_default,
+                    <%= range_field_tag("password_expire_after_days", Settings.files.deletable_pushes_default,
                                         { :name => "file_push[expire_after_days]",
                                           :class => "form-range",
-                                          :min => Settings.expire_after_days_min,
-                                          :max => Settings.expire_after_days_max,
+                                          :min => Settings.files.expire_after_days_min,
+                                          :max => Settings.files.expire_after_days_max,
                                           :step => "1",
                                           "data-action" => "change->knobs#updateDaysSlider input->knobs#updateDaysSlider",
                                           "data-knobs-target" => "daysRange"
@@ -57,18 +57,18 @@
                 </div>
                 <div class='col-4'>
                     <label for='password_expire_after_days' data-knobs-target="daysRangeLabel">
-                        <%=Settings.expire_after_days_default %> <%= _('Days') %>
+                        <%=Settings.files.deletable_pushes_default %> <%= _('Days') %>
                     </label>
                 </div>
             </div>
 
             <div class='row'>
                 <div class='col-8'>
-                    <%=range_field_tag("password_expire_after_views", Settings.expire_after_views_default,
+                    <%=range_field_tag("password_expire_after_views", Settings.files.expire_after_views_default,
                                        { :name => "file_push[expire_after_views]",
                                          :class => "form-range",
-                                         :min => Settings.expire_after_views_min,
-                                         :max => Settings.expire_after_views_max,
+                                         :min => Settings.files.expire_after_views_min,
+                                         :max => Settings.files.expire_after_views_max,
                                          :step => "1",
                                          "data-action" => "change->knobs#updateViewsSlider input->knobs#updateViewsSlider",
                                          "data-knobs-target" => "viewsRange"
@@ -77,7 +77,7 @@
 
                 <div class='col-4'>
                     <label for='password_expire_after_views' data-knobs-target="viewsRangeLabel">
-                        <%= Settings.expire_after_views_default %> <%= _('Views') %>
+                        <%= Settings.files.expire_after_views_default %> <%= _('Views') %>
                     </label>
                 </div>
             </div>
@@ -92,22 +92,22 @@
             <div class='row'>
                 <div class='col'>
                     <div class="list-group mx-0">
-                        <% if Settings.enable_retrieval_step %>
+                        <% if Settings.files.enable_retrieval_step %>
                             <label class="list-group-item d-flex gap-2">
-                            <%=check_box_tag "file_push[retrieval_step]", nil, Settings.retrieval_step_default,
+                            <%=check_box_tag "file_push[retrieval_step]", nil, Settings.files.retrieval_step_default,
                                             { class: 'form-check-input flex-shrink-0',
-                                            x_default: Settings.retrieval_step_default } %>
+                                            x_default: Settings.files.retrieval_step_default } %>
                             <span>
                                 <%= _('Use a 1-click retrieval step') %>
                                 <small class="d-block text-muted"><%= _('Helps to avoid chat systems and URL scanners from eating up views.') %></small>
                             </span>
                             </label>
                         <% end %>
-                        <% if Settings.enable_deletable_pushes %>
+                        <% if Settings.files.enable_deletable_pushes %>
                             <label class="list-group-item d-flex gap-2">
-                            <%= check_box_tag "file_push[deletable_by_viewer]", nil, Settings.deletable_pushes_default,
+                            <%= check_box_tag "file_push[deletable_by_viewer]", nil, Settings.files.deletable_pushes_default,
                                             { class: 'form-check-input flex-shrink-0',
-                                                x_default: Settings.deletable_pushes_default }  %>
+                                                x_default: Settings.files.deletable_pushes_default }  %>
                             <span>
                                 <%= _('Allow immediate deletion') %>
                                 <small class="d-block text-muted"><%= _('Allow users to delete passwords once retrieved.') %></small>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -4,17 +4,17 @@
     data-controller="knobs pwgen passwords form"
     data-knobs-lang-day-value=<%= _('Day') %>
     data-knobs-lang-days-value=<%= _('Days') %>
-    data-knobs-default-days-value=<%= Settings.expire_after_days_default %>
+    data-knobs-default-days-value=<%= Settings.pw.expire_after_days_default %>
 
     data-knobs-lang-view-value=<%= _('View') %>
     data-knobs-lang-views-value=<%= _('Views') %>
-    data-knobs-default-views-value=<%= Settings.expire_after_views_default %>
+    data-knobs-default-views-value=<%= Settings.pw.expire_after_views_default %>
 
     data-knobs-lang-save-value=<%= _('Save') %>
     data-knobs-lang-saved-value=<%= _('Saved!') %>
 
-    data-knobs-default-retrieval-step-value=<%= Settings.retrieval_step_default %>
-    data-knobs-default-deletable-by-viewer-value=<%= Settings.deletable_pushes_default %>
+    data-knobs-default-retrieval-step-value=<%= Settings.pw.retrieval_step_default %>
+    data-knobs-default-deletable-by-viewer-value=<%= Settings.pw.deletable_pushes_default %>
 
     data-pwgen-use-numbers-default-value="<%= Settings.gen.has_numbers %>"
     data-pwgen-title-cased-default-value="<%= Settings.gen.title_cased %>"
@@ -69,11 +69,11 @@
             <div class='row'>
                 <p><%= _('Expire secret link and delete after:') %></p>
                 <div class='col-8'>
-                    <%= range_field_tag("password_expire_after_days", Settings.expire_after_days_default,
+                    <%= range_field_tag("password_expire_after_days", Settings.pw.expire_after_days_default,
                                         { :name => "password[expire_after_days]",
                                           :class => "form-range",
-                                          :min => Settings.expire_after_days_min,
-                                          :max => Settings.expire_after_days_max,
+                                          :min => Settings.pw.expire_after_days_min,
+                                          :max => Settings.pw.expire_after_days_max,
                                           :step => "1",
                                           "data-action" => "change->knobs#updateDaysSlider input->knobs#updateDaysSlider",
                                           "data-knobs-target" => "daysRange"
@@ -81,18 +81,18 @@
                 </div>
                 <div class='col-4'>
                     <label for='password_expire_after_days' data-knobs-target="daysRangeLabel">
-                        <%=Settings.expire_after_days_default %> <%= _('Days') %>
+                        <%=Settings.pw.expire_after_days_default %> <%= _('Days') %>
                     </label>
                 </div>
             </div>
 
             <div class='row'>
                 <div class='col-8'>
-                    <%=range_field_tag("password_expire_after_views", Settings.expire_after_views_default,
+                    <%=range_field_tag("password_expire_after_views", Settings.pw.expire_after_views_default,
                                         { :name => "password[expire_after_views]",
                                             :class => "form-range",
-                                            :min => Settings.expire_after_views_min,
-                                            :max => Settings.expire_after_views_max,
+                                            :min => Settings.pw.expire_after_views_min,
+                                            :max => Settings.pw.expire_after_views_max,
                                             :step => "1",
                                             "data-action" => "change->knobs#updateViewsSlider input->knobs#updateViewsSlider",
                                             "data-knobs-target" => "viewsRange"
@@ -101,7 +101,7 @@
 
                 <div class='col-4'>
                     <label for='password_expire_after_views' data-knobs-target="viewsRangeLabel">
-                        <%= Settings.expire_after_views_default %> <%= _('Views') %>
+                        <%= Settings.pw.expire_after_views_default %> <%= _('Views') %>
                     </label>
                 </div>
             </div>
@@ -116,9 +116,9 @@
             <div class='row'>
                 <div class='col'>
                     <div class="list-group mx-0">
-                        <% if Settings.enable_retrieval_step %>
+                        <% if Settings.pw.enable_retrieval_step %>
                             <label class="list-group-item d-flex gap-2">
-                            <%= check_box_tag "password[retrieval_step]", nil, Settings.retrieval_step_default,
+                            <%= check_box_tag "password[retrieval_step]", nil, Settings.pw.retrieval_step_default,
                                             { class: 'form-check-input flex-shrink-0',
                                               "data-knobs-target" => "retrievalStepCheckbox" } %>
                             <span>
@@ -127,9 +127,9 @@
                             </span>
                             </label>
                         <% end %>
-                        <% if Settings.enable_deletable_pushes%>
+                        <% if Settings.pw.enable_deletable_pushes%>
                             <label class="list-group-item d-flex gap-2">
-                            <%= check_box_tag "password[deletable_by_viewer]", nil, Settings.deletable_pushes_default,
+                            <%= check_box_tag "password[deletable_by_viewer]", nil, Settings.pw.deletable_pushes_default,
                                             { class: 'form-check-input flex-shrink-0',
                                               "data-knobs-target" => "deletableByViewerCheckbox" } %>
                             <span>

--- a/app/views/urls/audit.html.erb
+++ b/app/views/urls/audit.html.erb
@@ -47,19 +47,6 @@
                 </label>
                 <label class="list-group-item d-flex gap-2">
                 <span>
-                    <%= _('Deletable by Viewers') %>:
-                    <strong>
-                        <% if @push.deletable_by_viewer %>
-                            <%= _('True') %>
-                        <% else %>
-                            <%= _('False') %>
-                        <% end %>
-                    </strong>
-                    <small class="d-block text-muted"><%= _('This allows end users to delete content once retrieved.') %></small>
-                </span>
-                </label>
-                <label class="list-group-item d-flex gap-2">
-                <span>
                     <%= _('1-click Retrieval Step') %>:
                     <strong>
                         <% if @push.retrieval_step %>

--- a/app/views/urls/new.html.erb
+++ b/app/views/urls/new.html.erb
@@ -4,14 +4,14 @@
     data-controller="knobs passwords form"
     data-knobs-lang-day-value=<%= _('Day') %>
     data-knobs-lang-days-value=<%= _('Days') %>
-    data-knobs-default-days-value=<%= Settings.expire_after_days_default %>
+    data-knobs-default-days-value=<%= Settings.url.expire_after_days_default %>
 
     data-knobs-lang-view-value=<%= _('View') %>
     data-knobs-lang-views-value=<%= _('Views') %>
-    data-knobs-default-views-value=<%= Settings.expire_after_views_default %>
+    data-knobs-default-views-value=<%= Settings.url.expire_after_views_default %>
 
-    data-knobs-default-retrieval-step-value=<%= Settings.retrieval_step_default %>
-    data-knobs-default-deletable-by-viewer-value=<%= Settings.deletable_pushes_default %>
+    data-knobs-default-retrieval-step-value=<%= Settings.url.retrieval_step_default %>
+    data-knobs-default-deletable-by-viewer-value=<%= Settings.url.deletable_pushes_default %>
 
     data-knobs-ga-enabled-value=<%= ENV.key?('GA_ENABLE') %>
 >
@@ -41,11 +41,11 @@
             <div class='row'>
                 <p><%= _('Expire secret link and delete after:') %></p>
                 <div class='col-8'>
-                    <%= range_field_tag("password_expire_after_days", Settings.expire_after_days_default,
+                    <%= range_field_tag("password_expire_after_days", Settings.url.expire_after_days_default,
                                         { :name => "url[expire_after_days]",
                                           :class => "form-range",
-                                          :min => Settings.expire_after_days_min,
-                                          :max => Settings.expire_after_days_max,
+                                          :min => Settings.url.expire_after_days_min,
+                                          :max => Settings.url.expire_after_days_max,
                                           :step => "1",
                                           "data-action" => "change->knobs#updateDaysSlider input->knobs#updateDaysSlider",
                                           "data-knobs-target" => "daysRange"
@@ -53,18 +53,18 @@
                 </div>
                 <div class='col-4'>
                     <label for='password_expire_after_days' data-knobs-target="daysRangeLabel">
-                        <%=Settings.expire_after_days_default %> <%= _('Days') %>
+                        <%=Settings.url.expire_after_days_default %> <%= _('Days') %>
                     </label>
                 </div>
             </div>
 
             <div class='row'>
                 <div class='col-8'>
-                    <%=range_field_tag("password_expire_after_views", Settings.expire_after_views_default,
+                    <%=range_field_tag("password_expire_after_views", Settings.url.expire_after_views_default,
                                        { :name => "url[expire_after_views]",
                                          :class => "form-range",
-                                         :min => Settings.expire_after_views_min,
-                                         :x_default => Settings.expire_after_views_default,
+                                         :min => Settings.url.expire_after_views_min,
+                                         :x_default => Settings.url.expire_after_views_default,
                                          :step => "1",
                                          "data-action" => "change->knobs#updateViewsSlider input->knobs#updateViewsSlider",
                                          "data-knobs-target" => "viewsRange"
@@ -73,7 +73,7 @@
 
                 <div class='col-4'>
                     <label for='password_expire_after_views' data-knobs-target="viewsRangeLabel">
-                        <%= Settings.expire_after_views_default %> <%= _('Views') %>
+                        <%= Settings.url.expire_after_views_default %> <%= _('Views') %>
                     </label>
                 </div>
             </div>
@@ -88,11 +88,11 @@
             <div class='row'>
                 <div class='col'>
                     <div class="list-group mx-0">
-                        <% if Settings.enable_retrieval_step %>
+                        <% if Settings.url.enable_retrieval_step %>
                             <label class="list-group-item d-flex gap-2">
-                            <%=check_box_tag "url[retrieval_step]", nil, Settings.retrieval_step_default,
+                            <%=check_box_tag "url[retrieval_step]", nil, Settings.url.retrieval_step_default,
                                             { class: 'form-check-input flex-shrink-0',
-                                            x_default: Settings.retrieval_step_default } %>
+                                            x_default: Settings.url.retrieval_step_default } %>
                             <span>
                                 <%= _('Use a 1-click retrieval step') %>
                                 <small class="d-block text-muted"><%= _('Helps to avoid chat systems and URL scanners from eating up redirects.') %></small>

--- a/app/views/urls/new.html.erb
+++ b/app/views/urls/new.html.erb
@@ -11,7 +11,6 @@
     data-knobs-default-views-value=<%= Settings.url.expire_after_views_default %>
 
     data-knobs-default-retrieval-step-value=<%= Settings.url.retrieval_step_default %>
-    data-knobs-default-deletable-by-viewer-value=<%= Settings.url.deletable_pushes_default %>
 
     data-knobs-ga-enabled-value=<%= ENV.key?('GA_ENABLE') %>
 >

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -7,80 +7,34 @@
 
 ### Application Defaults
 #
-# Expire After XX Days
-#
-# Controls the "Expire After Days" form settings in Password#new
-#
-# Environment variable overrides:
-# PWP__EXPIRE_AFTER_DAYS_DEFAULT=7
-# PWP__EXPIRE_AFTER_DAYS_MIN=1
-# PWP__EXPIRE_AFTER_DAYS_MAX=90
-#
-expire_after_days_default: 7
-expire_after_days_min: 1
-expire_after_days_max: 90
 
-# Expire After XX Views
+### URL Pushes
 #
-# Controls the "Expire After Views" form settings in Password#new
+# Enable or disable URL based pushes.  These allow you to share URLs securely.
+# Like regular pushes, they expire after a set time or amount of views.
 #
-# Environment variable overrides:
-# PWP__EXPIRE_AFTER_VIEWS_DEFAULT=5
-# PWP__EXPIRE_AFTER_VIEWS_MIN=1
-# PWP__EXPIRE_AFTER_VIEWS_MAX=100
-#
-expire_after_views_default: 5
-expire_after_views_min: 1
-expire_after_views_max: 100
-
-# Retrieval Step
-#
-# This enables or disables the "1-click retrieval step" feature entirely.  For the default value
-# when it is enabled here, see the next setting.
+# Note that `enable_logins` is required for URL based pushes to work.  It is a
+# feature for logged in users only.
 #
 # Environment variable override:
-# PWP__ENABLE_RETRIEVAL_STEP='false'
+# PWP__ENABLE_URL_PUSHES='false'
 #
-enable_retrieval_step: true
+enable_url_pushes: false
 
-# Default Form Value for the Retrieval Step
+### File Uploads
 #
-# When the retrieval step is enabled (above), what is the default value on the form?
+# File uploads are disabled by default since they require a place to store
+# those files.
 #
-# When true, secret URLs will be generated as /p/xxxxxxxx/r which will show a page
-# requiring a click to view the page /p/xxxxxxxx
+# If enabling file uploads, make sure to fill out the 'files' section below.
+#
+# Note that `enable_logins` is required for file uploads to work.  It is a
+# feature for logged in users only.
 #
 # Environment variable override:
-# PWP__RETRIEVAL_STEP_DEFAULT='true'
+# PWP__ENABLE_FILE_PUSHES='false'
 #
-retrieval_step_default: false
-
-# Deletable Pushes
-#
-# default: true
-#
-# This enables or disables the "Allow Immediate Deletion" feature entirely.  For the default value
-# when it is enabled here, see the next setting.
-#
-# Environment variable override:
-# PWP__ENABLE_DELETABLE_PUSHES='false'
-#
-enable_deletable_pushes: true
-
-# Deletable Pushes Default Value
-#
-# default: true
-#
-# When this is set to true, this option does two things:
-#   1. Sets the default check state for the "Allow viewers to
-#       optionally delete password before expiration" checkbox
-#   2. JSON API: Sets the default value for newly pushed passwords if
-#       unspecified
-#
-# Environment variable override:
-# PWP__DELETABLE_PUSHES_DEFAULT='false'
-#
-deletable_pushes_default: true
+enable_file_pushes: false
 
 ### Logins (User accounts)
 #
@@ -157,15 +111,265 @@ host_protocol: 'https'
 #
 # override_base_url: 'https://pwpush.mydomain.com'
 
+## Expiration Settings for Password Pushes
+#
+pw:
+  # Expire Password Pushes After XX Days
+  #
+  # Controls the "Expire After Days" for Password Pushes
+  #
+  # Environment variable overrides:
+  # PWP__PW__EXPIRE_AFTER_DAYS_DEFAULT=7
+  # PWP__PW__EXPIRE_AFTER_DAYS_MIN=1
+  # PWP__PW__EXPIRE_AFTER_DAYS_MAX=90
+  #
+  expire_after_days_default: 7
+  expire_after_days_min: 1
+  expire_after_days_max: 90
+
+  # Expire Password Pushes After XX Views
+  #
+  # Controls the "Expire After Views" form settings in Password#new
+  #
+  # Environment variable overrides:
+  # PWP__PW__EXPIRE_AFTER_VIEWS_DEFAULT=5
+  # PWP__PW__EXPIRE_AFTER_VIEWS_MIN=1
+  # PWP__PW__EXPIRE_AFTER_VIEWS_MAX=100
+  #
+  expire_after_views_default: 5
+  expire_after_views_min: 1
+  expire_after_views_max: 100
+
+  # Retrieval Step for Password Pushes
+  #
+  # This enables or disables the "1-click retrieval step" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__PW__ENABLE_RETRIEVAL_STEP='false'
+  #
+  enable_retrieval_step: true
+
+  # Default Form Value for the Retrieval Step
+  #
+  # When the retrieval step is enabled (above), what is the default value on the form?
+  #
+  # When true, secret URLs will be generated as /p/xxxxxxxx/r which will show a page
+  # requiring a click to view the page /p/xxxxxxxx
+  #
+  # Environment variable override:
+  # PWP__PW__RETRIEVAL_STEP_DEFAULT='true'
+  #
+  retrieval_step_default: false
+
+  # Deletable Password Pushes
+  #
+  # default: true
+  #
+  # This enables or disables the "Allow Immediate Deletion" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__PW__ENABLE_DELETABLE_PUSHES='false'
+  #
+  enable_deletable_pushes: true
+
+  # Deletable Pushes Default Value
+  #
+  # default: true
+  #
+  # When this is set to true, this option does two things:
+  #   1. Sets the default check state for the "Allow viewers to
+  #       optionally delete password before expiration" checkbox
+  #   2. JSON API: Sets the default value for newly pushed passwords if
+  #       unspecified
+  #
+  # Environment variable override:
+  # PWP__PW__DELETABLE_PUSHES_DEFAULT='false'
+  #
+  deletable_pushes_default: true
+
+## Expiration Settings for URL Pushes
+#
+url:
+  # Expire URL Pushes After XX Days
+  #
+  # Controls the "Expire After Days" for URL Pushes
+  #
+  # Environment variable overrides:
+  # PWP__URL__EXPIRE_AFTER_DAYS_DEFAULT=7
+  # PWP__URL__EXPIRE_AFTER_DAYS_MIN=1
+  # PWP__URL__EXPIRE_AFTER_DAYS_MAX=90
+  #
+  expire_after_days_default: 7
+  expire_after_days_min: 1
+  expire_after_days_max: 90
+
+  # Expire URL Pushes After XX Views
+  #
+  # Controls the "Expire After Views" form settings in Password#new
+  #
+  # Environment variable overrides:
+  # PWP__URL__EXPIRE_AFTER_VIEWS_DEFAULT=5
+  # PWP__URL__EXPIRE_AFTER_VIEWS_MIN=1
+  # PWP__URL__EXPIRE_AFTER_VIEWS_MAX=100
+  #
+  expire_after_views_default: 5
+  expire_after_views_min: 1
+  expire_after_views_max: 100
+
+  # Retrieval Step for URL Pushes
+  #
+  # This enables or disables the "1-click retrieval step" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__URL__ENABLE_RETRIEVAL_STEP='false'
+  #
+  enable_retrieval_step: true
+
+  # Default Form Value for the Retrieval Step
+  #
+  # When the retrieval step is enabled (above), what is the default value on the form?
+  #
+  # When true, secret URLs will be generated as /r/xxxxxxxx/r which will show a page
+  # requiring a click to view the page /r/xxxxxxxx
+  #
+  # Environment variable override:
+  # PWP__URL__RETRIEVAL_STEP_DEFAULT='true'
+  #
+  retrieval_step_default: false
+
+### File Upload: Expiration & Storage Settings
+#
+files:
+  # Expire File Pushes After XX Days
+  #
+  # Controls the "Expire After Days" for File Pushes
+  #
+  # Environment variable overrides:
+  # PWP__FILES__EXPIRE_AFTER_DAYS_DEFAULT=7
+  # PWP__FILES__EXPIRE_AFTER_DAYS_MIN=1
+  # PWP__FILES__EXPIRE_AFTER_DAYS_MAX=90
+  #
+  expire_after_days_default: 7
+  expire_after_days_min: 1
+  expire_after_days_max: 90
+
+  # Expire File Pushes After XX Views
+  #
+  # Controls the "Expire After Views" form settings for File Pushes
+  #
+  # Environment variable overrides:
+  # PWP__FILES__EXPIRE_AFTER_VIEWS_DEFAULT=5
+  # PWP__FILES__EXPIRE_AFTER_VIEWS_MIN=1
+  # PWP__FILES__EXPIRE_AFTER_VIEWS_MAX=100
+  #
+  expire_after_views_default: 5
+  expire_after_views_min: 1
+  expire_after_views_max: 100
+
+  # Retrieval Step for File Pushes
+  #
+  # This enables or disables the "1-click retrieval step" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__FILES__ENABLE_RETRIEVAL_STEP='false'
+  #
+  enable_retrieval_step: true
+
+  # Default Form Value for the Retrieval Step
+  #
+  # When the retrieval step is enabled (above), what is the default value on the form?
+  #
+  # When true, secret URLs will be generated as /f/xxxxxxxx/r which will show a page
+  # requiring a click to view the page /f/xxxxxxxx
+  #
+  # Environment variable override:
+  # PWP__FILES__RETRIEVAL_STEP_DEFAULT='true'
+  #
+  retrieval_step_default: false
+
+  # Deletable File Pushes
+  #
+  # default: true
+  #
+  # This enables or disables the "Allow Immediate Deletion" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__FILES__ENABLE_DELETABLE_PUSHES='false'
+  #
+  enable_deletable_pushes: true
+
+  # Deletable File Pushes Default Value
+  #
+  # default: true
+  #
+  # When this is set to true, this option does two things:
+  #   1. Sets the default check state for the "Allow viewers to
+  #       optionally delete password before expiration" checkbox
+  #   2. JSON API: Sets the default value for newly pushed passwords if
+  #       unspecified
+  #
+  # Environment variable override:
+  # PWP__FILES__DELETABLE_PUSHES_DEFAULT='false'
+  #
+  deletable_pushes_default: true
+
+  # File Storage
+  #
+  # Password Pusher can store uploaded files into Amazon S3, Google Cloud Services
+  # or Microsoft Azure.
+  #
+  # Choose your file storage preference by setting the following option to
+  # one of the following values:
+  #   * local     - use local disk (likely won't work in container environments)
+  #   * amazon    - use Amazon S3 (and provide 's3' credentials below)
+  #   * google    - use Google Cloud Storage (and provide 'gcs' credentials below)
+  #   * microsoft - use Microsoft Azure Storage (and provide 'as' credentials below)
+  #
+  # Environment variable override:
+  # PWP__FILES_STORAGE='local'
+  #
+  storage: 'local'
+
+  # Amazon S3 Storage Credentials
+  s3:
+    # Environment Variable Override: PWP__FILES__S3__ENDPOINT=''
+    endpoint: ''
+    # Environment Variable Override: PWP__FILES__S3__ACCESS_KEY_ID=''
+    access_key_id: '_'
+    # Environment Variable Override: PWP__FILES__S3__SECRET_ACCESS_KEY=''
+    secret_access_key: ''
+    # Environment Variable Override: PWP__FILES__S3__REGION=''
+    region: 'us-east-1'
+    # Environment Variable Override: PWP__FILES__S3__BUCKET=''
+    bucket: 'pwpush-files'
+
+  # Google Cloud Storage Credentials
+  gcs:
+    # Environment Variable Override: PWP__FILES__GCS__PROJECT=''
+    project: ''
+    # Environment Variable Override: PWP__FILES__GCS__CREDENTIALS=''
+    credentials: ''
+    # Environment Variable Override: PWP__FILES__GCS__BUCKET=''
+    bucket: ''
+
+  # Microsoft Azure Storage Credentials
+  as:
+    # Environment Variable Override: PWP__FILES__AS__STORAGE_ACCOUNT_NAME=''
+    storage_account_name: ''
+    # Environment Variable Override: PWP__FILES__AS__STORAGE_ACCESS_KEY=''
+    storage_access_key: ''
+    # Environment Variable Override: PWP__FILES__AS__CONTAINER=''
+    container: ''
+
+
 ### Password Generator Defaults
 #
 # Set the defaults of the front page password generator.
-#
-# !!! Use the environment variables to configure the password generator defaults.
-#
-# Issue: To configure these values, please set the respective environment variables.
-# Changing the values in this file will not make a difference.  This is due to a framework
-# issue that will be fixed at a future date.  Apologies for the inconvenience.
 #
 gen:
   # Whether generated passwords have numbers
@@ -421,86 +625,6 @@ feedback:
   #
   # Environment Variable Override: PWP__FEEDBACK__EMAIL='my@email.com'
   email: 'feedback@pwpush.com'
-
-### URL Pushes
-#
-# Enable or disable URL based pushes.  These allow you to share URLs securely.
-# Like regular pushes, they expire after a set time or amount of views.
-#
-# Note that `enable_logins` is required for URL based pushes to work.  It is a
-# feature for logged in users only.
-#
-# Environment variable override:
-# PWP__ENABLE_URL_PUSHES='false'
-#
-enable_url_pushes: false
-
-### File Uploads
-#
-# File uploads are disabled by default since they require a place to store
-# those files.
-#
-# If enabling file uploads, make sure to fill out the 'files' section below.
-#
-# Note that `enable_logins` is required for file uploads to work.  It is a
-# feature for logged in users only.
-#
-# Environment variable override:
-# PWP__ENABLE_FILE_PUSHES='false'
-#
-enable_file_pushes: false
-
-### File Upload: Storage Settings
-#
-files:
-  # File Storage
-  #
-  # Password Pusher can store uploaded files into Amazon S3, Google Cloud Services
-  # or Microsoft Azure.
-  #
-  # Choose your file storage preference by setting the following option to
-  # one of the following values:
-  #   * local     - use local disk (likely won't work in container environments)
-  #   * amazon    - use Amazon S3 (and provide 's3' credentials below)
-  #   * google    - use Google Cloud Storage (and provide 'gcs' credentials below)
-  #   * microsoft - use Microsoft Azure Storage (and provide 'as' credentials below)
-  #
-  # Environment variable override:
-  # PWP__FILES_STORAGE='local'
-  #
-  storage: 'local'
-
-  # Amazon S3 Storage Credentials
-  s3:
-    # Environment Variable Override: PWP__FILES__S3__ENDPOINT=''
-    endpoint: ''
-    # Environment Variable Override: PWP__FILES__S3__ACCESS_KEY_ID=''
-    access_key_id: '_'
-    # Environment Variable Override: PWP__FILES__S3__SECRET_ACCESS_KEY=''
-    secret_access_key: ''
-    # Environment Variable Override: PWP__FILES__S3__REGION=''
-    region: 'us-east-1'
-    # Environment Variable Override: PWP__FILES__S3__BUCKET=''
-    bucket: 'pwpush-files'
-
-  # Google Cloud Storage Credentials
-  gcs:
-    # Environment Variable Override: PWP__FILES__GCS__PROJECT=''
-    project: ''
-    # Environment Variable Override: PWP__FILES__GCS__CREDENTIALS=''
-    credentials: ''
-    # Environment Variable Override: PWP__FILES__GCS__BUCKET=''
-    bucket: ''
-
-  # Microsoft Azure Storage Credentials
-  as:
-    # Environment Variable Override: PWP__FILES__AS__STORAGE_ACCOUNT_NAME=''
-    storage_account_name: ''
-    # Environment Variable Override: PWP__FILES__AS__STORAGE_ACCESS_KEY=''
-    storage_access_key: ''
-    # Environment Variable Override: PWP__FILES__AS__CONTAINER=''
-    container: ''
-
 
 ### Language & Internationalization
 #

--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -2,12 +2,25 @@ def load_legacy_environment_variables
     # Check for Legacy Environment Variables (to be deprecated)
     deprecations_detected = false
 
+    legacy_options = [ :expire_after_days_default, :expire_after_days_min, :expire_after_days_max, :expire_after_views_default,
+                       :expire_after_views_min, :expire_after_views_max, :enable_retrieval_step, :retrieval_step_default,
+                       :enable_deletable_pushes, :deletable_pushes_default ]
+
+    for option in legacy_options do
+        if !Settings.send(option).nil?
+            Rails.logger.warn("The setting (#{option}) has been moved to the 'pw' section of the settings.yml file.\n" +
+                              "Please update your settings.yml file or if using environment variables, change the variable name 'PWP__#{option.to_s.upcase}' to 'PWP__PW__#{option.to_s.upcase}'.\n")
+            Settings.pw.__send__("#{option}=", Settings.send(option))                   
+            deprecations_detected = true
+        end
+    end
+
     # Legacy environment variable: EXPIRE_AFTER_DAYS_DEFAULT
     # Deprecated in October 2022
     if ENV.key?('EXPIRE_AFTER_DAYS_DEFAULT')
         Rails.logger.warn("The environment variable EXPIRE_AFTER_DAYS_DEFAULT has been deprecated and will be removed in a future version.\n" +
                           "Please change this environment variable to PWP__EXPIRE_AFTER_DAYS_DEFAULT or switch to a custom settings.yml entirely.")
-        Settings.expire_after_days_default = ENV['EXPIRE_AFTER_DAYS_DEFAULT'].to_i
+        Settings.pw.expire_after_days_default = ENV['EXPIRE_AFTER_DAYS_DEFAULT'].to_i
         deprecations_detected = true
     end
 
@@ -16,7 +29,7 @@ def load_legacy_environment_variables
     if ENV.key?('EXPIRE_AFTER_DAYS_MIN')
         Rails.logger.warn("The environment variable EXPIRE_AFTER_DAYS_MIN has been deprecated and will be removed in a future version.\n" +
                           "Please change this environment variable to PWP__EXPIRE_AFTER_DAYS_MIN or switch to a custom settings.yml entirely.")
-        Settings.expire_after_days_min = ENV['EXPIRE_AFTER_DAYS_MIN'].to_i
+        Settings.pw.expire_after_days_min = ENV['EXPIRE_AFTER_DAYS_MIN'].to_i
         deprecations_detected = true
     end
 
@@ -25,7 +38,7 @@ def load_legacy_environment_variables
     if ENV.key?('EXPIRE_AFTER_DAYS_MAX')
         Rails.logger.warn("The environment variable EXPIRE_AFTER_DAYS_MAX has been deprecated and will be removed in a future version.\n" +
                           "Please change this environment variable to PWP__EXPIRE_AFTER_DAYS_MAX or switch to a custom settings.yml entirely.")
-        Settings.expire_after_days_max = ENV['EXPIRE_AFTER_DAYS_MAX'].to_i
+        Settings.pw.expire_after_days_max = ENV['EXPIRE_AFTER_DAYS_MAX'].to_i
         deprecations_detected = true
     end
 
@@ -34,7 +47,7 @@ def load_legacy_environment_variables
     if ENV.key?('EXPIRE_AFTER_VIEWS_DEFAULT')
         Rails.logger.warn("The environment variable EXPIRE_AFTER_VIEWS_DEFAULT has been deprecated and will be removed in a future version.\n" +
                           "Please change this environment variable to PWP__EXPIRE_AFTER_VIEWS_DEFAULT or switch to a custom settings.yml entirely.")
-        Settings.expire_after_views_default = ENV['EXPIRE_AFTER_VIEWS_DEFAULT'].to_i
+        Settings.pw.expire_after_views_default = ENV['EXPIRE_AFTER_VIEWS_DEFAULT'].to_i
         deprecations_detected = true
     end
 
@@ -43,7 +56,7 @@ def load_legacy_environment_variables
     if ENV.key?('EXPIRE_AFTER_VIEWS_MIN')
         Rails.logger.warn("The environment variable EXPIRE_AFTER_VIEWS_MIN has been deprecated and will be removed in a future version.\n" +
                           "Please change this environment variable to PWP__EXPIRE_AFTER_VIEWS_MIN or switch to a custom settings.yml entirely.")
-        Settings.expire_after_views_min = ENV['EXPIRE_AFTER_VIEWS_MIN'].to_i
+        Settings.pw.expire_after_views_min = ENV['EXPIRE_AFTER_VIEWS_MIN'].to_i
         deprecations_detected = true
     end
 
@@ -52,7 +65,7 @@ def load_legacy_environment_variables
     if ENV.key?('EXPIRE_AFTER_VIEWS_MAX')
         Rails.logger.warn("The environment variable EXPIRE_AFTER_VIEWS_MAX has been deprecated and will be removed in a future version.\n" +
                           "Please change this environment variable to PWP__EXPIRE_AFTER_VIEWS_MAX or switch to a custom settings.yml entirely.")
-        Settings.expire_after_views_max = ENV['EXPIRE_AFTER_VIEWS_MAX'].to_i
+        Settings.pw.expire_after_views_max = ENV['EXPIRE_AFTER_VIEWS_MAX'].to_i
         deprecations_detected = true
     end
 
@@ -61,7 +74,7 @@ def load_legacy_environment_variables
     if ENV.key?('RETRIEVAL_STEP_ENABLED')
         Rails.logger.warn("The environment variable RETRIEVAL_STEP_ENABLED has been deprecated and will be removed in a future version.\n" +
                           "Please change this environment variable to PWP__ENABLE_RETRIEVAL_STEP or switch to a custom settings.yml entirely.")
-        Settings.enable_retrieval_step = ENV['RETRIEVAL_STEP_ENABLED'].downcase == 'true'
+        Settings.pw.enable_retrieval_step = ENV['RETRIEVAL_STEP_ENABLED'].downcase == 'true'
         deprecations_detected = true
     end
 
@@ -70,7 +83,7 @@ def load_legacy_environment_variables
     if ENV.key?('RETRIEVAL_STEP_DEFAULT')
         Rails.logger.warn("The environment variable RETRIEVAL_STEP_DEFAULT has been deprecated and will be removed in a future version.\n" +
                           "Please change this environment variable to PWP__RETRIEVAL_STEP_DEFAULT or switch to a custom settings.yml entirely.")
-        Settings.retrieval_step_default = ENV['RETRIEVAL_STEP_DEFAULT'].downcase == 'true'
+        Settings.pw.retrieval_step_default = ENV['RETRIEVAL_STEP_DEFAULT'].downcase == 'true'
         deprecations_detected = true
     end
 
@@ -79,7 +92,7 @@ def load_legacy_environment_variables
     if ENV.key?('DELETABLE_PASSWORDS_ENABLED')
         Rails.logger.warn("The environment variable DELETABLE_PASSWORDS_ENABLED has been deprecated and will be removed in a future version.\n" +
                           "Please change this environment variable to PWP__ENABLE_DELETABLE_PUSHES or switch to a custom settings.yml entirely.")
-        Settings.enable_deletable_pushes = ENV['DELETABLE_PASSWORDS_ENABLED'].downcase == 'true'
+        Settings.pw.enable_deletable_pushes = ENV['DELETABLE_PASSWORDS_ENABLED'].downcase == 'true'
         deprecations_detected = true
     end
 
@@ -88,7 +101,7 @@ def load_legacy_environment_variables
     if ENV.key?('DELETABLE_BY_VIEWER_PASSWORDS')
         Rails.logger.warn("The environment variable DELETABLE_BY_VIEWER_PASSWORDS has been deprecated and will be removed in a future version.\n" +
                           "Please change this environment variable to PWP__ENABLE_DELETABLE_PUSHES or switch to a custom settings.yml entirely.")
-        Settings.enable_deletable_pushes = ENV['DELETABLE_BY_VIEWER_PASSWORDS'].downcase == 'true'
+        Settings.pw.enable_deletable_pushes = ENV['DELETABLE_BY_VIEWER_PASSWORDS'].downcase == 'true'
         deprecations_detected = true
     end
 
@@ -97,7 +110,7 @@ def load_legacy_environment_variables
     if ENV.key?('DELETABLE_BY_VIEWER_DEFAULT')
         Rails.logger.warn("The environment variable DELETABLE_BY_VIEWER_DEFAULT has been deprecated and will be removed in a future version.\n" +
                           "Please change this environment variable to PWP__DELETABLE_PUSHES_DEFAULT or switch to a custom settings.yml entirely.")
-        Settings.deletable_pushes_default = ENV['DELETABLE_BY_VIEWER_DEFAULT'].downcase == 'true'
+        Settings.pw.deletable_pushes_default = ENV['DELETABLE_BY_VIEWER_DEFAULT'].downcase == 'true'
         deprecations_detected = true
     end
 
@@ -106,7 +119,7 @@ def load_legacy_environment_variables
     if ENV.key?('DELETABLE_PASSWORDS_DEFAULT')
         Rails.logger.warn("The environment variable DELETABLE_PASSWORDS_DEFAULT has been deprecated and will be removed in a future version.\n" +
                           "Please change this environment variable to PWP__DELETABLE_PUSHES_DEFAULT or switch to a custom settings.yml entirely.")
-        Settings.deletable_pushes_default = ENV['DELETABLE_PASSWORDS_DEFAULT'].downcase == 'true'
+        Settings.pw.deletable_pushes_default = ENV['DELETABLE_PASSWORDS_DEFAULT'].downcase == 'true'
         deprecations_detected = true
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,80 +7,34 @@
 
 ### Application Defaults
 #
-# Expire After XX Days
-#
-# Controls the "Expire After Days" form settings in Password#new
-#
-# Environment variable overrides:
-# PWP__EXPIRE_AFTER_DAYS_DEFAULT=7
-# PWP__EXPIRE_AFTER_DAYS_MIN=1
-# PWP__EXPIRE_AFTER_DAYS_MAX=90
-#
-expire_after_days_default: 7
-expire_after_days_min: 1
-expire_after_days_max: 90
 
-# Expire After XX Views
+### URL Pushes
 #
-# Controls the "Expire After Views" form settings in Password#new
+# Enable or disable URL based pushes.  These allow you to share URLs securely.
+# Like regular pushes, they expire after a set time or amount of views.
 #
-# Environment variable overrides:
-# PWP__EXPIRE_AFTER_VIEWS_DEFAULT=5
-# PWP__EXPIRE_AFTER_VIEWS_MIN=1
-# PWP__EXPIRE_AFTER_VIEWS_MAX=100
-#
-expire_after_views_default: 5
-expire_after_views_min: 1
-expire_after_views_max: 100
-
-# Retrieval Step
-#
-# This enables or disables the "1-click retrieval step" feature entirely.  For the default value
-# when it is enabled here, see the next setting.
+# Note that `enable_logins` is required for URL based pushes to work.  It is a
+# feature for logged in users only.
 #
 # Environment variable override:
-# PWP__ENABLE_RETRIEVAL_STEP='false'
+# PWP__ENABLE_URL_PUSHES='false'
 #
-enable_retrieval_step: true
+enable_url_pushes: false
 
-# Default Form Value for the Retrieval Step
+### File Uploads
 #
-# When the retrieval step is enabled (above), what is the default value on the form?
+# File uploads are disabled by default since they require a place to store
+# those files.
 #
-# When true, secret URLs will be generated as /p/xxxxxxxx/r which will show a page
-# requiring a click to view the page /p/xxxxxxxx
+# If enabling file uploads, make sure to fill out the 'files' section below.
+#
+# Note that `enable_logins` is required for file uploads to work.  It is a
+# feature for logged in users only.
 #
 # Environment variable override:
-# PWP__RETRIEVAL_STEP_DEFAULT='true'
+# PWP__ENABLE_FILE_PUSHES='false'
 #
-retrieval_step_default: false
-
-# Deletable Pushes
-#
-# default: true
-#
-# This enables or disables the "Allow Immediate Deletion" feature entirely.  For the default value
-# when it is enabled here, see the next setting.
-#
-# Environment variable override:
-# PWP__ENABLE_DELETABLE_PUSHES='false'
-#
-enable_deletable_pushes: true
-
-# Deletable Pushes Default Value
-#
-# default: true
-#
-# When this is set to true, this option does two things:
-#   1. Sets the default check state for the "Allow viewers to
-#       optionally delete password before expiration" checkbox
-#   2. JSON API: Sets the default value for newly pushed passwords if
-#       unspecified
-#
-# Environment variable override:
-# PWP__DELETABLE_PUSHES_DEFAULT='false'
-#
-deletable_pushes_default: true
+enable_file_pushes: false
 
 ### Logins (User accounts)
 #
@@ -157,15 +111,265 @@ host_protocol: 'https'
 #
 # override_base_url: 'https://pwpush.mydomain.com'
 
+## Expiration Settings for Password Pushes
+#
+pw:
+  # Expire Password Pushes After XX Days
+  #
+  # Controls the "Expire After Days" for Password Pushes
+  #
+  # Environment variable overrides:
+  # PWP__PW__EXPIRE_AFTER_DAYS_DEFAULT=7
+  # PWP__PW__EXPIRE_AFTER_DAYS_MIN=1
+  # PWP__PW__EXPIRE_AFTER_DAYS_MAX=90
+  #
+  expire_after_days_default: 7
+  expire_after_days_min: 1
+  expire_after_days_max: 90
+
+  # Expire Password Pushes After XX Views
+  #
+  # Controls the "Expire After Views" form settings in Password#new
+  #
+  # Environment variable overrides:
+  # PWP__PW__EXPIRE_AFTER_VIEWS_DEFAULT=5
+  # PWP__PW__EXPIRE_AFTER_VIEWS_MIN=1
+  # PWP__PW__EXPIRE_AFTER_VIEWS_MAX=100
+  #
+  expire_after_views_default: 5
+  expire_after_views_min: 1
+  expire_after_views_max: 100
+
+  # Retrieval Step for Password Pushes
+  #
+  # This enables or disables the "1-click retrieval step" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__PW__ENABLE_RETRIEVAL_STEP='false'
+  #
+  enable_retrieval_step: true
+
+  # Default Form Value for the Retrieval Step
+  #
+  # When the retrieval step is enabled (above), what is the default value on the form?
+  #
+  # When true, secret URLs will be generated as /p/xxxxxxxx/r which will show a page
+  # requiring a click to view the page /p/xxxxxxxx
+  #
+  # Environment variable override:
+  # PWP__PW__RETRIEVAL_STEP_DEFAULT='true'
+  #
+  retrieval_step_default: false
+
+  # Deletable Password Pushes
+  #
+  # default: true
+  #
+  # This enables or disables the "Allow Immediate Deletion" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__PW__ENABLE_DELETABLE_PUSHES='false'
+  #
+  enable_deletable_pushes: true
+
+  # Deletable Pushes Default Value
+  #
+  # default: true
+  #
+  # When this is set to true, this option does two things:
+  #   1. Sets the default check state for the "Allow viewers to
+  #       optionally delete password before expiration" checkbox
+  #   2. JSON API: Sets the default value for newly pushed passwords if
+  #       unspecified
+  #
+  # Environment variable override:
+  # PWP__PW__DELETABLE_PUSHES_DEFAULT='false'
+  #
+  deletable_pushes_default: true
+
+## Expiration Settings for URL Pushes
+#
+url:
+  # Expire URL Pushes After XX Days
+  #
+  # Controls the "Expire After Days" for URL Pushes
+  #
+  # Environment variable overrides:
+  # PWP__URL__EXPIRE_AFTER_DAYS_DEFAULT=7
+  # PWP__URL__EXPIRE_AFTER_DAYS_MIN=1
+  # PWP__URL__EXPIRE_AFTER_DAYS_MAX=90
+  #
+  expire_after_days_default: 7
+  expire_after_days_min: 1
+  expire_after_days_max: 90
+
+  # Expire URL Pushes After XX Views
+  #
+  # Controls the "Expire After Views" form settings in Password#new
+  #
+  # Environment variable overrides:
+  # PWP__URL__EXPIRE_AFTER_VIEWS_DEFAULT=5
+  # PWP__URL__EXPIRE_AFTER_VIEWS_MIN=1
+  # PWP__URL__EXPIRE_AFTER_VIEWS_MAX=100
+  #
+  expire_after_views_default: 5
+  expire_after_views_min: 1
+  expire_after_views_max: 100
+
+  # Retrieval Step for URL Pushes
+  #
+  # This enables or disables the "1-click retrieval step" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__URL__ENABLE_RETRIEVAL_STEP='false'
+  #
+  enable_retrieval_step: true
+
+  # Default Form Value for the Retrieval Step
+  #
+  # When the retrieval step is enabled (above), what is the default value on the form?
+  #
+  # When true, secret URLs will be generated as /r/xxxxxxxx/r which will show a page
+  # requiring a click to view the page /r/xxxxxxxx
+  #
+  # Environment variable override:
+  # PWP__URL__RETRIEVAL_STEP_DEFAULT='true'
+  #
+  retrieval_step_default: false
+
+### File Upload: Expiration & Storage Settings
+#
+files:
+  # Expire File Pushes After XX Days
+  #
+  # Controls the "Expire After Days" for File Pushes
+  #
+  # Environment variable overrides:
+  # PWP__FILES__EXPIRE_AFTER_DAYS_DEFAULT=7
+  # PWP__FILES__EXPIRE_AFTER_DAYS_MIN=1
+  # PWP__FILES__EXPIRE_AFTER_DAYS_MAX=90
+  #
+  expire_after_days_default: 7
+  expire_after_days_min: 1
+  expire_after_days_max: 90
+
+  # Expire File Pushes After XX Views
+  #
+  # Controls the "Expire After Views" form settings for File Pushes
+  #
+  # Environment variable overrides:
+  # PWP__FILES__EXPIRE_AFTER_VIEWS_DEFAULT=5
+  # PWP__FILES__EXPIRE_AFTER_VIEWS_MIN=1
+  # PWP__FILES__EXPIRE_AFTER_VIEWS_MAX=100
+  #
+  expire_after_views_default: 5
+  expire_after_views_min: 1
+  expire_after_views_max: 100
+
+  # Retrieval Step for File Pushes
+  #
+  # This enables or disables the "1-click retrieval step" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__FILES__ENABLE_RETRIEVAL_STEP='false'
+  #
+  enable_retrieval_step: true
+
+  # Default Form Value for the Retrieval Step
+  #
+  # When the retrieval step is enabled (above), what is the default value on the form?
+  #
+  # When true, secret URLs will be generated as /f/xxxxxxxx/r which will show a page
+  # requiring a click to view the page /f/xxxxxxxx
+  #
+  # Environment variable override:
+  # PWP__FILES__RETRIEVAL_STEP_DEFAULT='true'
+  #
+  retrieval_step_default: false
+
+  # Deletable File Pushes
+  #
+  # default: true
+  #
+  # This enables or disables the "Allow Immediate Deletion" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__FILES__ENABLE_DELETABLE_PUSHES='false'
+  #
+  enable_deletable_pushes: true
+
+  # Deletable File Pushes Default Value
+  #
+  # default: true
+  #
+  # When this is set to true, this option does two things:
+  #   1. Sets the default check state for the "Allow viewers to
+  #       optionally delete password before expiration" checkbox
+  #   2. JSON API: Sets the default value for newly pushed passwords if
+  #       unspecified
+  #
+  # Environment variable override:
+  # PWP__FILES__DELETABLE_PUSHES_DEFAULT='false'
+  #
+  deletable_pushes_default: true
+
+  # File Storage
+  #
+  # Password Pusher can store uploaded files into Amazon S3, Google Cloud Services
+  # or Microsoft Azure.
+  #
+  # Choose your file storage preference by setting the following option to
+  # one of the following values:
+  #   * local     - use local disk (likely won't work in container environments)
+  #   * amazon    - use Amazon S3 (and provide 's3' credentials below)
+  #   * google    - use Google Cloud Storage (and provide 'gcs' credentials below)
+  #   * microsoft - use Microsoft Azure Storage (and provide 'as' credentials below)
+  #
+  # Environment variable override:
+  # PWP__FILES_STORAGE='local'
+  #
+  storage: 'local'
+
+  # Amazon S3 Storage Credentials
+  s3:
+    # Environment Variable Override: PWP__FILES__S3__ENDPOINT=''
+    endpoint: ''
+    # Environment Variable Override: PWP__FILES__S3__ACCESS_KEY_ID=''
+    access_key_id: '_'
+    # Environment Variable Override: PWP__FILES__S3__SECRET_ACCESS_KEY=''
+    secret_access_key: ''
+    # Environment Variable Override: PWP__FILES__S3__REGION=''
+    region: 'us-east-1'
+    # Environment Variable Override: PWP__FILES__S3__BUCKET=''
+    bucket: 'pwpush-files'
+
+  # Google Cloud Storage Credentials
+  gcs:
+    # Environment Variable Override: PWP__FILES__GCS__PROJECT=''
+    project: ''
+    # Environment Variable Override: PWP__FILES__GCS__CREDENTIALS=''
+    credentials: ''
+    # Environment Variable Override: PWP__FILES__GCS__BUCKET=''
+    bucket: ''
+
+  # Microsoft Azure Storage Credentials
+  as:
+    # Environment Variable Override: PWP__FILES__AS__STORAGE_ACCOUNT_NAME=''
+    storage_account_name: ''
+    # Environment Variable Override: PWP__FILES__AS__STORAGE_ACCESS_KEY=''
+    storage_access_key: ''
+    # Environment Variable Override: PWP__FILES__AS__CONTAINER=''
+    container: ''
+
+
 ### Password Generator Defaults
 #
 # Set the defaults of the front page password generator.
-#
-# !!! Use the environment variables to configure the password generator defaults.
-#
-# Issue: To configure these values, please set the respective environment variables.
-# Changing the values in this file will not make a difference.  This is due to a framework
-# issue that will be fixed at a future date.  Apologies for the inconvenience.
 #
 gen:
   # Whether generated passwords have numbers
@@ -421,86 +625,6 @@ feedback:
   #
   # Environment Variable Override: PWP__FEEDBACK__EMAIL='my@email.com'
   email: 'feedback@pwpush.com'
-
-### URL Pushes
-#
-# Enable or disable URL based pushes.  These allow you to share URLs securely.
-# Like regular pushes, they expire after a set time or amount of views.
-#
-# Note that `enable_logins` is required for URL based pushes to work.  It is a
-# feature for logged in users only.
-#
-# Environment variable override:
-# PWP__ENABLE_URL_PUSHES='false'
-#
-enable_url_pushes: false
-
-### File Uploads
-#
-# File uploads are disabled by default since they require a place to store
-# those files.
-#
-# If enabling file uploads, make sure to fill out the 'files' section below.
-#
-# Note that `enable_logins` is required for file uploads to work.  It is a
-# feature for logged in users only.
-#
-# Environment variable override:
-# PWP__ENABLE_FILE_PUSHES='false'
-#
-enable_file_pushes: false
-
-### File Upload: Storage Settings
-#
-files:
-  # File Storage
-  #
-  # Password Pusher can store uploaded files into Amazon S3, Google Cloud Services
-  # or Microsoft Azure.
-  #
-  # Choose your file storage preference by setting the following option to
-  # one of the following values:
-  #   * local     - use local disk (likely won't work in container environments)
-  #   * amazon    - use Amazon S3 (and provide 's3' credentials below)
-  #   * google    - use Google Cloud Storage (and provide 'gcs' credentials below)
-  #   * microsoft - use Microsoft Azure Storage (and provide 'as' credentials below)
-  #
-  # Environment variable override:
-  # PWP__FILES_STORAGE='local'
-  #
-  storage: 'local'
-
-  # Amazon S3 Storage Credentials
-  s3:
-    # Environment Variable Override: PWP__FILES__S3__ENDPOINT=''
-    endpoint: ''
-    # Environment Variable Override: PWP__FILES__S3__ACCESS_KEY_ID=''
-    access_key_id: '_'
-    # Environment Variable Override: PWP__FILES__S3__SECRET_ACCESS_KEY=''
-    secret_access_key: ''
-    # Environment Variable Override: PWP__FILES__S3__REGION=''
-    region: 'us-east-1'
-    # Environment Variable Override: PWP__FILES__S3__BUCKET=''
-    bucket: 'pwpush-files'
-
-  # Google Cloud Storage Credentials
-  gcs:
-    # Environment Variable Override: PWP__FILES__GCS__PROJECT=''
-    project: ''
-    # Environment Variable Override: PWP__FILES__GCS__CREDENTIALS=''
-    credentials: ''
-    # Environment Variable Override: PWP__FILES__GCS__BUCKET=''
-    bucket: ''
-
-  # Microsoft Azure Storage Credentials
-  as:
-    # Environment Variable Override: PWP__FILES__AS__STORAGE_ACCOUNT_NAME=''
-    storage_account_name: ''
-    # Environment Variable Override: PWP__FILES__AS__STORAGE_ACCESS_KEY=''
-    storage_access_key: ''
-    # Environment Variable Override: PWP__FILES__AS__CONTAINER=''
-    container: ''
-
 
 ### Language & Internationalization
 #

--- a/db/migrate/20230113173429_remove_deletable_from_urls.rb
+++ b/db/migrate/20230113173429_remove_deletable_from_urls.rb
@@ -1,0 +1,5 @@
+class RemoveDeletableFromUrls < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :urls, :deletable_by_viewer, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_28_161228) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_13_173429) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -83,7 +83,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_28_161228) do
     t.string "url_token"
     t.integer "user_id"
     t.boolean "deleted", default: false
-    t.boolean "deletable_by_viewer", default: true
     t.boolean "retrieval_step", default: false
     t.datetime "expired_on"
     t.text "payload_ciphertext", limit: 2097152

--- a/test/integration/file_push/file_push_creation_test.rb
+++ b/test/integration/file_push/file_push_creation_test.rb
@@ -122,7 +122,7 @@ class PasswordCreationTest < ActionDispatch::IntegrationTest
     deletable_checkbox = css_select '#password_deletable_by_viewer'
     assert(deletable_checkbox)
 
-    found = Settings.enable_deletable_pushes
+    found = Settings.files.enable_deletable_pushes
     deletable_checkbox.each do |item|
       if item.content.include?('Allow viewers to optionally delete password before expiration')
         found = true
@@ -135,7 +135,7 @@ class PasswordCreationTest < ActionDispatch::IntegrationTest
     assert(deletable_checkbox.length == 1)
 
     # DELETABLE_PASSWORDS_DEFAULT determines initial check state
-    if Settings.deletable_pushes_default == true
+    if Settings.files.deletable_pushes_default == true
       assert(deletable_checkbox.first.attributes['checked'].value == 'checked')
     else
       assert(deletable_checkbox.first.attributes['checked'].nil?)

--- a/test/integration/file_push/file_push_deletion_test.rb
+++ b/test/integration/file_push/file_push_deletion_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class PasswordCreationTest < ActionDispatch::IntegrationTest
   def test_password_deletion
     sign_out :user
-    assert Settings.enable_deletable_pushes == true
+    assert Settings.files.enable_deletable_pushes == true
 
     get '/'
     assert_response :success

--- a/test/integration/file_push/file_push_json_creation_test.rb
+++ b/test/integration/file_push/file_push_json_creation_test.rb
@@ -13,17 +13,17 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?('deleted')
     assert_equal false, res['deleted']
     assert res.key?('deletable_by_viewer')
-    assert_equal Settings.deletable_pushes_default, res['deletable_by_viewer']
+    assert_equal Settings.files.deletable_pushes_default, res['deletable_by_viewer']
     assert res.key?('days_remaining')
-    assert_equal Settings.expire_after_days_default, res['days_remaining']
+    assert_equal Settings.files.expire_after_days_default, res['days_remaining']
     assert res.key?('views_remaining')
-    assert_equal Settings.expire_after_views_default, res['views_remaining']
+    assert_equal Settings.files.expire_after_views_default, res['views_remaining']
 
     # These should be default values since we didn't specify them in the params
     assert res.key?('expire_after_days')
-    assert_equal Settings.expire_after_days_default, res['expire_after_days']
+    assert_equal Settings.files.expire_after_days_default, res['expire_after_days']
     assert res.key?('expire_after_views')
-    assert_equal Settings.expire_after_views_default, res['expire_after_views']
+    assert_equal Settings.files.expire_after_views_default, res['expire_after_views']
   end
 
   def test_json_creation_with_uncommon_characters
@@ -38,17 +38,17 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?('deleted')
     assert_equal false, res['deleted']
     assert res.key?('deletable_by_viewer')
-    assert_equal Settings.deletable_pushes_default, res['deletable_by_viewer']
+    assert_equal Settings.files.deletable_pushes_default, res['deletable_by_viewer']
     assert res.key?('days_remaining')
-    assert_equal Settings.expire_after_days_default, res['days_remaining']
+    assert_equal Settings.files.expire_after_days_default, res['days_remaining']
     assert res.key?('views_remaining')
-    assert_equal Settings.expire_after_views_default, res['views_remaining']
+    assert_equal Settings.files.expire_after_views_default, res['views_remaining']
 
     # These should be default values since we didn't specify them in the params
     assert res.key?('expire_after_days')
-    assert_equal Settings.expire_after_days_default, res['expire_after_days']
+    assert_equal Settings.files.expire_after_days_default, res['expire_after_days']
     assert res.key?('expire_after_views')
-    assert_equal Settings.expire_after_views_default, res['expire_after_views']
+    assert_equal Settings.files.expire_after_views_default, res['expire_after_views']
 
     # Validate payload
     get "/p/#{res["url_token"]}.json"
@@ -83,7 +83,7 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
 
     res = JSON.parse(@response.body)
     assert res.key?('deletable_by_viewer')
-    assert_equal Settings.enable_deletable_pushes, res['deletable_by_viewer']
+    assert_equal Settings.files.enable_deletable_pushes, res['deletable_by_viewer']
   end
 
   def test_custom_days_expiration

--- a/test/integration/file_push/file_push_json_deletion_test.rb
+++ b/test/integration/file_push/file_push_json_deletion_test.rb
@@ -14,11 +14,11 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?("deleted")
     assert_equal false, res["deleted"]
     assert res.key?("deletable_by_viewer")
-    assert_equal Settings.deletable_pushes_default, res["deletable_by_viewer"]
+    assert_equal Settings.files.deletable_pushes_default, res["deletable_by_viewer"]
     assert res.key?("days_remaining")
-    assert_equal Settings.expire_after_days_default, res["days_remaining"]
+    assert_equal Settings.files.expire_after_days_default, res["days_remaining"]
     assert res.key?("views_remaining")
-    assert_equal Settings.expire_after_views_default, res["views_remaining"]
+    assert_equal Settings.files.expire_after_views_default, res["views_remaining"]
 
     # Delete the new password via json e.g. /p/<url_token>.json
     delete "/p/" + res["url_token"] + ".json"
@@ -32,11 +32,11 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?("deleted")
     assert_equal true, res["deleted"]
     assert res.key?("deletable_by_viewer")
-    assert_equal Settings.deletable_pushes_default, res["deletable_by_viewer"]
+    assert_equal Settings.files.deletable_pushes_default, res["deletable_by_viewer"]
     assert res.key?("days_remaining")
-    assert_equal Settings.expire_after_days_default, res["days_remaining"]
+    assert_equal Settings.files.expire_after_days_default, res["days_remaining"]
     assert res.key?("views_remaining")
-    assert_equal Settings.expire_after_views_default, res["views_remaining"]
+    assert_equal Settings.files.expire_after_views_default, res["views_remaining"]
 
     # Now try to retrieve the password again
     get "/p/" + res["url_token"] + ".json"
@@ -51,10 +51,10 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?("deleted")
     assert_equal true, res["deleted"]
     assert res.key?("deletable_by_viewer")
-    assert_equal Settings.deletable_pushes_default, res["deletable_by_viewer"]
+    assert_equal Settings.files.deletable_pushes_default, res["deletable_by_viewer"]
     assert res.key?("days_remaining")
-    assert_equal Settings.expire_after_days_default, res["days_remaining"]
+    assert_equal Settings.files.expire_after_days_default, res["days_remaining"]
     assert res.key?("views_remaining")
-    assert_equal Settings.expire_after_views_default-1, res["views_remaining"]
+    assert_equal Settings.files.expire_after_views_default-1, res["views_remaining"]
   end
 end

--- a/test/integration/file_push/file_push_json_retrieval_test.rb
+++ b/test/integration/file_push/file_push_json_retrieval_test.rb
@@ -14,7 +14,7 @@ class PasswordJsonRetrievalTest < ActionDispatch::IntegrationTest
     assert res.key?("deleted")
     assert_equal false, res["deleted"]
     assert res.key?("deletable_by_viewer")
-    assert_equal Settings.deletable_pushes_default, res["deletable_by_viewer"]
+    assert_equal Settings.files.deletable_pushes_default, res["deletable_by_viewer"]
     assert res.key?("days_remaining")
     assert_equal 2, res["views_remaining"]
     assert res.key?("expire_after_days")

--- a/test/integration/password/password_creation_test.rb
+++ b/test/integration/password/password_creation_test.rb
@@ -115,7 +115,7 @@ class PasswordCreationTest < ActionDispatch::IntegrationTest
     deletable_checkbox = css_select '#password_deletable_by_viewer'
     assert(deletable_checkbox)
 
-    found = Settings.enable_deletable_pushes
+    found = Settings.pw.enable_deletable_pushes
     deletable_checkbox.each do |item|
       if item.content.include?('Allow viewers to optionally delete password before expiration')
         found = true
@@ -128,7 +128,7 @@ class PasswordCreationTest < ActionDispatch::IntegrationTest
     assert(deletable_checkbox.length == 1)
 
     # DELETABLE_PASSWORDS_DEFAULT determines initial check state
-    if Settings.deletable_pushes_default == true
+    if Settings.pw.deletable_pushes_default == true
       assert(deletable_checkbox.first.attributes['checked'].value == 'checked')
     else
       assert(deletable_checkbox.first.attributes['checked'].nil?)

--- a/test/integration/password/password_deletion_test.rb
+++ b/test/integration/password/password_deletion_test.rb
@@ -4,7 +4,7 @@ class PasswordCreationTest < ActionDispatch::IntegrationTest
   def test_anonymous_password_deletion
     sign_out :user
 
-    assert Settings.enable_deletable_pushes == true
+    assert Settings.pw.enable_deletable_pushes == true
     # create
     post passwords_path, params: { password: { payload: 'testpw', deletable_by_viewer: 'on' } }
     assert_response :redirect

--- a/test/integration/password/password_json_creation_test.rb
+++ b/test/integration/password/password_json_creation_test.rb
@@ -13,17 +13,17 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?('deleted')
     assert_equal false, res['deleted']
     assert res.key?('deletable_by_viewer')
-    assert_equal Settings.deletable_pushes_default, res['deletable_by_viewer']
+    assert_equal Settings.pw.deletable_pushes_default, res['deletable_by_viewer']
     assert res.key?('days_remaining')
-    assert_equal Settings.expire_after_days_default, res['days_remaining']
+    assert_equal Settings.pw.expire_after_days_default, res['days_remaining']
     assert res.key?('views_remaining')
-    assert_equal Settings.expire_after_views_default, res['views_remaining']
+    assert_equal Settings.pw.expire_after_views_default, res['views_remaining']
 
     # These should be default values since we didn't specify them in the params
     assert res.key?('expire_after_days')
-    assert_equal Settings.expire_after_days_default, res['expire_after_days']
+    assert_equal Settings.pw.expire_after_days_default, res['expire_after_days']
     assert res.key?('expire_after_views')
-    assert_equal Settings.expire_after_views_default, res['expire_after_views']
+    assert_equal Settings.pw.expire_after_views_default, res['expire_after_views']
   end
 
   def test_json_creation_with_uncommon_characters
@@ -38,17 +38,17 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?('deleted')
     assert_equal false, res['deleted']
     assert res.key?('deletable_by_viewer')
-    assert_equal Settings.deletable_pushes_default, res['deletable_by_viewer']
+    assert_equal Settings.pw.deletable_pushes_default, res['deletable_by_viewer']
     assert res.key?('days_remaining')
-    assert_equal Settings.expire_after_days_default, res['days_remaining']
+    assert_equal Settings.pw.expire_after_days_default, res['days_remaining']
     assert res.key?('views_remaining')
-    assert_equal Settings.expire_after_views_default, res['views_remaining']
+    assert_equal Settings.pw.expire_after_views_default, res['views_remaining']
 
     # These should be default values since we didn't specify them in the params
     assert res.key?('expire_after_days')
-    assert_equal Settings.expire_after_days_default, res['expire_after_days']
+    assert_equal Settings.pw.expire_after_days_default, res['expire_after_days']
     assert res.key?('expire_after_views')
-    assert_equal Settings.expire_after_views_default, res['expire_after_views']
+    assert_equal Settings.pw.expire_after_views_default, res['expire_after_views']
 
     # Validate payload
     get "/p/#{res["url_token"]}.json"
@@ -83,7 +83,7 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
 
     res = JSON.parse(@response.body)
     assert res.key?('deletable_by_viewer')
-    assert_equal Settings.enable_deletable_pushes, res['deletable_by_viewer']
+    assert_equal Settings.pw.enable_deletable_pushes, res['deletable_by_viewer']
   end
 
   def test_custom_days_expiration

--- a/test/integration/password/password_json_deletion_test.rb
+++ b/test/integration/password/password_json_deletion_test.rb
@@ -14,11 +14,11 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?("deleted")
     assert_equal false, res["deleted"]
     assert res.key?("deletable_by_viewer")
-    assert_equal Settings.deletable_pushes_default, res["deletable_by_viewer"]
+    assert_equal Settings.pw.deletable_pushes_default, res["deletable_by_viewer"]
     assert res.key?("days_remaining")
-    assert_equal Settings.expire_after_days_default, res["days_remaining"]
+    assert_equal Settings.pw.expire_after_days_default, res["days_remaining"]
     assert res.key?("views_remaining")
-    assert_equal Settings.expire_after_views_default, res["views_remaining"]
+    assert_equal Settings.pw.expire_after_views_default, res["views_remaining"]
 
     # Delete the new password via json e.g. /p/<url_token>.json
     delete "/p/" + res["url_token"] + ".json"
@@ -32,11 +32,11 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?("deleted")
     assert_equal true, res["deleted"]
     assert res.key?("deletable_by_viewer")
-    assert_equal Settings.deletable_pushes_default, res["deletable_by_viewer"]
+    assert_equal Settings.pw.deletable_pushes_default, res["deletable_by_viewer"]
     assert res.key?("days_remaining")
-    assert_equal Settings.expire_after_days_default, res["days_remaining"]
+    assert_equal Settings.pw.expire_after_days_default, res["days_remaining"]
     assert res.key?("views_remaining")
-    assert_equal Settings.expire_after_views_default, res["views_remaining"]
+    assert_equal Settings.pw.expire_after_views_default, res["views_remaining"]
 
     # Now try to retrieve the password again
     get "/p/" + res["url_token"] + ".json"
@@ -51,10 +51,10 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?("deleted")
     assert_equal true, res["deleted"]
     assert res.key?("deletable_by_viewer")
-    assert_equal Settings.deletable_pushes_default, res["deletable_by_viewer"]
+    assert_equal Settings.pw.deletable_pushes_default, res["deletable_by_viewer"]
     assert res.key?("days_remaining")
-    assert_equal Settings.expire_after_days_default, res["days_remaining"]
+    assert_equal Settings.pw.expire_after_days_default, res["days_remaining"]
     assert res.key?("views_remaining")
-    assert_equal Settings.expire_after_views_default-1, res["views_remaining"]
+    assert_equal Settings.pw.expire_after_views_default-1, res["views_remaining"]
   end
 end

--- a/test/integration/password/password_json_retrieval_test.rb
+++ b/test/integration/password/password_json_retrieval_test.rb
@@ -14,7 +14,7 @@ class PasswordJsonRetrievalTest < ActionDispatch::IntegrationTest
     assert res.key?("deleted")
     assert_equal false, res["deleted"]
     assert res.key?("deletable_by_viewer")
-    assert_equal Settings.deletable_pushes_default, res["deletable_by_viewer"]
+    assert_equal Settings.pw.deletable_pushes_default, res["deletable_by_viewer"]
     assert res.key?("days_remaining")
     assert_equal 2, res["views_remaining"]
     assert res.key?("expire_after_days")

--- a/test/integration/url/url_json_creation_test.rb
+++ b/test/integration/url/url_json_creation_test.rb
@@ -27,17 +27,17 @@ class UrlJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?('deleted')
     assert_equal false, res['deleted']
     assert res.key?('deletable_by_viewer')
-    assert_equal Settings.deletable_pushes_default, res['deletable_by_viewer']
+    assert_equal Settings.url.deletable_pushes_default, res['deletable_by_viewer']
     assert res.key?('days_remaining')
-    assert_equal Settings.expire_after_days_default, res['days_remaining']
+    assert_equal Settings.url.expire_after_days_default, res['days_remaining']
     assert res.key?('views_remaining')
-    assert_equal Settings.expire_after_views_default, res['views_remaining']
+    assert_equal Settings.url.expire_after_views_default, res['views_remaining']
 
     # These should be default values since we didn't specify them in the params
     assert res.key?('expire_after_days')
-    assert_equal Settings.expire_after_days_default, res['expire_after_days']
+    assert_equal Settings.url.expire_after_days_default, res['expire_after_days']
     assert res.key?('expire_after_views')
-    assert_equal Settings.expire_after_views_default, res['expire_after_views']
+    assert_equal Settings.url.expire_after_views_default, res['expire_after_views']
   end
 
   def test_custom_days_expiration

--- a/test/integration/url/url_json_creation_test.rb
+++ b/test/integration/url/url_json_creation_test.rb
@@ -26,8 +26,7 @@ class UrlJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal false, res['expired']
     assert res.key?('deleted')
     assert_equal false, res['deleted']
-    assert res.key?('deletable_by_viewer')
-    assert_equal Settings.url.deletable_pushes_default, res['deletable_by_viewer']
+    assert !res.key?('deletable_by_viewer')
     assert res.key?('days_remaining')
     assert_equal Settings.url.expire_after_days_default, res['days_remaining']
     assert res.key?('views_remaining')

--- a/test/integration/url/url_json_deletion_test.rb
+++ b/test/integration/url/url_json_deletion_test.rb
@@ -27,8 +27,7 @@ class UrlJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal false, res["expired"]
     assert res.key?("deleted")
     assert_equal false, res["deleted"]
-    assert res.key?("deletable_by_viewer")
-    assert_equal Settings.url.deletable_pushes_default, res["deletable_by_viewer"]
+    assert !res.key?("deletable_by_viewer")
     assert res.key?("days_remaining")
     assert_equal Settings.url.expire_after_days_default, res["days_remaining"]
     assert res.key?("views_remaining")
@@ -45,8 +44,7 @@ class UrlJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal true, res["expired"]
     assert res.key?("deleted")
     assert_equal true, res["deleted"]
-    assert res.key?("deletable_by_viewer")
-    assert_equal Settings.url.deletable_pushes_default, res["deletable_by_viewer"]
+    assert !res.key?("deletable_by_viewer")
     assert res.key?("days_remaining")
     assert_equal Settings.url.expire_after_days_default, res["days_remaining"]
     assert res.key?("views_remaining")
@@ -64,8 +62,7 @@ class UrlJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal true, res["expired"]
     assert res.key?("deleted")
     assert_equal true, res["deleted"]
-    assert res.key?("deletable_by_viewer")
-    assert_equal Settings.url.deletable_pushes_default, res["deletable_by_viewer"]
+    assert !res.key?("deletable_by_viewer")
     assert res.key?("days_remaining")
     assert_equal Settings.url.expire_after_days_default, res["days_remaining"]
     assert res.key?("views_remaining")

--- a/test/integration/url/url_json_deletion_test.rb
+++ b/test/integration/url/url_json_deletion_test.rb
@@ -28,11 +28,11 @@ class UrlJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?("deleted")
     assert_equal false, res["deleted"]
     assert res.key?("deletable_by_viewer")
-    assert_equal Settings.deletable_pushes_default, res["deletable_by_viewer"]
+    assert_equal Settings.url.deletable_pushes_default, res["deletable_by_viewer"]
     assert res.key?("days_remaining")
-    assert_equal Settings.expire_after_days_default, res["days_remaining"]
+    assert_equal Settings.url.expire_after_days_default, res["days_remaining"]
     assert res.key?("views_remaining")
-    assert_equal Settings.expire_after_views_default, res["views_remaining"]
+    assert_equal Settings.url.expire_after_views_default, res["views_remaining"]
 
     # Delete the new url via json e.g. /r/<url_token>.json
     delete "/r/" + res["url_token"] + ".json", headers: { 'X-User-Email': @luca.email, 'X-User-Token': @luca.authentication_token }
@@ -46,11 +46,11 @@ class UrlJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?("deleted")
     assert_equal true, res["deleted"]
     assert res.key?("deletable_by_viewer")
-    assert_equal Settings.deletable_pushes_default, res["deletable_by_viewer"]
+    assert_equal Settings.url.deletable_pushes_default, res["deletable_by_viewer"]
     assert res.key?("days_remaining")
-    assert_equal Settings.expire_after_days_default, res["days_remaining"]
+    assert_equal Settings.url.expire_after_days_default, res["days_remaining"]
     assert res.key?("views_remaining")
-    assert_equal Settings.expire_after_views_default, res["views_remaining"]
+    assert_equal Settings.url.expire_after_views_default, res["views_remaining"]
 
     # Now try to retrieve the url again
     get "/r/" + res["url_token"] + ".json"
@@ -65,10 +65,10 @@ class UrlJsonCreationTest < ActionDispatch::IntegrationTest
     assert res.key?("deleted")
     assert_equal true, res["deleted"]
     assert res.key?("deletable_by_viewer")
-    assert_equal Settings.deletable_pushes_default, res["deletable_by_viewer"]
+    assert_equal Settings.url.deletable_pushes_default, res["deletable_by_viewer"]
     assert res.key?("days_remaining")
-    assert_equal Settings.expire_after_days_default, res["days_remaining"]
+    assert_equal Settings.url.expire_after_days_default, res["days_remaining"]
     assert res.key?("views_remaining")
-    assert_equal Settings.expire_after_views_default-1, res["views_remaining"]
+    assert_equal Settings.url.expire_after_views_default-1, res["views_remaining"]
   end
 end

--- a/test/integration/url/url_json_retrieval_test.rb
+++ b/test/integration/url/url_json_retrieval_test.rb
@@ -27,8 +27,7 @@ class UrlJsonRetrievalTest < ActionDispatch::IntegrationTest
     assert_equal false, res["expired"]
     assert res.key?("deleted")
     assert_equal false, res["deleted"]
-    assert res.key?("deletable_by_viewer")
-    assert_equal Settings.url.deletable_pushes_default, res["deletable_by_viewer"]
+    assert !res.key?("deletable_by_viewer")
     assert res.key?("days_remaining")
     assert_equal 2, res["views_remaining"]
     assert res.key?("expire_after_days")

--- a/test/integration/url/url_json_retrieval_test.rb
+++ b/test/integration/url/url_json_retrieval_test.rb
@@ -28,7 +28,7 @@ class UrlJsonRetrievalTest < ActionDispatch::IntegrationTest
     assert res.key?("deleted")
     assert_equal false, res["deleted"]
     assert res.key?("deletable_by_viewer")
-    assert_equal Settings.deletable_pushes_default, res["deletable_by_viewer"]
+    assert_equal Settings.url.deletable_pushes_default, res["deletable_by_viewer"]
     assert res.key?("days_remaining")
     assert_equal 2, res["views_remaining"]
     assert res.key?("expire_after_days")

--- a/test/unit/password_test.rb
+++ b/test/unit/password_test.rb
@@ -31,11 +31,11 @@ class PasswordTest < Minitest::Test
     push = Password.new(created_at: 3.days.ago, updated_at: 3.days.ago, payload: 'asdf')
     push.validate!
 
-    assert push.expire_after_days == Settings.expire_after_days_default
-    assert push.expire_after_views == Settings.expire_after_views_default
+    assert push.expire_after_days == Settings.pw.expire_after_days_default
+    assert push.expire_after_views == Settings.pw.expire_after_views_default
 
-    assert push.retrieval_step == Settings.retrieval_step_default if Settings.enable_retrieval_step
-    assert push.deletable_by_viewer == Settings.deletable_pushes_default if Settings.enable_deletable_pushes
+    assert push.retrieval_step == Settings.pw.retrieval_step_default if Settings.pw.enable_retrieval_step
+    assert push.deletable_by_viewer == Settings.pw.deletable_pushes_default if Settings.pw.enable_deletable_pushes
   end
 
   def test_days_expiration

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -20,12 +20,12 @@ class SettingsTest < Minitest::Test
     legacy_env_var = 'EXPIRE_AFTER_DAYS_DEFAULT'
 
     Settings.reload!
-    assert Settings.method(legacy_env_var.downcase).call == 7
+    assert Settings.pw.method(legacy_env_var.downcase).call == 7
 
     ENV[legacy_env_var] = "9"
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.method(legacy_env_var.downcase).call == 9
+    assert Settings.pw.method(legacy_env_var.downcase).call == 9
 
     ENV.delete(legacy_env_var)
   end
@@ -34,12 +34,12 @@ class SettingsTest < Minitest::Test
     legacy_env_var = 'EXPIRE_AFTER_DAYS_MIN'
 
     Settings.reload!
-    assert Settings.method(legacy_env_var.downcase).call == 1
+    assert Settings.pw.method(legacy_env_var.downcase).call == 1
 
     ENV[legacy_env_var] = "3"
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.method(legacy_env_var.downcase).call == 3
+    assert Settings.pw.method(legacy_env_var.downcase).call == 3
 
     ENV.delete(legacy_env_var)
   end
@@ -48,12 +48,12 @@ class SettingsTest < Minitest::Test
     legacy_env_var = 'EXPIRE_AFTER_DAYS_MAX'
 
     Settings.reload!
-    assert Settings.method(legacy_env_var.downcase).call == 90
+    assert Settings.pw.method(legacy_env_var.downcase).call == 90
 
     ENV[legacy_env_var] = "5"
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.method(legacy_env_var.downcase).call == 5
+    assert Settings.pw.method(legacy_env_var.downcase).call == 5
 
     ENV.delete(legacy_env_var)
   end
@@ -62,12 +62,12 @@ class SettingsTest < Minitest::Test
     legacy_env_var = 'EXPIRE_AFTER_VIEWS_DEFAULT'
 
     Settings.reload!
-    assert Settings.method(legacy_env_var.downcase).call == 5
+    assert Settings.pw.method(legacy_env_var.downcase).call == 5
 
     ENV[legacy_env_var] = "9"
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.method(legacy_env_var.downcase).call == 9
+    assert Settings.pw.method(legacy_env_var.downcase).call == 9
 
     ENV.delete(legacy_env_var)
   end
@@ -76,12 +76,12 @@ class SettingsTest < Minitest::Test
     legacy_env_var = 'EXPIRE_AFTER_VIEWS_MIN'
 
     Settings.reload!
-    assert Settings.method(legacy_env_var.downcase).call == 1
+    assert Settings.pw.method(legacy_env_var.downcase).call == 1
 
     ENV[legacy_env_var] = "3"
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.method(legacy_env_var.downcase).call == 3
+    assert Settings.pw.method(legacy_env_var.downcase).call == 3
 
     ENV.delete(legacy_env_var)
   end
@@ -90,12 +90,12 @@ class SettingsTest < Minitest::Test
     legacy_env_var = 'EXPIRE_AFTER_VIEWS_MAX'
 
     Settings.reload!
-    assert Settings.method(legacy_env_var.downcase).call == 100
+    assert Settings.pw.method(legacy_env_var.downcase).call == 100
 
     ENV[legacy_env_var] = "100"
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.method(legacy_env_var.downcase).call == 100
+    assert Settings.pw.method(legacy_env_var.downcase).call == 100
 
     ENV.delete(legacy_env_var)
   end

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -102,102 +102,102 @@ class SettingsTest < Minitest::Test
 
   def test_legacy_RETRIEVAL_STEP_ENABLED
     Settings.reload!
-    assert Settings.enable_retrieval_step == true
+    assert Settings.pw.enable_retrieval_step == true
 
     ENV['RETRIEVAL_STEP_ENABLED'] = 'false'
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.enable_retrieval_step == false
+    assert Settings.pw.enable_retrieval_step == false
 
     ENV['RETRIEVAL_STEP_ENABLED'] = 'true'
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.enable_retrieval_step == true
+    assert Settings.pw.enable_retrieval_step == true
 
     ENV.delete('RETRIEVAL_STEP_ENABLED')
   end
   
   def test_legacy_RETRIEVAL_STEP_DEFAULT
     Settings.reload!
-    assert Settings.retrieval_step_default == false
+    assert Settings.pw.retrieval_step_default == false
 
     ENV['RETRIEVAL_STEP_DEFAULT'] = 'false'
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.retrieval_step_default == false
+    assert Settings.pw.retrieval_step_default == false
 
     ENV['RETRIEVAL_STEP_DEFAULT'] = 'true'
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.retrieval_step_default == true
+    assert Settings.pw.retrieval_step_default == true
 
     ENV.delete('RETRIEVAL_STEP_DEFAULT')
   end
   
   def test_legacy_DELETABLE_PASSWORDS_ENABLED
     Settings.reload!
-    assert Settings.enable_deletable_pushes == true
+    assert Settings.pw.enable_deletable_pushes == true
 
     ENV['DELETABLE_PASSWORDS_ENABLED'] = 'false'
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.enable_deletable_pushes == false
+    assert Settings.pw.enable_deletable_pushes == false
 
     ENV['DELETABLE_PASSWORDS_ENABLED'] = 'true'
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.enable_deletable_pushes == true
+    assert Settings.pw.enable_deletable_pushes == true
 
     ENV.delete('DELETABLE_PASSWORDS_ENABLED')
   end
   
   def test_legacy_DELETABLE_BY_VIEWER_PASSWORDS
     Settings.reload!
-    assert Settings.enable_deletable_pushes == true
+    assert Settings.pw.enable_deletable_pushes == true
 
     ENV['DELETABLE_BY_VIEWER_PASSWORDS'] = 'false'
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.enable_deletable_pushes == false
+    assert Settings.pw.enable_deletable_pushes == false
 
     ENV['DELETABLE_BY_VIEWER_PASSWORDS'] = 'true'
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.enable_deletable_pushes == true
+    assert Settings.pw.enable_deletable_pushes == true
 
     ENV.delete('DELETABLE_BY_VIEWER_PASSWORDS')
   end
 
   def test_legacy_DELETABLE_PASSWORDS_DEFAULT
     Settings.reload!
-    assert Settings.deletable_pushes_default == true
+    assert Settings.pw.deletable_pushes_default == true
 
     ENV['DELETABLE_PASSWORDS_DEFAULT'] = 'false'
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.deletable_pushes_default == false
+    assert Settings.pw.deletable_pushes_default == false
 
     ENV['DELETABLE_PASSWORDS_DEFAULT'] = 'true'
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.deletable_pushes_default == true
+    assert Settings.pw.deletable_pushes_default == true
 
     ENV.delete('DELETABLE_PASSWORDS_DEFAULT')
   end
   
   def test_legacy_DELETABLE_BY_VIEWER_DEFAULT
     Settings.reload!
-    assert Settings.deletable_pushes_default == true
+    assert Settings.pw.deletable_pushes_default == true
 
     ENV['DELETABLE_BY_VIEWER_DEFAULT'] = 'false'
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.deletable_pushes_default == false
+    assert Settings.pw.deletable_pushes_default == false
 
     ENV['DELETABLE_BY_VIEWER_DEFAULT'] = 'true'
     Settings.reload!
     load_legacy_environment_variables
-    assert Settings.deletable_pushes_default == true
+    assert Settings.pw.deletable_pushes_default == true
 
     ENV.delete('DELETABLE_BY_VIEWER_DEFAULT')
   end


### PR DESCRIPTION
## Description

- Per push type expiration settings
- Update defaults

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
