### PR TITLE
refactor(dockerfile): move layers around for speed improvement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -616,4 +616,4 @@ RUBY VERSION
    ruby 3.1.4p223
 
 BUNDLED WITH
-   2.4.18
+   2.4.10

--- a/containers/docker/pwpush/Dockerfile
+++ b/containers/docker/pwpush/Dockerfile
@@ -14,12 +14,22 @@ ARG BUNDLE_DEPLOYMENT
 LABEL org.opencontainers.image.authors ='pglombardo@hey.com'
 
 # Required packages
-RUN apk add --no-cache build-base git curl tzdata zlib-dev nodejs yarn libc6-compat sqlite-dev mariadb-dev libpq-dev
+RUN apk add --no-cache \
+    build-base \
+    curl \
+    git \
+    libc6-compat \
+    libpq-dev \
+    mariadb-dev \
+    nodejs \
+    sqlite-dev \
+    tzdata \
+    yarn
 
 ENV APP_ROOT=/opt/PasswordPusher
 
 WORKDIR ${APP_ROOT}
-COPY ./ ${APP_ROOT}/
+COPY Gemfile Gemfile.lock package.json yarn.lock ./
 
 ENV RACK_ENV=production RAILS_ENV=production
 
@@ -29,6 +39,8 @@ RUN bundle config set without "${BUNDLE_WITHOUT}" \
     && bundle install
 
 RUN yarn install
+
+COPY ./ ${APP_ROOT}/
 
 # Set DATABASE_URL to sqlite to have a ready
 # to use db file for ephemeral configuration
@@ -53,7 +65,14 @@ ARG BUNDLE_DEPLOYMENT
 LABEL maintainer='pglombardo@hey.com'
 
 # install packages
-RUN apk add --no-cache tzdata bash nodejs libc6-compat sqlite-dev mariadb-connector-c libpq
+RUN apk add --no-cache \
+    bash \
+    libc6-compat \
+    libpq \
+    mariadb-connector-c \
+    nodejs \
+    sqlite-dev \
+    tzdata
 
 # Create a user and group to run the application
 ARG UID=1000


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Working #1509 was a bit too slow when the layers were in the old order.  `COPY ./ .` early in will result to always needing to build the deps.

Even updated `Gemfile.lock` to the version inside the container, again to limit the need for rebuild.

And, do we really need `ENV LC_CTYPE=UTF-8 LC_ALL=en_US.UTF-8`?  I see no docs on why.  Upstream already sets UTF-8 https://github.com/docker-library/ruby/blob/31c1fdba369192fe2c3cf327d7d98819edc1400b/3.2/alpine3.18/Dockerfile#L28

Ed1t: I also put the packages on separate lines so it's easier to see what is installed.  I personally prefer this as a way to always have control what is installed.  That way you can look for similarities, etc. for improving the container images.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
