### PR TITLE
GA: Add Turbolinks support

### DIFF
--- a/app/views/layouts/_ga.html.erb
+++ b/app/views/layouts/_ga.html.erb
@@ -5,7 +5,16 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', '<%= ENV['GA_ACCOUNT'] %>');
+  </script>
+
+  <script type="module">
+    let isInitialLoad = true;
+    document.addEventListener('turbolinks:load', () => {
+      if (isInitialLoad){isInitialLoad = false; return;}
+      gtag('config', '<%= ENV['GA_ACCOUNT'] %>', {
+        page_path: window.location.pathname,
+      });
+    });
   </script>
 <% end %>


### PR DESCRIPTION
## Description

Turbolinks doesn't allow GA to track subsequent page loads.

Update the code with a turbolinks listener.

[source](https://dev.to/tylerlwsmith/using-google-analyticss-gtagjs-with-turbolinks-5coa)
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
