### PR TITLE
Changes to enable workflow dispatch for 'build' github action

### DIFF
--- a/.github/workflows/docker-containers.yml
+++ b/.github/workflows/docker-containers.yml
@@ -8,12 +8,18 @@ on:
       - "v*.*.*"
 
   workflow_dispatch:
-
+    inputs:
+      dockerPush:
+        description: 'Push image to docker hub?'
+        required: true
+        type: boolean
+        default: false
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Run every day at 5:24 UTC - build 'latest' docker containers
     - cron: "24 17 * * *"
-
+env:
+  DOCKER_PUSH: true
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -35,11 +41,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set DOCKER_PUSH for workflow_dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: echo "DOCKER_PUSH=${{ github.event.inputs.dockerPush }}" >> $GITHUB_ENV
+
+      - name: Set DOCKER_PUSH for workflow_dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: echo "DOCKER_PUSH=${{ github.event.inputs.dockerPush }}" >> $GITHUB_ENV
+
       - name: Populate Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: pglombardo/pwpush-${{ matrix.dbType }}
+          images: ${{ secrets.DOCKER_USERNAME }}/pwpush-${{ matrix.dbType }}
           flavor: |
             latest=false
           tags: |
@@ -49,9 +63,11 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=semver,pattern=latest
+            type=sha
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
+        if: ${{env.DOCKER_PUSH == 'true'}}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -62,8 +78,8 @@ jobs:
           file: ./containers/docker/pwpush-${{ matrix.dbType }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           provenance: false
-          push: true
+          push: ${{env.DOCKER_PUSH == 'true'}}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-${{ matrix.dbType }}:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-${{ matrix.dbType }}:buildcache,mode=max
+          cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-${{ matrix.dbType }}:buildcache,mode=max,ignore-error=${{env.DOCKER_PUSH == 'false'}}

--- a/.github/workflows/docker-containers.yml
+++ b/.github/workflows/docker-containers.yml
@@ -45,10 +45,6 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: echo "DOCKER_PUSH=${{ github.event.inputs.dockerPush }}" >> $GITHUB_ENV
 
-      - name: Set DOCKER_PUSH for workflow_dispatch
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: echo "DOCKER_PUSH=${{ github.event.inputs.dockerPush }}" >> $GITHUB_ENV
-
       - name: Populate Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -63,7 +59,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=semver,pattern=latest
-            type=sha
+            type=sha,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
This PR reenables the option to use workflow dispatch for `build` action.


## Description

It's now allowed to run workflow dispatch at anytime with or without pushing to docker hub.

In current state the tag for the image is set by its commits SHA.

Additionally due to caching and if using in an fork it's necessary to have:
- `secrets.DOCKER_USERNAME` set according to docker hub account. 
(if not pushing pushing to docker hub it only needs some random value)
- `secrets.DOCKER_PASSWORD` set according to docker hub account. 
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
https://github.com/pglombardo/PasswordPusher/pull/1369#issuecomment-1713656580

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
