### PR TITLE
Set i18n_use_slash_separator=true

### DIFF
--- a/config/initializers/route_translator.rb
+++ b/config/initializers/route_translator.rb
@@ -1,4 +1,5 @@
 RouteTranslator.config do |config|
   config.force_locale = true
   config.generate_unnamed_unlocalized_routes = true
+  config.i18n_use_slash_separator = true
 end


### PR DESCRIPTION
## Description

This fixes a deprecation warning in route_translator.

Details on the deprecation are here:
https://github.com/enriclluelles/route_translator/pull/285

The original deprecation warning.
```sh
DEPRECATION WARNING: `i18n_use_slash_separator` set to `false` is deprecated and will be
removed in the next major release of Route Translator to match
Rails' ActiveRecord nested model syntax.

More information at https://github.com/enriclluelles/route_translator/pull/285
```

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
