### PR TITLE
Use prebuild 'simple_token_authentication' gem and remove database backend groups in Gemfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 .github
 .env*
 .dockerenv*
+tmp/

--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -62,7 +62,6 @@ jobs:
         run: |
           gem install bundler
           bundle config path vendor/bundle
-          bundle config set with 'sqlite'
           bundle install --jobs 4 --retry 3
           yarn install --frozen-lockfile
       - name: Run tests

--- a/Gemfile
+++ b/Gemfile
@@ -90,8 +90,7 @@ gem 'mail_form', '>= 1.9.0'
 gem 'oj'
 gem 'puma'
 gem 'rollbar'
-gem 'simple_token_authentication', '~> 1.18', '>= 1.18.0',
-    git: 'https://github.com/pglombardo/simple_token_authentication.git', branch: 'rails7-support'
+gem 'simple_token_authentication'
 
 gem 'devise-i18n'
 gem 'i18n-tasks', '~> 1.0.13'
@@ -107,17 +106,10 @@ gem 'google-cloud-storage', '~> 1.45', require: false
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
-group :postgres, optional: true do
-  gem 'pg'
-end
-
-group :mysql, optional: true do
-  gem 'mysql2'
-end
-
-group :sqlite, optional: true do
-  gem 'sqlite3', force_ruby_platform: true
-end
+# Database backends
+gem 'mysql2'
+gem 'pg'
+gem 'sqlite3', force_ruby_platform: true
 
 group :production, :private do
   gem 'rack-throttle', '0.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,4 @@
 GIT
-  remote: https://github.com/pglombardo/simple_token_authentication.git
-  revision: 47db3936689c5d93b4226f85c3ca71c182ec0580
-  branch: rails7-support
-  specs:
-    simple_token_authentication (1.18.0)
-      actionmailer (>= 3.2.6, < 8)
-      actionpack (>= 3.2.6, < 8)
-      active_model_serializers
-      activemodel-serializers-xml
-      devise (>= 3.2, < 6)
-
-GIT
   remote: https://github.com/pglombardo/version.git
   revision: 97678e0068542fb919f909b0d3a9e853ec7a24c2
   branch: master
@@ -69,20 +57,11 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    active_model_serializers (0.10.14)
-      actionpack (>= 4.1)
-      activemodel (>= 4.1)
-      case_transform (>= 0.2)
-      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (7.1.2)
       activesupport (= 7.1.2)
       globalid (>= 0.3.6)
     activemodel (7.1.2)
       activesupport (= 7.1.2)
-    activemodel-serializers-xml (1.0.2)
-      activemodel (> 5.x)
-      activesupport (> 5.x)
-      builder (~> 3.1)
     activerecord (7.1.2)
       activemodel (= 7.1.2)
       activesupport (= 7.1.2)
@@ -163,8 +142,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    case_transform (0.2)
-      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     config (5.0.0)
@@ -321,7 +298,6 @@ GEM
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
     json (2.6.3)
-    jsonapi-renderer (0.2.2)
     jwt (2.7.1)
     kramdown (2.4.0)
       rexml
@@ -530,6 +506,10 @@ GEM
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    simple_token_authentication (1.18.1)
+      actionmailer (>= 3.2.6, < 8)
+      actionpack (>= 3.2.6, < 8)
+      devise (>= 3.2, < 6)
     singleton (0.2.0)
     smart_properties (1.17.0)
     sprockets (4.2.1)
@@ -635,7 +615,7 @@ DEPENDENCIES
   ruby-debug-ide
   sass-rails (~> 6.0, >= 6.0.0)
   selenium-webdriver
-  simple_token_authentication (~> 1.18, >= 1.18.0)!
+  simple_token_authentication
   sqlite3
   stimulus-rails
   terser (~> 1.1)

--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ gem install bundler
 
 export RAILS_ENV=private
 
-bundle config set with 'sqlite'
 bundle config set --local deployment 'true'
 bundle install --without development production test
 ./bin/rails assets:precompile
@@ -202,7 +201,6 @@ export RAILS_ENV=production
 # Update the following line to point to your Postgres (or MySQL/Mariadb) instance
 DATABASE_URL=postgresql://passwordpusher_user:passwordpusher_passwd@postgres:5432/passwordpusher_db
 
-bundle config set with 'postgres' # or 'mysql'
 bundle install --without development private test
 ./bin/rails assets:precompile
 ./bin/rails db:setup

--- a/containers/docker/pwpush/Dockerfile
+++ b/containers/docker/pwpush/Dockerfile
@@ -1,12 +1,10 @@
 # Setting global arguments
-ARG BUNDLE_WITH=sqlite:mysql:postgres
 ARG BUNDLE_WITHOUT=development:test:private
 ARG BUNDLE_DEPLOYMENT=true
 
 FROM ruby:3.2-alpine AS build-env
 
 # include global args
-ARG BUNDLE_WITH
 ARG BUNDLE_WITHOUT
 ARG BUNDLE_DEPLOYMENT
 
@@ -34,7 +32,6 @@ ENV RACK_ENV=production RAILS_ENV=production
 
 RUN bundle config set without "${BUNDLE_WITHOUT}" \
     && bundle config set deployment "${BUNDLE_DEPLOYMENT}" \
-    && bundle config set with "${BUNDLE_WITH}" \
     && bundle install
 
 RUN yarn install
@@ -57,7 +54,6 @@ RUN rm -rf node_modules tmp/cache vendor/assets spec \
 FROM ruby:3.2-alpine
 
 # include global args
-ARG BUNDLE_WITH
 ARG BUNDLE_WITHOUT
 ARG BUNDLE_DEPLOYMENT
 
@@ -88,7 +84,6 @@ ENV RACK_ENV=production RAILS_ENV=production
 COPY --from=build-env --chown=pwpusher:pwpusher ${APP_ROOT} ${APP_ROOT}
 
 RUN bundle config set without "${BUNDLE_WITHOUT}" \
-    && bundle config set with "${BUNDLE_WITH}" \
     && bundle config set deployment "${BUNDLE_DEPLOYMENT}"
 
 USER pwpusher


### PR DESCRIPTION
## Description
This PR:
1) Switches back to the prebuild `simple_token_authentication` gem. 
Rails 7 support got merged on upstream. No further reason to use forked version. 
2) Database groups `sqlite`, `mysql2` and `postgres` seem to obsolete due the #1369.
Removed and fix locations where they where used.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
