### PR TITLE
Fix URL push 1-click option

### DIFF
--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -3,8 +3,8 @@ require 'securerandom'
 class UrlsController < ApplicationController
   helper UrlsHelper
 
-  # Authentication always except for :show, :new
-  acts_as_token_authentication_handler_for User, except: [:show, :new, :passphrase, :access]
+  # Authentication always except for the following:
+  acts_as_token_authentication_handler_for User, except: [:show, :new, :preliminary, :passphrase, :access]
 
   resource_description do
     name 'URL Pushes'


### PR DESCRIPTION
## Description

This fixes an issue where URL pushes with the 1-click option incorrectly required the user to login.

Reported via feedback from a end user.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
