### PR TITLE
Deprecate relative_root option

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -85,11 +85,11 @@ Notes:
 | Environment Variable | Description | Default Value |
 | --------- | ------------------ | --- |
 | PWP__DEFAULT_LOCALE | Sets the default language for the application.  See the [documentation](https://github.com/pglombardo/PasswordPusher#internationalization). | `en` |
-| PWP__RELATIVE_ROOT | Runs the application in a subfolder.  e.g. With a value of `pwp` the front page will then be at `https://url/pwp` | `Not set` |
 | PWP__SHOW_VERSION | Show the version in the footer | `true` |
 | PWP__SHOW_GDPR_CONSENT_BANNER | Optionally enable or disable the GDPR cookie consent banner. | `true` |
 | PWP__TIMEZONE | Set the application wide timezone.  Use a valid timezone string (see note below). | `America/New_York` |
 | SECRET_KEY_BASE | A secret key that is used for various security-related features, including session cookie encryption and other cryptographic operations.  Use `/opt/PasswordPusher/bin/rails secret` to generate a random key string. [See the SECRET_KEY_BASE wiki page.](https://github.com/pglombardo/PasswordPusher/wiki/SECRET_KEY_BASE)| _Randomly Generated on boot_ |
+| PWP__RELATIVE_ROOT | <DEPRECATED/doesn't work reliably - Will be removed in a future version.> Runs the application in a subfolder.  e.g. With a value of `pwp` the front page will then be at `https://url/pwp` | `Not set` |
 
 _Note_: The list of valid timezone strings can be found at [https://en.wikipedia.org/wiki/List_of_tz_database_time_zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -923,9 +923,16 @@ log_to_stdout: false
 
 ### Run in Subfolder
 #
+# WARNING:  This option very likely doesn't work as expected and will
+# be removed in the future.
+#
+# See:
+#  - https://github.com/pglombardo/PasswordPusher/issues/905
+#  - https://github.com/pglombardo/PasswordPusher/discussions/1859#discussioncomment-8399220
+#
 # To run in a subfolder, specify the path to use.  For example, if `relative_root`
 # is set too 'pwpush_root', then the application is hosted at https://<host>/pwpush_root/
 # (and this is where you will find the front page of the application).
 #
 # Environment variable override: PWP__RELATIVE_ROOT='pwpush'
-# relative_root: 'pwpush'
+relative_root: 'pwpush'

--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -5,15 +5,12 @@ def load_legacy_environment_variables
   # Check for Legacy Environment Variables (to be deprecated)
   deprecations_detected = false
 
-  legacy_options = %i[]
+  legacy_options = %i[relative_root]
 
   legacy_options.each do |option|
     next if Settings.send(option).nil?
 
-    Rails.logger.warn("The setting (#{option}) has been moved to the 'pw' section of the settings.yml file.\n" \
-                      "Please update your settings.yml file or if using environment variables, change the\n" \
-                      "variable name 'PWP__#{option.to_s.upcase}' to 'PWP__PW__#{option.to_s.upcase}'.\n")
-    Settings.pw.__send__(:"#{option}=", Settings.send(option))
+    Rails.logger.warn("The setting (#{option}) has been DEPRECATED and will be removed in a future version.")
     deprecations_detected = true
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -923,9 +923,16 @@ log_to_stdout: false
 
 ### Run in Subfolder
 #
+# WARNING:  This option very likely doesn't work as expected and will
+# be removed in the future.
+#
+# See:
+#  - https://github.com/pglombardo/PasswordPusher/issues/905
+#  - https://github.com/pglombardo/PasswordPusher/discussions/1859#discussioncomment-8399220
+#
 # To run in a subfolder, specify the path to use.  For example, if `relative_root`
 # is set too 'pwpush_root', then the application is hosted at https://<host>/pwpush_root/
 # (and this is where you will find the front page of the application).
 #
 # Environment variable override: PWP__RELATIVE_ROOT='pwpush'
-# relative_root: 'pwpush'
+relative_root: 'pwpush'


### PR DESCRIPTION
## Description

This PR deprecates the ability to run the application in a subfolder.  It doesn't
work as every recent issue filed has indicated.

If you have the setting `Settings.relative_root` set or the environment variable `PWP__RELATIVE_ROOT` set, you'll
get a deprecation warning in your logs.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
