### PR TITLE
Revise zh-CN label in application language menu

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -805,7 +805,7 @@ language_codes:
   th: 'ไทย'
   uk: 'Українська'
   ur: 'اردو'
-  zh-CN: '中国人'
+  zh-CN: '中文'
 
 # Used internally for the language selector model.
 # This provides a conversion of language codes to

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -805,7 +805,7 @@ language_codes:
   th: 'ไทย'
   uk: 'Українська'
   ur: 'اردو'
-  zh-CN: '中国人'
+  zh-CN: '中文'
 
 # Used internally for the language selector model.
 # This provides a conversion of language codes to


### PR DESCRIPTION
## Description

Revise the application's language menu by replacing the "zh-CN" label with '中文' to avoid confusion. 

中国人 - Refers to people from China or of Chinese descent.
中文 - Refers to the Chinese language.

## Related Issue

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
