### PR TITLE
Revert "Bump ruby from 3.2-alpine to 3.3-alpine in /containers/docker"

### DIFF
--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -2,7 +2,7 @@
 ARG BUNDLE_WITHOUT=development:test
 ARG BUNDLE_DEPLOYMENT=true
 
-FROM ruby:3.3-alpine AS build-env
+FROM ruby:3.2-alpine AS build-env
 
 # include global args
 ARG BUNDLE_WITHOUT
@@ -62,7 +62,7 @@ RUN rm -rf node_modules tmp/cache vendor/assets spec \
 
 ################## Build done ##################
 
-FROM ruby:3.3-alpine
+FROM ruby:3.2-alpine
 
 # include global args
 ARG BUNDLE_WITHOUT


### PR DESCRIPTION
Ruby 3.3 has a bug with alpine that is breaking the container builds.   We'll update after 3.3.1 is released with the fix.

Reverts pglombardo/PasswordPusher#1757

Revert until the Ruby 3.3 segfault on asset:precompile bug is fixed in 3.3.1.