### PR TITLE
Change to use docker metadata action for tags

### DIFF
--- a/.github/workflows/docker-containers.yml
+++ b/.github/workflows/docker-containers.yml
@@ -82,3 +82,5 @@ jobs:
           push: ${{ env.DOCKER_PUSH }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-${{ matrix.dbType }}:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-${{ matrix.dbType }}:buildcache,mode=max

--- a/.github/workflows/docker-containers.yml
+++ b/.github/workflows/docker-containers.yml
@@ -1,29 +1,29 @@
+---
 name: Docker Container Builds
 
 on:
   push:
     tags:
-      - "v*.*.*"
       - "release"
+      - "v*.*.*"
 
   workflow_dispatch:
-    inputs:
-      dockerTagName:
-        description: 'What Docker tag to create?'
-        required: true
-        default: 'development-0xdeadbeef'
-      dockerPush:
-        description: 'Push image to docker hub?'
-        required: true
-        type: boolean
-        default: false
+  #   inputs:
+  #     dockerTagName:
+  #       description: "What Docker tag to create?"
+  #       required: true
+  #       default: "development-0xdeadbeef"
+  #     dockerPush:
+  #       description: "Push image to docker hub?"
+  #       required: true
+  #       type: boolean
+  #       default: false
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Run every day at 5:24 UTC - build 'latest' docker containers
-    - cron:  '24 17 * * *'
+    - cron: "24 17 * * *"
 env:
   DOCKER_PUSH: true
-  DOCKER_TAG:
 
 jobs:
   build:
@@ -33,8 +33,9 @@ jobs:
       matrix:
         include:
           - dbType: ephemeral
-          - dbType: postgres
           - dbType: mysql
+          - dbType: postgres
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -45,43 +46,39 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - id: get_version
-        uses: battila7/get-version-action@v2
+      # - name: Manually configured docker tag
+      #   if: ${{ github.event_name == 'workflow_dispatch' }}
+      #   run: |
+      #     echo "DOCKER_TAG=${{ github.event.inputs.dockerTagName }}" >> $GITHUB_ENV
+      #     echo "DOCKER_PUSH=${{ github.event.inputs.dockerPush }}" >> $GITHUB_ENV
 
-      - run: echo "DOCKER_TAG=${{ steps.get_version.outputs.version-without-v }}" >> $GITHUB_ENV
-
-      - name: Should docker tag be latest?
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: echo "DOCKER_TAG=latest" >> $GITHUB_ENV
-
-      - name: Should docker tag be release?
-        if: ${{ github.ref == 'refs/tags/release' }}
-        run: echo "DOCKER_TAG=release" >> $GITHUB_ENV
-
-      - name: Manually configured docker tag
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-             echo "DOCKER_TAG=${{ github.event.inputs.dockerTagName }}" >> $GITHUB_ENV
-             echo "DOCKER_PUSH=${{ github.event.inputs.dockerPush }}" >> $GITHUB_ENV
-
-      - name: Show us the DOCKER_TAG
-        run: echo "${{ env.DOCKER_TAG}}"
-
-      - name: Show us the DOCKER_PUSH
-        run: echo "${{ env.DOCKER_PUSH}}"
+      - name: Populate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: pglombardo/pwpush-${{ matrix.dbType }}
+          flavor: |
+            latest=false
+          tags: |
+            type=match,pattern=release
+            type=schedule,pattern=latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=semver,pattern=latest
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
-        if: ${{env.DOCKER_PUSH == 'true'}}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push pwpush-${{ matrix.dbType }} Docker images
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v4
         with:
           file: ./containers/docker/pwpush-${{ matrix.dbType }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           provenance: false
-          push: ${{env.DOCKER_PUSH == 'true'}}
-          tags: pglombardo/pwpush-${{ matrix.dbType }}:${{ env.DOCKER_TAG }}
+          push: ${{ env.DOCKER_PUSH }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-containers.yml
+++ b/.github/workflows/docker-containers.yml
@@ -8,22 +8,11 @@ on:
       - "v*.*.*"
 
   workflow_dispatch:
-  #   inputs:
-  #     dockerTagName:
-  #       description: "What Docker tag to create?"
-  #       required: true
-  #       default: "development-0xdeadbeef"
-  #     dockerPush:
-  #       description: "Push image to docker hub?"
-  #       required: true
-  #       type: boolean
-  #       default: false
+
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Run every day at 5:24 UTC - build 'latest' docker containers
     - cron: "24 17 * * *"
-env:
-  DOCKER_PUSH: true
 
 jobs:
   build:
@@ -73,7 +62,6 @@ jobs:
           file: ./containers/docker/pwpush-${{ matrix.dbType }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           provenance: false
-          push: ${{ env.DOCKER_PUSH }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-${{ matrix.dbType }}:buildcache

--- a/.github/workflows/docker-containers.yml
+++ b/.github/workflows/docker-containers.yml
@@ -46,12 +46,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # - name: Manually configured docker tag
-      #   if: ${{ github.event_name == 'workflow_dispatch' }}
-      #   run: |
-      #     echo "DOCKER_TAG=${{ github.event.inputs.dockerTagName }}" >> $GITHUB_ENV
-      #     echo "DOCKER_PUSH=${{ github.event.inputs.dockerPush }}" >> $GITHUB_ENV
-
       - name: Populate Docker metadata
         id: meta
         uses: docker/metadata-action@v4


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Change to use the upstream [Docker Metadata action](https://github.com/marketplace/actions/docker-metadata-action) for populating the tags.  The old action is obsolete.

I've commented out the workflow_dispatch section as to ask how it's used in the real world.  Is it something that we can tweak using the upstream action?

Ed1t: my goal was to have these in the image:
```json
    "Labels": {
        "maintainer": "pglombardo@hey.com",
        "org.opencontainers.image.created": "2023-06-27T17:27:21.882Z",
        "org.opencontainers.image.description": "🔐   An application to securely communicate passwords over the web.  Passwords automatically expire after a certain number of views and/or time has passed.  Track who, what and when.",
        "org.opencontainers.image.licenses": "Apache-2.0",
        "org.opencontainers.image.revision": "59c9bed0ca6acc1f293bbfca28f92decc5cd5cbb",
        "org.opencontainers.image.source": "https://github.com/MindTooth/PasswordPusher",
        "org.opencontainers.image.title": "PasswordPusher",
        "org.opencontainers.image.url": "https://github.com/MindTooth/PasswordPusher",
        "org.opencontainers.image.version": "latest"
    },
```

Especially `org.opencontainers.image.source` so that Renovate are able to pull in a changelog.  Without it, Renovate isn't able to pull a changelog, nor link to the package name.

### Missing link and changelog

<img width="862" alt="Screenshot 2023-06-28 at 11 44 41" src="https://github.com/pglombardo/PasswordPusher/assets/33870508/f266f6e1-771a-41ab-838d-b7bd35480475">

https://github.com/MindTooth/renovate-docker-test/pull/3

### Link and changelog

<img width="1000" alt="Screenshot 2023-06-28 at 11 52 21" src="https://github.com/pglombardo/PasswordPusher/assets/33870508/a834aa04-e115-48eb-ac83-ed6c1d7e5075">

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
