### PR TITLE
Launch Password Pusher with Let's Encrypt SSL/TLS Certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Password Pusher is also [on Twitter](https://twitter.com/pwpush), [Gettr](https:
 
 _or_
 
-→ Run your own instance with one command: `docker run -d -p "5100:5100" pglombardo/pwpush:latest` then go to http://localhost:5100
+→ Run your own instance with `docker run -d -p "5100:5100" pglombardo/pwpush:latest` or a [production ready setup with a database & SSL/TLS](https://github.com/pglombardo/PasswordPusher/tree/master/containers/docker/all-in-one).
 
 _or_
 

--- a/containers/docker/all-in-one/Caddyfile
+++ b/containers/docker/all-in-one/Caddyfile
@@ -1,0 +1,12 @@
+{
+  # Global options block
+  email user@example.com  # Replace with your email for Let's Encrypt notifications
+  acme_ca https://acme-v02.api.letsencrypt.org/directory  # Use Let's Encrypt production API
+}
+
+example.com { # Replace with your domain
+  reverse_proxy pwpush:5100
+#  tls {
+#    dns cloudflare {env.CLOUDFLARE_API_TOKEN}  # Optional: Replace with your DNS provider if using DNS challenge
+#  }
+}

--- a/containers/docker/all-in-one/README.md
+++ b/containers/docker/all-in-one/README.md
@@ -1,0 +1,19 @@
+# Password Pusher - All In One Setup
+
+The files in this directory allow you to launch a Password Pusher instance with automatic SSL/TLS certificate
+management thanks to Caddy server.
+
+Caddy server is a piece of software that when given a domain, will automatically fetch, update & monitor TSL
+certificates for that domain in tandem with Let's Encrypt.
+
+# Prerequisites
+
+To run this, you will need both Docker and Docker Compose installed.
+
+# How to Run
+
+1. Open `docker-compose-pwpush.yml` and follow the instructions inside.
+
+2. Open `Caddyfile` and do the same.
+
+3. Run `docker-compose -f docker-compose-pwpush.yml`

--- a/containers/docker/all-in-one/README.md
+++ b/containers/docker/all-in-one/README.md
@@ -1,9 +1,9 @@
 # Password Pusher - All In One Setup
 
 The files in this directory allow you to launch a Password Pusher instance with automatic SSL/TLS certificate
-management thanks to Caddy server.
+management thanks to Caddy server & Let's Encrypt.
 
-Caddy server is a piece of software that when given a domain, will automatically fetch, update & monitor TSL
+Caddy is a proxy that when given a domain, will automatically fetch, update & monitor TSL
 certificates for that domain in tandem with Let's Encrypt.
 
 # Prerequisites

--- a/containers/docker/all-in-one/docker-compose-pwpush.yml
+++ b/containers/docker/all-in-one/docker-compose-pwpush.yml
@@ -1,0 +1,127 @@
+version: '2.1'
+
+services:
+  # --> By default, this file will launch a Password Pusher instance with an
+  # ephemeral (temporary) database of SQLite3.  The database will be lost on
+  # restart.  If you want a persistent database, enable one of databases below.
+  #
+  # Uncomment to add a PostgreSQL service
+  #
+  # postgres:
+  #   image: docker.io/postgres:15
+  #   volumes:
+  #     - /var/lib/postgresql/data:/var/lib/postgresql/data
+  #   ports:
+  #     - "5432:5432"
+  #   environment:
+  #     POSTGRES_USER: pwpush_user
+  #     POSTGRES_PASSWORD: pwpush_passwd
+  #     POSTGRES_DB: pwpush_db
+
+  # Uncomment to add a MySQL service
+  #
+  # mysql:
+  #   image: mysql:8.0.32
+  #   ports:
+  #     - "3306:3306"
+  #   environment:
+  #     MYSQL_USER: 'pwpush_user'
+  #     MYSQL_PASSWORD: 'pwpush_passwd'
+  #     MYSQL_DATABASE: 'pwpush_db'
+  #     MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
+  #   volumes:
+  #     - /var/lib/pwpush-mysql/data:/var/lib/mysql
+
+  # Uncomment to add a MariaDB service
+  #
+  # mariadb:
+  #   image: mariadb:10.6.5
+  #   ports:
+  #     - "3306:3306"
+  #   environment:
+  #     MARIADB_USER: 'pwpush_user'
+  #     MARIADB_PASSWORD: 'pwpush_passwd'
+  #     MARIADB_DATABASE: 'pwpush_db'
+  #     MARIADB_RANDOM_ROOT_PASSWORD: 'yes'
+  #   volumes:
+  #     - /var/lib/pwpush-mariadb/data:/var/lib/mysql
+
+  pwpush:
+    image: docker.io/pglombardo/pwpush:latest
+    ports:
+      - "5100:5100"
+    #
+    # If using postgres, mysql or mariadb, uncomment the block and appropriate
+    # lines below by removing "# " (two characters) from the beginning of
+    # the line.  This is a YAML file: indentation & spacing are critical
+    #
+    # depends_on:
+      # - postgres  # Uncomment to use PostgreSQL
+      # - mysql     # Uncomment to use MySQL
+      # - mariadb   # Uncomment to use MariaDB
+    # links:
+      # - postgres:postgres # Uncomment to use PostgreSQL
+      # - mysql:mysql       # Uncomment to use MySQL
+      # - mariadb:mariadb   # Uncomment to use MariaDB
+    environment:
+      # **--> !! If using postgres, mysql or mariadb, enable the appropriate line !! <--**
+      #
+      # --> Uncomment to use PostgreSQL
+      # DATABASE_URL: 'postgres://pwpush_user:pwpush_passwd@postgres:5432/pwpush_db'
+      #
+      # --> Uncomment to use MySQL or MariaDB
+      # DATABASE_URL: 'mysql2://pwpush_user:pwpush_passwd@mysql:3306/pwpush_db'
+      #
+      # --> Uncomment to use SQLite3 (ephemeral) db that will be lost on container restart
+      DATABASE_URL: "sqlite3:db/db.sqlite3"
+      #
+      ################################################################################################
+      # You can set other environment variables here, or in a env file.  See:
+      # https://docs.docker.com/compose/environment-variables/
+      #
+      # Password Pusher provides an example Docker environment file:
+      # https://github.com/pglombardo/PasswordPusher/tree/master/containers/docker/pwpush-docker-env-file
+
+  ssl_proxy:
+      image: caddy:latest
+      ports:
+        - "80:80"
+        - "443:443"
+      volumes:
+        - ./Caddyfile:/etc/caddy/Caddyfile
+        - caddy_data:/data
+        - caddy_config:/config
+      depends_on:
+        - pwpush
+
+volumes:
+  caddy_data:
+  caddy_config:
+
+###############################################################################
+# Other Notes
+###############################################################################
+# See also the Password Pusher Configuration documentation
+# https://github.com/pglombardo/PasswordPusher/blob/master/Configuration.md
+#
+# Uncomment the following lines to set environment variables and add your own.
+# environment:
+#   PWP__PW__EXPIRE_AFTER_DAYS_DEFAULT: "1"
+#   PWP__PW__EXPIRE_AFTER_VIEWS_MIN: "1"
+#   PWP__PW__RETRIEVAL_STEP_DEFAULT: "true"
+#
+# Uncomment the following lines to mount a volume.
+# volumes:
+#   # Example of a persistent volume for the storage directory (file uploads)
+#   - /path/to/directory:/opt/PasswordPusher/storage:rw
+#
+# Or you could override a single file in the container with a bind mount:
+# volumes:
+#   - type: bind
+#     source: /path/to/my/custom/settings.yml
+#     target: /opt/PasswordPusher/config/settings.yml
+#
+# To customise the application via configuration file, see settings.yml:
+# https://github.com/pglombardo/PasswordPusher/blob/master/config/settings.yml
+#
+# Then you can use the above bind mount to overlay the file into the container on boot.


### PR DESCRIPTION
## Description

The files in this directory allow you to launch a Password Pusher instance with automatic SSL/TLS certificate management thanks to Caddy server & Let's Encrypt.

tldr; Launch and get Password Pusher hosted with valid SSL certs for the domain you specify.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
