### PR TITLE
User Confirmation: Add click-through step

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -14,9 +14,13 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   # end
 
   # GET /resource/confirmation?confirmation_token=abcdef
-  # def show
-  #   super
-  # end
+  def show
+    if params[:go].present?
+      super
+    else
+      render "show", layout: "bare"
+    end
+  end
 
   # protected
 

--- a/app/views/devise/confirmations/show.html.erb
+++ b/app/views/devise/confirmations/show.html.erb
@@ -1,0 +1,6 @@
+
+<div class="container-fluid h-100 mx-0 py-0 px-0 bg-light">
+  <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center bg-light">
+    <%= link_to t('confirmation_go'), user_confirmation_path({ confirmation_token: params[:confirmation_token], go: true}) %>
+  </div>
+</div>

--- a/config/locales/pwpush.en.yml
+++ b/config/locales/pwpush.en.yml
@@ -1,7 +1,6 @@
 ---
 en:
   about: About
-  confirmation_go: Click Here to Confirm Your Account
   accounts:
     edit_policy:
     policy:
@@ -132,6 +131,7 @@ en:
       log_viewed: Successful view on %{date} by %{user}
       unknown: Unknown
       viewed_by: Viewed by %{user}
+  confirmation_go: Click Here to Confirm Your Account
   dashboard:
     show:
       detail: Detail

--- a/config/locales/pwpush.en.yml
+++ b/config/locales/pwpush.en.yml
@@ -1,6 +1,7 @@
 ---
 en:
   about: About
+  confirmation_go: Click Here to Confirm Your Account
   accounts:
     edit_policy:
     policy:


### PR DESCRIPTION
## Description

To address the issues raised in #2180, this PR adds a required click through to confirm accounts.

<!-- Add a more detailed description of the changes if needed. -->

![Screenshot 2024-06-03 at 12 19 24](https://github.com/pglombardo/PasswordPusher/assets/395132/311b38a6-fa7a-4d1c-907b-f1e5b66ca32c)


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
#2180

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
