### PR TITLE
Keep node_modules in Docker image

### DIFF
--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -55,7 +55,7 @@ ENV SECRET_KEY_BASE=662e5f1c1f71b78c6fc0455cf72b590aefc7e924bbe356556c8dacd18fa0
 RUN bundle exec rails assets:precompile && bundle exec rake db:setup
 
 # Removing unneccesary files/directories
-RUN rm -rf node_modules tmp/cache vendor/assets spec \
+RUN rm -rf tmp/cache vendor/assets spec \
     && rm -rf vendor/bundle/ruby/*/cache/*.gem \
     && find vendor/bundle/ruby/*/gems/ -name "*.c" -delete \
     && find vendor/bundle/ruby/*/gems/ -name "*.o" -delete


### PR DESCRIPTION
## Description

With recent changes in #1828 & #1827, we no load assets from the node_modules directory.

Previously this directory was deleted to reduce image size but unfortunately that is not an option going forward.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
