### PR TITLE
fix: add option to not show version in footer

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -86,6 +86,7 @@ Notes:
 | --------- | ------------------ | --- |
 | PWP__DEFAULT_LOCALE | Sets the default language for the application.  See the [documentation](https://github.com/pglombardo/PasswordPusher#internationalization). | `en` |
 | PWP__RELATIVE_ROOT | Runs the application in a subfolder.  e.g. With a value of `pwp` the front page will then be at `https://url/pwp` | `Not set` |
+| PWP__SHOW_VERSION | Show the version in the footer | `true` |
 
 ## Password Push Expiration Settings
 
@@ -500,7 +501,7 @@ services:
 
 Remember that when doing this, this new CSS code has to be precompiled.
 
-To do this in Docker containers, simply set the environment variable `PWP_PRECOMPILE=true`.  For source code, run `bin/rails assets:precompile`.  This compilation process will incorporate the custom CSS into the updated site theme. 
+To do this in Docker containers, simply set the environment variable `PWP_PRECOMPILE=true`.  For source code, run `bin/rails assets:precompile`.  This compilation process will incorporate the custom CSS into the updated site theme.
 
 # Google Analytics
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="footer mt-auto py-3">
   <div class="container">
     <div class="d-flex flex-wrap justify-content-between align-items-center py-3 my-4 border-top">
-      <p class="col-md-5 mb-0 text-muted">&copy; 2023 <%= _('Peter') %> Giacomo Lombardo, v<%= Version.current %></p>
+      <p class="col-md-5 mb-0 text-muted">&copy; 2023 <%= _('Peter') %> Giacomo Lombardo<% if Settings.show_version %>, v<%= Version.current %><% end %></p>
 
       <%= link_to root_path(locale: locale.to_s), class: "col-md-2 d-flex align-items-center justify-content-center mb-3 mb-md-0 me-md-auto link-dark text-decoration-none" do %>
         <picture>

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -138,6 +138,17 @@ host_protocol: 'https'
 #
 # override_base_url: 'https://pwpush.mydomain.com'
 
+### Show version on the footer
+#
+# Enable/disable PasswordPusher verison on the footer.
+#
+# Environment variable override:
+# PWP__SHOW_VERSION=true
+#
+# Default: true
+
+show_version: true
+
 ### Allowed Hosts
 #
 # This is a list of allowed hosts for the application.  This is used to

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -138,6 +138,17 @@ host_protocol: 'https'
 #
 # override_base_url: 'https://pwpush.mydomain.com'
 
+### Show version on the footer
+#
+# Enable/disable PasswordPusher verison on the footer.
+#
+# Environment variable override:
+# PWP__SHOW_VERSION=true
+#
+# Default: true
+
+show_version: true
+
 ### Allowed Hosts
 #
 # This is a list of allowed hosts for the application.  This is used to

--- a/containers/examples/pwpush-and-nginx/env-file
+++ b/containers/examples/pwpush-and-nginx/env-file
@@ -12,8 +12,10 @@ export PWP__MAIL__SMTP_STARTTLS=true
 export PWP__MAIL__OPEN_TIMEOUT=10
 export PWP__MAIL__READ_TIMEOUT=10
 export PWP__HOST_DOMAIN=localhost.dev
-export PWP__HOST_PROTOCOL=https 
+export PWP__HOST_PROTOCOL=https
 export PWP__MAIL__MAILER_SENDER='"Your Name" <name@mydomain.com>'
+
+export PWP__SHOW_VERSION=false
 
 export PWP__ENABLE_FILE_PUSHES=true
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Build upon https://github.com/pglombardo/PasswordPusher/pull/1511.  Add the option to disable showing the version number in the footer.  Enabled by default.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [x] I've added documentation as necessary so users can easily use and understand this feature/fix.
