### PR TITLE
Throttling: Increase default thresholds

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -614,17 +614,17 @@ brand:
 throttling:
   # ..maximum number of allowed HTTP requests per day
   #
-  # Default: 1000
+  # Default: 5000
   #
   # Environment Variable Override: PWP__THROTTLING__DAILY='1000'
-  daily: 1000
+  daily: 5000
 
   # ..maximum number of allowed HTTP requests per hour
   #
-  # Default: 100
+  # Default: 200
   #
   # Environment Variable Override: PWP__THROTTLING__HOURLY='100'
-  hourly: 100
+  hourly: 200
 
   # ..maximum number of allowed HTTP requests per minute
   #
@@ -635,10 +635,10 @@ throttling:
 
   # ..maximum number of allowed HTTP requests per second
   #
-  # Default: 2
+  # Default: 3
   #
   # Environment Variable Override: PWP__THROTTLING__SECOND='2'
-  second: 2
+  second: 3
 
 
 ### Mail Server Configuration

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -614,17 +614,17 @@ brand:
 throttling:
   # ..maximum number of allowed HTTP requests per day
   #
-  # Default: 1000
+  # Default: 5000
   #
   # Environment Variable Override: PWP__THROTTLING__DAILY='1000'
-  daily: 1000
+  daily: 5000
 
   # ..maximum number of allowed HTTP requests per hour
   #
-  # Default: 100
+  # Default: 200
   #
   # Environment Variable Override: PWP__THROTTLING__HOURLY='100'
-  hourly: 100
+  hourly: 200
 
   # ..maximum number of allowed HTTP requests per minute
   #
@@ -635,10 +635,10 @@ throttling:
 
   # ..maximum number of allowed HTTP requests per second
   #
-  # Default: 2
+  # Default: 3
   #
   # Environment Variable Override: PWP__THROTTLING__SECOND='2'
-  second: 2
+  second: 3
 
 
 ### Mail Server Configuration


### PR DESCRIPTION
## Description

Increase the default throttling thresholds.

This is useful when people apply site monitors that ping the site often.

Fixes #1107

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
