### PR TITLE
fix: bump bundler version in lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -659,4 +659,4 @@ RUBY VERSION
    ruby 3.1.4p223
 
 BUNDLED WITH
-   2.4.10
+   2.4.19


### PR DESCRIPTION
We do this to not trigger a rebuild of layers.

## Description

<!-- Add a more detailed description of the changes if needed. -->

> 37.02 Bundler 2.4.19 is running, but your lockfile was generated with 2.4.10. Installing Bundler 2.4.10 and restarting using that version.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
