### PR TITLE
Fix: Dark theme regression with updated Bootstrap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem "terser", "~> 1.1"
 gem 'json', '~> 2.0' # Legacy carry-over
 gem 'will_paginate', '~> 4.0.0'
 gem 'will_paginate-bootstrap-style'
-gem 'bootstrap', '~> 5.3'
+gem 'bootstrap', '5.2.3'
 
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem "turbo-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,9 +132,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
-    bootstrap (5.3.1)
+    bootstrap (5.2.3)
       autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 2.11.8, < 3)
+      popper_js (>= 2.11.6, < 3)
       sassc-rails (>= 2.0.0)
     builder (3.2.4)
     capybara (3.39.2)
@@ -558,7 +558,7 @@ DEPENDENCIES
   aws-sdk-s3
   azure-storage-blob (~> 2.0)
   bootsnap (>= 1.4.4)
-  bootstrap (~> 5.3)
+  bootstrap (= 5.2.3)
   capybara (>= 3.37.1, < 4.0)
   config
   debase (>= 0.2.5.beta2)


### PR DESCRIPTION
## Description

The latest bootstrap gem update breaks the dark theme on pwpush.com.   Until I update the theme to follow recent bootstrap changes we will limit the bootstrap gem to 5.2.3.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
