### PR TITLE
Add optional allowed_hosts setting

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -138,6 +138,31 @@ host_protocol: 'https'
 #
 # override_base_url: 'https://pwpush.mydomain.com'
 
+### Allowed Hosts
+#
+# This is a list of allowed hosts for the application.  This is used to
+# prevent host header attacks.
+#
+# When set, the application will only respond to requests with a host header
+# that matches one of the values in this list.
+#
+# This feature is generally only used when the application is behind a proxy.
+#
+# It's generally not required to use this unless you are getting the related error
+# in the application.  localhost and the IP that the application is running on
+# are always allowed.
+#
+# Note: If you need more than one value, you have to use the YAML syntax and not
+# the environment variable override.  This is a limitation in the config gem.
+#
+# Environment variable override:
+# PWP__ALLOWED_HOSTS='pwpush.com'
+#
+# allowed_hosts:
+#   - 'pwpush.com'
+#   - 'pwpush.mydomain.com'
+#   - 'pwpush.myotherdomain.com'
+
 ## Expiration Settings for Password Pushes
 #
 pw:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -95,11 +95,12 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
-  # If a user sets the override_base_url setting, we need to add the domain to the list of allowed hosts
-  if Settings.override_base_url
-    require 'uri/http'
-
-    uri = URI.parse(Settings.override_base_url)
-    config.hosts << uri.host.downcase
+  # If a user sets the allowed_hosts setting, we need to add the domain(s) to the list of allowed hosts
+  if Settings.allowed_hosts.present?
+    if Settings.allowed_hosts.is_a?(Array)
+      config.hosts.concat(Settings.allowed_hosts)
+    else
+      config.hosts << Settings.allowed_hosts
+    end
   end
 end

--- a/config/environments/private.rb
+++ b/config/environments/private.rb
@@ -71,11 +71,12 @@ Rails.application.configure do
 
   config.active_record.dump_schema_after_migration = false
 
-  # If a user sets the override_base_url setting, we need to add the domain to the list of allowed hosts
-  if Settings.override_base_url
-    require 'uri/http'
-
-    uri = URI.parse(Settings.override_base_url)
-    config.hosts << uri.host.downcase
+  # If a user sets the allowed_hosts setting, we need to add the domain(s) to the list of allowed hosts
+  if Settings.allowed_hosts.present?
+    if Settings.allowed_hosts.is_a?(Array)
+      config.hosts.concat(Settings.allowed_hosts)
+    else
+      config.hosts << Settings.allowed_hosts
+    end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,11 +119,12 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # If a user sets the override_base_url setting, we need to add the domain to the list of allowed hosts
-  if Settings.override_base_url
-    require 'uri/http'
-
-    uri = URI.parse(Settings.override_base_url)
-    config.hosts << uri.host.downcase
+  # If a user sets the allowed_hosts setting, we need to add the domain(s) to the list of allowed hosts
+  if Settings.allowed_hosts.present?
+    if Settings.allowed_hosts.is_a?(Array)
+      config.hosts.concat(Settings.allowed_hosts)
+    else
+      config.hosts << Settings.allowed_hosts
+    end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -138,6 +138,31 @@ host_protocol: 'https'
 #
 # override_base_url: 'https://pwpush.mydomain.com'
 
+### Allowed Hosts
+#
+# This is a list of allowed hosts for the application.  This is used to
+# prevent host header attacks.
+#
+# When set, the application will only respond to requests with a host header
+# that matches one of the values in this list.
+#
+# This feature is generally only used when the application is behind a proxy.
+#
+# It's generally not required to use this unless you are getting the related error
+# in the application.  localhost and the IP that the application is running on
+# are always allowed.
+#
+# Note: If you need more than one value, you have to use the YAML syntax and not
+# the environment variable override.  This is a limitation in the config gem.
+#
+# Environment variable override:
+# PWP__ALLOWED_HOSTS='pwpush.com'
+#
+# allowed_hosts:
+#   - 'pwpush.com'
+#   - 'pwpush.mydomain.com'
+#   - 'pwpush.myotherdomain.com'
+
 ## Expiration Settings for Password Pushes
 #
 pw:


### PR DESCRIPTION
## Description

This adds a new option to the Settings object `allowed_hosts`.

This configured which Host Headers the application is authorized to respond to.

Documentation in the `settings.yml`

Fixes #1343

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
