### PR TITLE
Docker: Don't Precompile Assets by Default

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -626,6 +626,15 @@ feedback:
   # Environment Variable Override: PWP__FEEDBACK__EMAIL='my@email.com'
   email: 'feedback@pwpush.com'
 
+### Docker Precompilation
+#
+# If set to true, the Docker image will precompile assets on container boot.
+#
+# This is useful if you modified the assets (e.g. CSS, JS, images) to customize
+# the theme etc...  Assets are precompiled before serving.
+#
+# precompile: false
+
 ### Language & Internationalization
 #
 # List of supported languages indexed by language code.  This is used

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -626,6 +626,15 @@ feedback:
   # Environment Variable Override: PWP__FEEDBACK__EMAIL='my@email.com'
   email: 'feedback@pwpush.com'
 
+### Docker Precompilation
+#
+# If set to true, the Docker image will precompile assets on container boot.
+#
+# This is useful if you modified the assets (e.g. CSS, JS, images) to customize
+# the theme etc...  Assets are precompiled before serving.
+#
+# precompile: false
+
 ### Language & Internationalization
 #
 # List of supported languages indexed by language code.  This is used

--- a/containers/docker/pwpush-ephemeral/entrypoint.sh
+++ b/containers/docker/pwpush-ephemeral/entrypoint.sh
@@ -5,8 +5,13 @@ export RAILS_ENV=private
 
 echo "Password Pusher: migrating database to latest..."
 bundle exec rake db:migrate
-echo "Password Pusher: precompiling assets..."
-bundle exec rails assets:precompile
+
+if [ "$PWP_PRECOMPILE" == "true" ]
+then
+    echo "Password Pusher: precompiling assets..."
+    bundle exec rails assets:precompile
+fi
+
 echo "Password Pusher: starting puma webserver..."
 bundle exec puma -C config/puma.rb -e private
 

--- a/containers/docker/pwpush-mysql/entrypoint.sh
+++ b/containers/docker/pwpush-mysql/entrypoint.sh
@@ -5,8 +5,13 @@ export RAILS_ENV=production
 
 echo "Password Pusher: migrating database to latest..."
 bundle exec rake db:migrate
-echo "Password Pusher: precompiling assets..."
-bundle exec rails assets:precompile
+
+if [ "$PWP_PRECOMPILE" == "true" ]
+then
+    echo "Password Pusher: precompiling assets..."
+    bundle exec rails assets:precompile
+fi
+
 echo "Password Pusher: starting puma webserver..."
 bundle exec puma -C config/puma.rb
 

--- a/containers/docker/pwpush-postgres/entrypoint.sh
+++ b/containers/docker/pwpush-postgres/entrypoint.sh
@@ -5,8 +5,13 @@ export RAILS_ENV=production
 
 echo "Password Pusher: migrating database to latest..."
 bundle exec rake db:migrate
-echo "Password Pusher: precompiling assets..."
-bundle exec rails assets:precompile
+
+if [ "$PWP_PRECOMPILE" == "true" ]
+then
+    echo "Password Pusher: precompiling assets..."
+    bundle exec rails assets:precompile
+fi
+
 echo "Password Pusher: starting puma webserver..."
 bundle exec puma -C config/puma.rb
 


### PR DESCRIPTION
## Description

Docker: Don't Precompile Assets by Default

Set the environment variable `PWP_PRECOMPILE` if you want assets to be precompiled on container boot.

This is useful for people who add custom CSS, images or JS.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
