### PR TITLE
Downcase language codes

### DIFF
--- a/config/routes/legacy_pushes.rb
+++ b/config/routes/legacy_pushes.rb
@@ -54,6 +54,6 @@ get "/:locale/r/:url_token/r", to: redirect("/r/%{url_token}/r?locale=%{locale}"
 
 # Redirects for translated routes
 I18n.available_locales.each do |locale|
-  get "/#{locale}", to: redirect("/?locale=#{locale}")
-  get "/#{locale}/api", to: redirect("/api?locale=#{locale}")
+  get "/#{locale.downcase}", to: redirect("/?locale=#{locale.downcase}")
+  get "/#{locale.downcase}/api", to: redirect("/api?locale=#{locale.downcase}")
 end


### PR DESCRIPTION
## Description

Language codes with capitalization (such as `pt-BR`) were not redirecting properly.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
