### PR TITLE
GDPR: Host Assets Locally

### DIFF
--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -30,6 +30,8 @@ $accordion-color: #fff;
 @import "@fontsource/roboto-mono/300";
 
 @import "bootstrap";
+@import "bootstrap-icons";
+@import "flag-icons.min.css";
 
 @import "themes/<%= ENV.fetch('PWP__THEME', 'default') %>";
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,8 +16,6 @@
   <%= csp_meta_tag %>
 
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css"/>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.1.0/css/flag-icons.min.css"/>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 </head>
 

--- a/app/views/layouts/bare.html.erb
+++ b/app/views/layouts/bare.html.erb
@@ -16,8 +16,6 @@
   <%= csp_meta_tag %>
 
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css"/>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.1.0/css/flag-icons.min.css"/>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 </head>
 

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -16,8 +16,6 @@
   <%= csp_meta_tag %>
 
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css"/>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.1.0/css/flag-icons.min.css"/>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 </head>
 

--- a/app/views/layouts/naked.html.erb
+++ b/app/views/layouts/naked.html.erb
@@ -16,8 +16,6 @@
   <%= csp_meta_tag %>
 
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css"/>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.1.0/css/flag-icons.min.css"/>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 </head>
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -17,6 +17,13 @@ Rails.application.config.assets.paths << Rails.root.join('vendor/stylesheets/@fo
 Rails.application.config.assets.paths << Rails.root.join('vendor/stylesheets/@fontsource/roboto-slab/files')
 Rails.application.config.assets.paths << Rails.root.join('vendor/stylesheets/@fontsource/roboto-mono/files')
 
+Rails.application.config.assets.paths << Rails.root.join('node_modules/bootstrap-icons')
+Rails.application.config.assets.paths << Rails.root.join('node_modules/bootstrap-icons/font')
+
+Rails.application.config.assets.paths << Rails.root.join('node_modules/flag-icons')
+Rails.application.config.assets.paths << Rails.root.join('node_modules/flag-icons/css')
+Rails.application.config.assets.paths << Rails.root.join('node_modules/flag-icons/flags')
+
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "@rails/actioncable": "^7.0.4",
     "@rails/activestorage": "^7.0.5",
     "bootstrap": "^5.2.3",
+    "bootstrap-icons": "^1.11.3",
     "clipboard": "^2.0.11",
     "esbuild": "^0.18.11",
+    "flag-icons": "^7.1.0",
     "js-cookie": "^3.0.4",
     "omgopass": "^3.2.1",
     "spoiler-alert": "^0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,6 +147,11 @@
   dependencies:
     spark-md5 "^3.0.1"
 
+bootstrap-icons@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz#03f9cb754ec005c52f9ee616e2e84a82cab3084b"
+  integrity sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==
+
 bootstrap@^5.2.3:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.2.tgz#97226583f27aae93b2b28ab23f4c114757ff16ae"
@@ -193,6 +198,11 @@ esbuild@^0.18.11:
     "@esbuild/win32-arm64" "0.18.20"
     "@esbuild/win32-ia32" "0.18.20"
     "@esbuild/win32-x64" "0.18.20"
+
+flag-icons@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/flag-icons/-/flag-icons-7.1.0.tgz#6898ae3b3a57e5a363e12478c1ef384aa62d641f"
+  integrity sha512-AH4v++19bpC5P3Wh767top4wylJYJCWkFnvNiDqGHDxqSqdMZ49jpLXp8PWBHTTXaNQ+/A+QPrOwyiIGaiIhmw==
 
 good-listener@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

flag-icons and boostrap-icons are currently loaded via CDN.  This PR moves these assets locally so no external requests are needed for the application to function.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
#1735 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
