### PR TITLE
Switch to Rack::Attack for Throttling

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -544,10 +544,8 @@ per a given time period (per second, minute, hourly, or daily).
 
 | Environment Variable | Description | Default Value |
 | --------- | ------------------ | --- |
-| PWP__THROTTLING__DAILY | The maximum number of allowed HTTP requests per day | `5000` |
-| PWP__THROTTLING__HOURLY | The maximum number of allowed HTTP requests per hour | `600` |
-| PWP__THROTTLING__MINUTE | The maximum number of allowed HTTP requests per minute | `60` |
-| PWP__THROTTLING__SECOND | The maximum number of allowed HTTP requests per second | `20` |
+| PWP__THROTTLING__MINUTE | The maximum number of allowed HTTP requests per minute | `120` |
+| PWP__THROTTLING__SECOND | The maximum number of allowed HTTP requests per second | `60` |
 
 
 # Logging

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :development, :test do
   gem "standardrb", "~> 1.0"
 end
 
-gem "rack-attack"
 gem "rack-cors"
 
 # OSX: ../src/utils.h:33:10: fatal error: 'climits' file not found
@@ -117,7 +116,7 @@ gem "pg"
 gem "sqlite3", force_ruby_platform: true
 
 group :production do
-  gem "rack-throttle", "0.7.0"
+  gem "rack-attack"
   gem "rack-timeout"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,9 +415,6 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rack-throttle (0.7.0)
-      bundler (>= 1.0.0)
-      rack (>= 1.0.0)
     rack-timeout (0.7.0)
     rackup (2.1.0)
       rack (>= 3)
@@ -641,7 +638,6 @@ DEPENDENCIES
   puma
   rack-attack
   rack-cors
-  rack-throttle (= 0.7.0)
   rack-timeout
   rails (~> 7.1.3)
   rails-i18n (~> 7.0.9)

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -676,39 +676,24 @@ brand:
 # Throttling enforces a minimum time interval
 # between subsequent HTTP requests from a particular client, as
 # well as by defining a maximum number of allowed HTTP requests
-# per a given time period (per second, minute, hourly, or daily).
+# per a given time period (per second or minute)
 #
-# See https://github.com/dryruby/rack-throttle#throttling-strategies
-# for a description of function.
+# See https://github.com/rack/rack-attack
 #
 throttling:
-  # ..maximum number of allowed HTTP requests per day
-  #
-  # Default: 5000
-  #
-  # Environment Variable Override: PWP__THROTTLING__DAILY='5000'
-  daily: 5000
-
-  # ..maximum number of allowed HTTP requests per hour
-  #
-  # Default: 600
-  #
-  # Environment Variable Override: PWP__THROTTLING__HOURLY='600'
-  hourly: 600
-
   # ..maximum number of allowed HTTP requests per minute
   #
-  # Default: 60
+  # Default: 120
   #
   # Environment Variable Override: PWP__THROTTLING__MINUTE='60'
-  minute: 60
+  minute: 120
 
   # ..maximum number of allowed HTTP requests per second
   #
-  # Default: 20
+  # Default: 60
   #
   # Environment Variable Override: PWP__THROTTLING__SECOND='20'
