### PR TITLE
Remove last bit of Rack::Throttle

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -162,11 +162,4 @@ Rails.application.configure do
       raise "Settings.allowed_hosts (PWP__ALLOWED_HOSTS): Allowed hosts must be an array or string"
     end
   end
-
-  if Settings.throttling
-    config.middleware.use Rack::Throttle::Daily, max: Settings.throttling.daily
-    config.middleware.use Rack::Throttle::Hourly, max: Settings.throttling.hourly
-    config.middleware.use Rack::Throttle::Minute, max: Settings.throttling.minute
-    config.middleware.use Rack::Throttle::Second, max: Settings.throttling.second
-  end
 end


### PR DESCRIPTION
## Description

This left over bit was breaking the Docker builds.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
