### PR TITLE
Fix typo for Language title on `Configuration.md`

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -394,7 +394,7 @@ PWP__BRAND__LIGHT_LOGO=/logos/mylogo.png
 * the `brand` section of [settings.yml](https://github.com/pglombardo/PasswordPusher/blob/master/config/settings.yml) for more details, examples and description.
 * [this issue comment](https://github.com/pglombardo/PasswordPusher/issues/432#issuecomment-1282158006) on how to mount images into the contianer and set your environment variables accordingly
 
-# Change the Default Lanugage
+# Change the Default Language
 
 The application comes with more than 24 languages bundled in which are selectable inside the application.  The default language of the application is English.  If you would like to change this default language, simply set the following environment variable for your application.
 


### PR DESCRIPTION
## Description

Typo on [Configuration.md](https://github.com/pglombardo/PasswordPusher/blob/master/Configuration.md)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [X] I've added documentation as necessary so users can easily use and understand this feature/fix.
