### PR TITLE
Fix: Registration + Turbo Streams

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -26,6 +26,9 @@ Devise.setup do |config|
   # with default "from" parameter.
   config.mailer_sender = Settings.mail.mailer_sender if Settings.mail
 
+  # https://github.com/heartcombo/devise/issues/5439
+  config.navigational_formats = ['*/*', :html, :turbo_stream]
+
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
 


### PR DESCRIPTION
## Description

Registration with Turbo streams seems to be broken.

Known issue with devise: https://github.com/heartcombo/devise/issues/5439

- Latest language strings
- Fix registration

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
