### PR TITLE
Remove MiniProfiler call

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,6 @@ class ApplicationController < ActionController::Base
 
   add_flash_types :info, :error, :success, :warning
 
-  before_action do
-    Rack::MiniProfiler.authorize_request if current_user && current_user.admin == true
-  end
-
   def custom_set_locale_from_url
     locale_from_url = RouteTranslator.locale_from_params(params) ||
                       RouteTranslator::Host.locale_from_host(request.host) ||


### PR DESCRIPTION
## Description

This was breaking requests in 1.36.1

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
