### PR TITLE
Add "enabled_language_codes" option

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -821,13 +821,62 @@ feedback:
 #                 It cannot be set in this config file.
 theme: 'default'
 
+### Site Default Locale
+#
+# The default language for the application.  This must be one of the
+# valid/supported language codes from the list above.
+#
+# Note: This locale _must_ be in the list of enabled_language_codes.
+#
+# Example: default_locale: :es
+#
+# Environment Variable Override: PWP__DEFAULT_LOCALE='es'
+default_locale: :en
+
 ### Language & Internationalization
 #
-# List of supported languages indexed by language code.  This is used
-# to build the in application language menu.
+# List of enabled languages for the application.
 #
 # To remove the availability of languages from the application entirely,
-# comment out the language code(s) from the list below.
+# comment out (or remove) the language code(s) from the `enabled_language_codes`
+# list below.
+#
+enabled_language_codes:
+  - ca # 'Català'
+  - cs # 'Čeština'
+  - da # 'Dansk'
+  - de # 'Deutsch'
+  - en # 'English'
+  - es # 'Español'
+  - eu # 'Euskara'
+  - fi # 'Suomi'
+  - fr # 'Français'
+  - hi # 'हिन्दी'
+  - hu # 'Magyar'
+  - id # 'Indonesian'
+  - is # 'Íslenska'
+  - it # 'Italiano'
+  - ja # '日本語'
+  - ko # '한국어'
+  - lv # 'Latviski'
+  - nl # 'Nederlands'
+  - 'no' # 'Norsk' # _no_ keyword in Ruby evaluates to false  #-(
+  - pl # 'Polski'
+  - pt-BR # 'Português'
+  - pt-PT # 'Português'
+  - ro # 'Română'
+  - ru # 'Русский'
+  - sr # 'Српски'
+  - sv # 'Svenska'
+  - th # 'ไทย'
+  - uk # 'Українська'
+  - ur # 'اردو'
+  - zh-CN # '中文'
+
+### Language & Internationalization
+#
+# Map of language codes to language name.
+# Used internally for the language selector model.
 #
 # <language code>: '<language name>'
 language_codes:
@@ -899,17 +948,6 @@ country_codes:
   uk: :ua
   ur: :pk
   zh-CN: :cn
-
-
-### Site Default Locale
-#
-# The default language for the application.  This must be one of the
-# valid/supported language codes from the list above.
-#
-# Example: default_locale: :es
-#
-# Environment Variable Override: PWP__DEFAULT_LOCALE='es'
-default_locale: :en
 
 # Configure the logging verbosity of the application.
 #

--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Permitted locales available for the application
-I18n.available_locales = Settings.language_codes.keys
+I18n.available_locales = Settings.enabled_language_codes.map(&:to_sym)
 
 # Ability to set default locale to something other than :en
 # See config/settings.yml

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -821,13 +821,62 @@ feedback:
 #                 It cannot be set in this config file.
 theme: 'default'
 
+### Site Default Locale
+#
+# The default language for the application.  This must be one of the
+# valid/supported language codes from the list above.
+#
+# Note: This locale _must_ be in the list of enabled_language_codes.
+#
+# Example: default_locale: :es
+#
+# Environment Variable Override: PWP__DEFAULT_LOCALE='es'
+default_locale: :en
+
 ### Language & Internationalization
 #
-# List of supported languages indexed by language code.  This is used
-# to build the in application language menu.
+# List of enabled languages for the application.
 #
 # To remove the availability of languages from the application entirely,
-# comment out the language code(s) from the list below.
+# comment out (or remove) the language code(s) from the `enabled_language_codes`
+# list below.
+#
+enabled_language_codes:
+  - ca # 'Català'
+  - cs # 'Čeština'
+  - da # 'Dansk'
+  - de # 'Deutsch'
+  - en # 'English'
+  - es # 'Español'
+  - eu # 'Euskara'
+  - fi # 'Suomi'
+  - fr # 'Français'
+  - hi # 'हिन्दी'
+  - hu # 'Magyar'
+  - id # 'Indonesian'
+  - is # 'Íslenska'
+  - it # 'Italiano'
+  - ja # '日本語'
+  - ko # '한국어'
+  - lv # 'Latviski'
+  - nl # 'Nederlands'
+  - 'no' # 'Norsk' # _no_ keyword in Ruby evaluates to false  #-(
+  - pl # 'Polski'
+  - pt-BR # 'Português'
+  - pt-PT # 'Português'
+  - ro # 'Română'
+  - ru # 'Русский'
+  - sr # 'Српски'
+  - sv # 'Svenska'
+  - th # 'ไทย'
+  - uk # 'Українська'
+  - ur # 'اردو'
+  - zh-CN # '中文'
+
+### Language & Internationalization
+#
+# Map of language codes to language name.
+# Used internally for the language selector model.
 #
 # <language code>: '<language name>'
 language_codes:
@@ -899,17 +948,6 @@ country_codes:
   uk: :ua
   ur: :pk
   zh-CN: :cn
-
-
-### Site Default Locale
-#
-# The default language for the application.  This must be one of the
-# valid/supported language codes from the list above.
-#
-# Example: default_locale: :es
-#
-# Environment Variable Override: PWP__DEFAULT_LOCALE='es'
-default_locale: :en
 
 # Configure the logging verbosity of the application.
 #


### PR DESCRIPTION
## Description

This fixes #1904.

To disable a language, remove it from the `enabled_language_codes` list in the `settings.yml`

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
