### PR TITLE
Config: Make default db db/db.sqlite3

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -11,10 +11,6 @@ test:
   database: db/test.sqlite3
   <<: *base
 
-private:
-  database: db/private.sqlite3
-  <<: *base
-
 production:
-  database: db/production.sqlite3
+  database: db/db.sqlite3
   <<: *base


### PR DESCRIPTION
## Description

The Docker container sets [DATABASE_URL=sqlite3:db/db.sqlite3](https://github.com/pglombardo/PasswordPusher/blob/master/containers/docker/Dockerfile#L43) but the application config file sets `db/production.sqlite3` in config/database.yml.  This doesn't break anything but when you open a console in Docker, the discrepancy causes issues such as #1991.

So for production environment and not using a postgres or mysql database, `db/db.sqlite3` it is.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
