### PR TITLE
Fix: Increase default throttle limits

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -616,29 +616,29 @@ throttling:
   #
   # Default: 5000
   #
-  # Environment Variable Override: PWP__THROTTLING__DAILY='1000'
+  # Environment Variable Override: PWP__THROTTLING__DAILY='5000'
   daily: 5000
 
   # ..maximum number of allowed HTTP requests per hour
   #
-  # Default: 200
+  # Default: 600
   #
-  # Environment Variable Override: PWP__THROTTLING__HOURLY='100'
-  hourly: 200
+  # Environment Variable Override: PWP__THROTTLING__HOURLY='600'
+  hourly: 600
 
   # ..maximum number of allowed HTTP requests per minute
   #
-  # Default: 30
+  # Default: 60
   #
-  # Environment Variable Override: PWP__THROTTLING__MINUTE='30'
-  minute: 30
+  # Environment Variable Override: PWP__THROTTLING__MINUTE='60'
+  minute: 60
 
   # ..maximum number of allowed HTTP requests per second
   #
-  # Default: 3
+  # Default: 20
   #
-  # Environment Variable Override: PWP__THROTTLING__SECOND='2'
-  second: 3
+  # Environment Variable Override: PWP__THROTTLING__SECOND='20'
+  second: 20
 
 
 ### Mail Server Configuration

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -616,29 +616,29 @@ throttling:
   #
   # Default: 5000
   #
-  # Environment Variable Override: PWP__THROTTLING__DAILY='1000'
+  # Environment Variable Override: PWP__THROTTLING__DAILY='5000'
   daily: 5000
 
   # ..maximum number of allowed HTTP requests per hour
   #
-  # Default: 200
+  # Default: 600
   #
-  # Environment Variable Override: PWP__THROTTLING__HOURLY='100'
-  hourly: 200
+  # Environment Variable Override: PWP__THROTTLING__HOURLY='600'
+  hourly: 600
 
   # ..maximum number of allowed HTTP requests per minute
   #
-  # Default: 30
+  # Default: 60
   #
-  # Environment Variable Override: PWP__THROTTLING__MINUTE='30'
-  minute: 30
+  # Environment Variable Override: PWP__THROTTLING__MINUTE='60'
+  minute: 60
 
   # ..maximum number of allowed HTTP requests per second
   #
-  # Default: 3
+  # Default: 20
   #
-  # Environment Variable Override: PWP__THROTTLING__SECOND='2'
-  second: 3
+  # Environment Variable Override: PWP__THROTTLING__SECOND='20'
+  second: 20
 
 
 ### Mail Server Configuration


### PR DESCRIPTION
## Description

This PR increases the default throttle limits.

It was found that for file uploads, the per second throttling limits were being hit.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [X] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
