### PR TITLE
ci: disable provenance when building images

### DIFF
--- a/.github/workflows/docker-containers.yml
+++ b/.github/workflows/docker-containers.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           file: ./containers/docker/pwpush-ephemeral/Dockerfile
           platforms: linux/amd64,linux/arm64
+          provenance: false
           push: true
           tags: pglombardo/pwpush-ephemeral:${{ env.DOCKER_TAG }}
 
@@ -100,6 +101,7 @@ jobs:
         with:
           file: ./containers/docker/pwpush-postgres/Dockerfile
           platforms: linux/amd64,linux/arm64
+          provenance: false
           push: true
           tags: pglombardo/pwpush-postgres:${{ env.DOCKER_TAG }}
 
@@ -142,5 +144,6 @@ jobs:
         with:
           file: ./containers/docker/pwpush-mysql/Dockerfile
           platforms: linux/amd64,linux/arm64
+          provenance: false
           push: true
           tags: pglombardo/pwpush-mysql:${{ env.DOCKER_TAG }}


### PR DESCRIPTION
This has proven to break pulling images with older clients.

https://github.com/docker/buildx/releases/tag/v0.10.0

Read a bit more: https://github.com/docker/buildx/issues/1533

## Description

With the recent release of buildx 0.10.0 things has started to break.  This is caused by something called provenance and in turn has caused problems when pulling the images because changes to the mediatype metadata.

```
$ docker buildx imagetools inspect pglombardo/pwpush-ephemeral:1.24.4
Name:      docker.io/pglombardo/pwpush-ephemeral:1.24.4
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:76c9535b5219457549e549fa24c415678ef37c55a5199593ddd41a497bbf0384
           
Manifests: 
  Name:      docker.io/pglombardo/pwpush-ephemeral:1.24.4@sha256:fa63f204749695122df7c2f64270a4120480b7a83d9af10f6040b2b6eb379f35
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64
             
  Name:      docker.io/pglombardo/pwpush-ephemeral:1.24.4@sha256:119fd93e78eae300b73edf1ce10a53371055bd9ae07b9abb2840fc65163a7ddd
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64
```

```
$ docker buildx imagetools inspect pglombardo/pwpush-ephemeral:1.24.8
Name:      docker.io/pglombardo/pwpush-ephemeral:1.24.8
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:9e46c3b12082022b192df0549274ea480c48b479976b1d3a27a3fb510275e04f
           
Manifests: 
  Name:        docker.io/pglombardo/pwpush-ephemeral:1.24.8@sha256:b25156e6c45d808ddbe3826f86a85684e7a5feeedd3af8e37e02ec896caa26a1
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/amd64
               
  Name:        docker.io/pglombardo/pwpush-ephemeral:1.24.8@sha256:b1e480de774394aed0fd67f4a37930a2ddff8920748db91dd299140e4993c2b1
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/arm64
               
  Name:        docker.io/pglombardo/pwpush-ephemeral:1.24.8@sha256:0ad0b5c39abd42d185d3aae801678d4ad63c0576e7807b203b9526b31a9a3703
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations: 
    vnd.docker.reference.digest: sha256:b25156e6c45d808ddbe3826f86a85684e7a5feeedd3af8e37e02ec896caa26a1
    vnd.docker.reference.type:   attestation-manifest
               
  Name:        docker.io/pglombardo/pwpush-ephemeral:1.24.8@sha256:91732b06c0bf1649ff7664fa456d2f8b7404bd4c2984d45a0f3dbe0cf4a952e3
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations: 
    vnd.docker.reference.digest: sha256:b1e480de774394aed0fd67f4a37930a2ddff8920748db91dd299140e4993c2b1
    vnd.docker.reference.type:   attestation-manifest
```

Notice the change from `MediaType: application/vnd.docker.distribution.manifest.list.v2+json` to `MediaType:   application/vnd.oci.image.manifest.v1+json`.

Can also be seen in relation to https://github.com/pglombardo/PasswordPusher/pull/678

This should not break stuff.  It will make it more compatible for the foreseeable future if you don't need said feature for now.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
