### PR TITLE
DOCKER: Insert end-of-support notice into obsolete docker images

### DIFF
--- a/containers/docker/pwpush-ephemeral/Dockerfile
+++ b/containers/docker/pwpush-ephemeral/Dockerfile
@@ -5,16 +5,17 @@
 ARG BASEIMAGE=pwpush:latest
 FROM $BASEIMAGE
 
-# Insert decrecation note to inform users while spinning up containers
+# Insert end of support note to inform users while spinning up containers
 RUN sed -i '5 a \
             echo "          ##########################################################################          "\n \
-            echo "          ###                   !!DEPRECATION NOTIFICATION!!                     ###          "\n \
-            echo "          ###  THIS IMAGE IS DEPRECATED. SUPPORT FOR THIS IMAGE WILL BE DROPPED  ###          "\n \
-            echo "          ###         IN THE NEAR FUTURE. PLEASE MIGRATE TO THE NEW IMAGE        ###          "\n \
+            echo "          ###                 !!END OF SUPPORT NOTIFICATION!!                    ###          "\n \
+            echo "          ###            THIS IMAGE HAS REACHED END-OF-SUPPORT STATE.            ###          "\n \
+            echo "          ###       THERE WILL BE NO MORE NEW FEATURES OR SECURITY UPDATES.      ###          "\n \
+            echo "          ###        PLEASE MIGRATE TO THE NEW IMAGE AS SOON AS POSSIBLE.        ###          "\n \
             echo "          ###                                                                    ###          "\n \
             echo "          ###                      FOR MORE INFORMATION GOTO                     ###          "\n \
             echo "          ###            https://github.com/pglombardo/PasswordPusher            ###          "\n \
-            echo "          ###                   !!DEPRECATION NOTIFICATION!!                     ###          "\n \
+            echo "          ###                 !!END OF SUPPORT NOTIFICATION!!                    ###          "\n \
             echo "          ##########################################################################          "\n \
             ' ./containers/docker/pwpush/entrypoint.sh
 

--- a/containers/docker/pwpush-mysql/Dockerfile
+++ b/containers/docker/pwpush-mysql/Dockerfile
@@ -5,16 +5,17 @@
 ARG BASEIMAGE=pwpush:latest
 FROM $BASEIMAGE
 
-# Insert decrecation note to inform users while spinning up containers
+# Insert end of support note to inform users while spinning up containers
 RUN sed -i '5 a \
             echo "          ##########################################################################          "\n \
-            echo "          ###                   !!DEPRECATION NOTIFICATION!!                     ###          "\n \
-            echo "          ###  THIS IMAGE IS DEPRECATED. SUPPORT FOR THIS IMAGE WILL BE DROPPED  ###          "\n \
-            echo "          ###         IN THE NEAR FUTURE. PLEASE MIGRATE TO THE NEW IMAGE        ###          "\n \
+            echo "          ###                 !!END OF SUPPORT NOTIFICATION!!                    ###          "\n \
+            echo "          ###            THIS IMAGE HAS REACHED END-OF-SUPPORT STATE.            ###          "\n \
+            echo "          ###       THERE WILL BE NO MORE NEW FEATURES OR SECURITY UPDATES.      ###          "\n \
+            echo "          ###        PLEASE MIGRATE TO THE NEW IMAGE AS SOON AS POSSIBLE.        ###          "\n \
             echo "          ###                                                                    ###          "\n \
             echo "          ###                      FOR MORE INFORMATION GOTO                     ###          "\n \
             echo "          ###            https://github.com/pglombardo/PasswordPusher            ###          "\n \
-            echo "          ###                   !!DEPRECATION NOTIFICATION!!                     ###          "\n \
+            echo "          ###                 !!END OF SUPPORT NOTIFICATION!!                    ###          "\n \
             echo "          ##########################################################################          "\n \
             ' ./containers/docker/pwpush/entrypoint.sh
 

--- a/containers/docker/pwpush-postgres/Dockerfile
+++ b/containers/docker/pwpush-postgres/Dockerfile
@@ -5,16 +5,17 @@
 ARG BASEIMAGE=pwpush:latest
 FROM $BASEIMAGE
 
-# Insert decrecation note to inform users while spinning up containers
+# Insert end of support note to inform users while spinning up containers
 RUN sed -i '5 a \
             echo "          ##########################################################################          "\n \
-            echo "          ###                   !!DEPRECATION NOTIFICATION!!                     ###          "\n \
-            echo "          ###  THIS IMAGE IS DEPRECATED. SUPPORT FOR THIS IMAGE WILL BE DROPPED  ###          "\n \
-            echo "          ###         IN THE NEAR FUTURE. PLEASE MIGRATE TO THE NEW IMAGE        ###          "\n \
+            echo "          ###                 !!END OF SUPPORT NOTIFICATION!!                    ###          "\n \
+            echo "          ###            THIS IMAGE HAS REACHED END-OF-SUPPORT STATE.            ###          "\n \
+            echo "          ###       THERE WILL BE NO MORE NEW FEATURES OR SECURITY UPDATES.      ###          "\n \
+            echo "          ###        PLEASE MIGRATE TO THE NEW IMAGE AS SOON AS POSSIBLE.        ###          "\n \
             echo "          ###                                                                    ###          "\n \
             echo "          ###                      FOR MORE INFORMATION GOTO                     ###          "\n \
             echo "          ###            https://github.com/pglombardo/PasswordPusher            ###          "\n \
-            echo "          ###                   !!DEPRECATION NOTIFICATION!!                     ###          "\n \
+            echo "          ###                 !!END OF SUPPORT NOTIFICATION!!                    ###          "\n \
             echo "          ##########################################################################          "\n \
             ' ./containers/docker/pwpush/entrypoint.sh
 


### PR DESCRIPTION
## Description
This PR replaces the deprecation notice introduced in #1369 into a end-of-support notice.
This is in preparation to #1555 and ment to inform users to migrate as soon as possible.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
