### PR TITLE
Fix Container Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -663,5 +663,5 @@ storage/
 bin/*.rb
 
 /config/credentials/development.key
-
+/config/credentials/staging.key
 /config/credentials/production.key

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -913,8 +913,8 @@ default_locale: :en
 
 # Configure the logging verbosity of the application.
 #
-# Valid values are: debug, info, warn, error, fatal
-log_level: 'warn'
+# Valid values are: :debug, :info, :warn, :error, :fatal
+log_level: :warn
 
 # In containers, it is usually desired to log to stdout
 # instead of using log files (e.g. log/production.log).

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class Rack::Attack
-  blocklist("no instana clicks") do |request|
-    candidates = [/instana.io/]
-    candidates.find { |c| request.referer =~ c }
-  end
-end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -913,8 +913,8 @@ default_locale: :en
 
 # Configure the logging verbosity of the application.
 #
-# Valid values are: debug, info, warn, error, fatal
-log_level: 'warn'
+# Valid values are: :debug, :info, :warn, :error, :fatal
+log_level: :warn
 
 # In containers, it is usually desired to log to stdout
 # instead of using log files (e.g. log/production.log).


### PR DESCRIPTION
## Description

Docker container logging broke with some update recently.  This PR fixes the logging.

Use your `settings.yml` to set logging options.  By default, the logger will log to `/opt/PasswordPusher/log/production.log` at a `warn` level.

So it should just be warnings and errors if there are any.

This should hopefully assist in debugging and finding error details.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [x] I've added documentation as necessary so users can easily use and understand this feature/fix.
