### PR TITLE
Adjust helm chart to runAsNonRoot

### DIFF
--- a/containers/helm/templates/deployment.yaml
+++ b/containers/helm/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         {{ $k }}: {{ $v | quote }}
         {{- end }}
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
## Description

Currently the helm chart does not set a podSecurityContext. This may prevent the use in kubernetes clusters which do not allow images that run as root for security reasons.

<!-- Add a more detailed description of the changes if needed. -->
The Container already uses a non root user, so setting runAsNonRoot and specifying the User/Group ID (because runAsNonRoot requires a numeric user for validation) is sufficient. This allows the use in kubernetes clusters which do not allow images running as root.


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
