### PR TITLE
Add PikaPods deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ One click deploy to [Heroku Cloud](https://www.heroku.com) without having to set
 
 _This option will deploy a production Password Pusher instance backed by a postgres database to Heroku.  Heroku used to offer free dynos but that is [no longer the case](https://blog.heroku.com/next-chapter) from November 28, 2022.  Hosting charges will be incurred._
 
+## On PikaPods
+
+One click deploy to [PikaPods](https://www.pikapods.com/) from $1/month. Start free with $5 welcome credit.
+
+[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=pwpush)
+
 ## With Nginx
 
 See the prebuilt [Docker Compose example here](https://github.com/pglombardo/PasswordPusher/tree/master/containers/examples/pwpush-and-nginx).


### PR DESCRIPTION
## Description

A user just suggest to add your app to [PikaPods](https://www.pikapods.com/apps#new). Been looking for something similar for a while and it looked solid. So complied right away.

Preview: https://github.com/m3nu/PasswordPusher/tree/add-pikapods#on-pikapods

About PikaPods: We aim to make great open source apps, like PasswordPusher more accessible and easier to get started with. Currently we offer around 60 different apps that can be deployed with a single click and managed in a simple control panel.

So I'm suggesting to add PikaPods as additional deployment option. This would help an even wider audience to benefit from the project and run their own. We also do revenue sharing with our authors, which may be of interest in the future.

Thanks for the consideration!

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
