### PR TITLE
Timezones: Add option to set application default Timezone

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -88,6 +88,9 @@ Notes:
 | PWP__RELATIVE_ROOT | Runs the application in a subfolder.  e.g. With a value of `pwp` the front page will then be at `https://url/pwp` | `Not set` |
 | PWP__SHOW_VERSION | Show the version in the footer | `true` |
 | PWP__SHOW_GDPR_CONSENT_BANNER | Optionally enable or disable the GDPR cookie consent banner. | `true` |
+| PWP__TIMEZONE | Set the application wide timezone.  Use a valid timezone string (see note below). | `America/New_York` |
+
+_Note__: The list of valid timezone strings can be found at [https://en.wikipedia.org/wiki/List_of_tz_database_time_zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
 ## Password Push Expiration Settings
 

--- a/app/views/file_pushes/active.html.erb
+++ b/app/views/file_pushes/active.html.erb
@@ -33,7 +33,7 @@
       <% for push in @pushes do %>
         <tr>
           <td><%= push.url_token %></td>
-          <td><%= I18n.l push.created_at, format: :long %></td>
+          <td><%= I18n.l push.created_at.in_time_zone(Settings.timezone), format: :long %></td>
           <td>
             <% if push.note.blank? %>
               <span class='text-muted'><%= _('None') %></span>

--- a/app/views/file_pushes/audit.html.erb
+++ b/app/views/file_pushes/audit.html.erb
@@ -3,7 +3,7 @@
 <div class="d-flex flex-column justify-content-center align-items-center">
     <h4 class=''><%= _('Audit Log for File Push') %> <code><%= @push.url_token %></code></h4>
     <p class='text-muted mb-5'>
-        <%= _('Pushed on %s') % I18n.l(@push.created_at, format: :long) %>
+        <%= _('Pushed on %s') % I18n.l(@push.created_at.in_time_zone(Settings.timezone), format: :long) %>
     </p>
 
     <p><%= _('Secret URL for this push') %>:</p>
@@ -230,7 +230,7 @@
                 <div class="list-group-item list-group-item-action list-group-item-secondary"><%= _('Start of Audit Log') %></div>
                 <div class="list-group-item list-group-item-action list-group-item-primary">
                     <em class="bi bi-stars"></em>
-                    <%= _('Push created on') %> <%= I18n.l @push.created_at %> by <%= @push.user.email %>
+                    <%= _('Push created on') %> <%= I18n.l @push.created_at.in_time_zone(Settings.timezone) %> by <%= @push.user.email %>
                 </div>
 
                 <% if @push.views.empty? && !@push.expired %>
@@ -248,7 +248,7 @@
                                 <strong><%= view.user.email %></strong>
                                 <%= _('at IP address') %> <strong><%= view.ip %></strong>
                                 <%= _('on') %>
-                                <%= I18n.l view.created_at %>
+                                <%= I18n.l view.created_at.in_time_zone(Settings.timezone) %>
                             <% end %>
                             <br/>
                             <%= _('The push content has been deleted and the secret URL expired.') %>
@@ -263,7 +263,7 @@
                             <%= _('Successful view from IP address') %>
                             <strong><%= view.ip %></strong>
                             <%= _('on') %>
-                            <%= I18n.l view.created_at %>
+                            <%= I18n.l view.created_at.in_time_zone(Settings.timezone) %>
                             <br/>
                             <%= _('User Agent') %>: <code><%= view.user_agent %></code>
                             <br/>
@@ -275,7 +275,7 @@
                             <%= _('Failed view attempt (already expired) by') %>
                             <strong><%= view.ip %></strong>
                             <%= _('on') %>
-                            <%= I18n.l view.created_at %>
+                            <%= I18n.l view.created_at.in_time_zone(Settings.timezone) %>
                             <br/>
                             <%= _('User Agent') %>: <code><%= view.user_agent %></code>
                             <br/>

--- a/app/views/file_pushes/expired.html.erb
+++ b/app/views/file_pushes/expired.html.erb
@@ -35,7 +35,7 @@
               </div>
             <% end %>
           </td>
-          <td><%= I18n.l push.expired_on, format: :long %></td>
+          <td><%= I18n.l push.expired_on.in_time_zone(Settings.timezone), format: :long %></td>
           <td class="text-center">
               <%= link_to audit_file_push_path(push), class: 'btn btn-info btn-sm', rel: 'nofollow' do %>
                 <%= _('Audit Log') %>

--- a/app/views/passwords/active.html.erb
+++ b/app/views/passwords/active.html.erb
@@ -32,7 +32,7 @@
       <% for push in @pushes do %>
         <tr>
           <td><%= push.url_token %></td>
-          <td><%= I18n.l push.created_at, format: :long %></td>
+          <td><%= I18n.l push.created_at.in_time_zone(Settings.timezone), format: :long %></td>
           <td>
             <% if push.note.blank? %>
               <span class='text-muted'><%= _('None') %></span>

--- a/app/views/passwords/audit.html.erb
+++ b/app/views/passwords/audit.html.erb
@@ -3,7 +3,7 @@
 <div class="d-flex flex-column justify-content-center align-items-center">
     <h4 class=''><%= _('Audit Log for Password Push') %> <code><%= @push.url_token %></code></h4>
     <p class='text-muted mb-5'>
-        <%= _('Pushed on %s') % I18n.l(@push.created_at, format: :long) %>
+        <%= _('Pushed on %s') % I18n.l(@push.created_at.in_time_zone(Settings.timezone), format: :long) %>
     </p>
 
     <p><%= _('Secret URL for this push') %>:</p>
@@ -161,7 +161,7 @@
                 <div class="list-group-item list-group-item-action list-group-item-secondary"><%= _('Start of Audit Log') %></div>
                 <div class="list-group-item list-group-item-action list-group-item-primary">
                     <em class="bi bi-stars"></em>
-                    <%= _('Push created on') %> <%= I18n.l @push.created_at %> by <%= @push.user.email %>
+                    <%= _('Push created on') %> <%= I18n.l @push.created_at.in_time_zone(Settings.timezone) %> by <%= @push.user.email %>
                 </div>
 
                 <% if @push.views.empty? && !@push.expired %>
@@ -179,7 +179,7 @@
                                 <strong><%= view.user.email %></strong>
                                 <%= _('at IP address') %> <strong><%= view.ip %></strong>
                                 <%= _('on') %>
-                                <%= I18n.l view.created_at %>
+                                <%= I18n.l view.created_at.in_time_zone(Settings.timezone) %>
                             <% else %>
                                 <%= _('Password manually expired by an anonymous user') %>
                             <% end %>
@@ -197,7 +197,7 @@
                             <%= _('Successful view from IP address') %>
                             <strong><%= view.ip %></strong>
                             <%= _('on') %>
-                            <%= I18n.l view.created_at %>
+                            <%= I18n.l view.created_at.in_time_zone(Settings.timezone) %>
                             <br/>
                             <%= _('User Agent') %>: <code><%= view.user_agent %></code>
                             <br/>
@@ -209,7 +209,7 @@
                             <%= _('Failed view attempt (already expired) by') %>
                             <strong><%= view.ip %></strong>
                             <%= _('on') %>
-                            <%= I18n.l view.created_at %>
+                            <%= I18n.l view.created_at.in_time_zone(Settings.timezone) %>
                             <br/>
                             <%= _('User Agent') %>: <code><%= view.user_agent %></code>
                             <br/>

--- a/app/views/passwords/expired.html.erb
+++ b/app/views/passwords/expired.html.erb
@@ -36,7 +36,7 @@
               </div>
             <% end %>
           </td>
-          <td><%= I18n.l push.expired_on, format: :long %></td>
+          <td><%= I18n.l push.expired_on.in_time_zone(Settings.timezone), format: :long %></td>
           <td class="text-center">
               <%= link_to audit_password_path(push), class: 'btn btn-info btn-sm w-100', rel: 'nofollow' do %>
                 <%= _('Audit Log') %>

--- a/app/views/urls/active.html.erb
+++ b/app/views/urls/active.html.erb
@@ -32,7 +32,7 @@
       <% for push in @pushes do %>
         <tr>
           <td><%= push.url_token %></td>
-          <td><%= I18n.l push.created_at, format: :long %></td>
+          <td><%= I18n.l push.created_at.in_time_zone(Settings.timezone), format: :long %></td>
           <td>
             <% if push.note.blank? %>
               <span class='text-muted'><%= _('None') %></span>

--- a/app/views/urls/audit.html.erb
+++ b/app/views/urls/audit.html.erb
@@ -3,7 +3,7 @@
 <div class="d-flex flex-column justify-content-center align-items-center">
     <h4 class=''><%= _('Audit Log for URL Push') %> <code><%= @push.url_token %></code></h4>
     <p class='text-muted mb-5'>
-        <%= _('Pushed on %s') % I18n.l(@push.created_at, format: :long) %>
+        <%= _('Pushed on %s') % I18n.l(@push.created_at.in_time_zone(Settings.timezone), format: :long) %>
     </p>
 
     <p><%= _('Secret URL for this push') %>:</p>
@@ -148,7 +148,7 @@
                 <div class="list-group-item list-group-item-action list-group-item-secondary"><%= _('Start of Audit Log') %></div>
                 <div class="list-group-item list-group-item-action list-group-item-primary">
                     <em class="bi bi-stars"></em>
-                    <%= _('Push created on') %> <%= I18n.l @push.created_at %> by <%= @push.user.email %>
+                    <%= _('Push created on') %> <%= I18n.l @push.created_at.in_time_zone(Settings.timezone) %> by <%= @push.user.email %>
                 </div>
 
                 <% if @push.views.empty? && !@push.expired %>
@@ -179,7 +179,7 @@
                             <%= _('Successful view from IP address') %>
                             <strong><%= view.ip %></strong>
                             <%= _('on') %>
-                            <%= I18n.l view.created_at %>
+                            <%= I18n.l view.created_at.in_time_zone(Settings.timezone) %>
                             <br/>
                             <%= _('User Agent') %>: <code><%= view.user_agent %></code>
                             <br/>
@@ -191,7 +191,7 @@
                             <%= _('Failed view attempt (already expired) by') %>
                             <strong><%= view.ip %></strong>
                             <%= _('on') %>
-                            <%= I18n.l view.created_at %>
+                            <%= I18n.l view.created_at.in_time_zone(Settings.timezone) %>
                             <br/>
                             <%= _('User Agent') %>: <code><%= view.user_agent %></code>
                             <br/>

--- a/app/views/urls/expired.html.erb
+++ b/app/views/urls/expired.html.erb
@@ -35,7 +35,7 @@
               </div>
             <% end %>
           </td>
-          <td><%= I18n.l push.expired_on, format: :long %></td>
+          <td><%= I18n.l push.expired_on.in_time_zone(Settings.timezone), format: :long %></td>
           <td class="text-center">
               <%= link_to audit_url_path(push), class: 'btn btn-info btn-sm', rel: 'nofollow' do %>
                 <%= _('Audit Log') %>

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -158,6 +158,18 @@ show_version: true
 # Default: true
 show_gdpr_consent_banner: true
 
+### Timezone
+#
+# Set the timezone for the application.  A full list of timezone strings
+# can be found here:
+# https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+#
+# Environment variable override:
+# PWP__TIMEZONE='America/New_York'
+#
+# Default: 'America/New_York'
+timezone: 'America/New_York'
+
 ### Allowed Hosts
 #
 # This is a list of allowed hosts for the application.  This is used to

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -158,6 +158,18 @@ show_version: true
 # Default: true
 show_gdpr_consent_banner: true
 
+### Timezone
+#
+# Set the timezone for the application.  A full list of timezone strings
+# can be found here:
+# https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+#
+# Environment variable override:
+# PWP__TIMEZONE='America/New_York'
+#
+# Default: 'America/New_York'
+timezone: 'America/New_York'
+
 ### Allowed Hosts
 #
 # This is a list of allowed hosts for the application.  This is used to


### PR DESCRIPTION
## Description

This add a new option to the `settings.yml` to set the application wide
timezone.

Modify that file or set `PWP__TIMEZONE` to a valid timezone string.  The list of valid
timezone strings can be found here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

## Related Issue

#345

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [x] I've added documentation as necessary so users can easily use and understand this feature/fix.