-  second: 20
+  second: 60
 
 
 ### Mail Server Configuration

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,79 @@
+if defined? Rack::Attack
+  class Rack::Attack
+    # rack-attack helps you protect your Rails application from bad clients.
+    # You can use it to allow, block, and throttle requests.
+    # See https://github.com/rack/rack-attack for more details
+
+    # By default, rack-attack is enabled for all environments
+    # Rack::Attack.enabled = Rails.env.production?
+
+    ### Cache
+
+    # rack-attack uses the Rails.cache for storing throttling, allow2ban, and fail2ban filtering.
+    # They recommend using a separate Redis database to prevent an attack from taking down your main Redis database
+
+    # Use the memory store for faster tests
+    if Rails.env.test?
+      Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+      # else
+      #   Rack::Attack.cache.store = ActiveSupport::Cache::RedisCacheStore.new(url: "...")
+    end
+
+    # Return a Retry-After header for throttled requests
+    Rack::Attack.throttled_response_retry_after_header = true
+
+    ### Throttle Spammy Clients
+
+    # If any single client IP is making tons of requests, then they're
+    # probably malicious or a poorly-configured scraper. Either way, they
+    # don't deserve to hog all of the app server's CPU. Cut them off!
+
+    unless Rails.env.test?
+      # Throttle all requests by IP
+      #
+      throttle("req/ip", limit: Settings.throttling.minute, period: 1.minute) do |req|
+        req.ip # unless req.path.start_with?('/assets')
+      end
+
+      # Throttle API requests by IP address
+      #
+      throttle("api/ip", limit: Settings.throttling.second, period: 1.second) do |req|
+        if req.path == "/api"
+          req.ip
+        end
+      end
+    end
+
+    ### Prevent Brute-Force Login Attacks
+
+    # The most common brute-force login attack is a brute-force password
+    # attack where an attacker simply tries a large number of emails and
+    # passwords to see if any credentials match.
+    #
+    # Another common method of attack is to use a swarm of computers with
+    # different IPs to try brute-forcing a password for a specific account.
+
+    # Throttle POST requests to /users/sign_in by IP address
+    #
+    # throttle("logins/ip", limit: 5, period: 20.seconds) do |req|
+    #   if req.path == "/users/sign_in" && req.post?
+    #     req.ip
+    #   end
+    # end
+
+    # Throttle POST requests to /users/sign_in by email param
+    #
+    # Note: This creates a problem where a malicious user could intentionally
+    # throttle logins for another user and force their login requests to be
+    # denied, but that's not very common and shouldn't happen to you. (Knock
+    # on wood!)
+    #
+    # throttle("logins/email", limit: 5, period: 20.seconds) do |req|
+    #   if req.path == "/users/sign_in" && req.post?
+    #     # Normalize the email, using the same logic as your authentication process, to
+    #     # protect against rate limit bypasses. Return the normalized email if present, nil otherwise.
+    #     req.params["email"].to_s.downcase.gsub(/\s+/, "").presence
+    #   end
+    # end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -676,39 +676,24 @@ brand:
 # Throttling enforces a minimum time interval
 # between subsequent HTTP requests from a particular client, as
 # well as by defining a maximum number of allowed HTTP requests
-# per a given time period (per second, minute, hourly, or daily).
+# per a given time period (per second or minute)
 #
-# See https://github.com/dryruby/rack-throttle#throttling-strategies
-# for a description of function.
+# See https://github.com/rack/rack-attack
 #
 throttling:
-  # ..maximum number of allowed HTTP requests per day
-  #
-  # Default: 5000
-  #
-  # Environment Variable Override: PWP__THROTTLING__DAILY='5000'
-  daily: 5000
-
-  # ..maximum number of allowed HTTP requests per hour
-  #
-  # Default: 600
-  #
-  # Environment Variable Override: PWP__THROTTLING__HOURLY='600'
-  hourly: 600
-
   # ..maximum number of allowed HTTP requests per minute
   #
-  # Default: 60
+  # Default: 120
   #
   # Environment Variable Override: PWP__THROTTLING__MINUTE='60'
-  minute: 60
+  minute: 120
 
   # ..maximum number of allowed HTTP requests per second
   #
-  # Default: 20
+  # Default: 60
   #
   # Environment Variable Override: PWP__THROTTLING__SECOND='20'
-  second: 20
+  second: 60
 
 
 ### Mail Server Configuration


### PR DESCRIPTION
## Description

We've historically been using [rack-throttle](https://github.com/dryruby/rack-throttle) for request throttling.  That gem has been deprecated in favor of [rack-attack](https://github.com/rack/rack-attack) which this PR switches us to.

The change-over should be transparent for end users.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
