### PR TITLE
Email: Authentication nil by default

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -736,7 +736,7 @@ mail:
   # Important: Comment this out if your server doesn't require authentication.
   #
   # Environment Variable Override: PWP__MAIL__SMTP_AUTHENTICATION='plain'
-  smtp_authentication: 'plain'
+  # smtp_authentication: 'plain'
 
   # If your mail server requires authentication, set the username in this setting.
   # Environment Variable Override: PWP__MAIL__SMTP_USER_NAME='apikey'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -736,7 +736,7 @@ mail:
   # Important: Comment this out if your server doesn't require authentication.
   #
   # Environment Variable Override: PWP__MAIL__SMTP_AUTHENTICATION='plain'
-  smtp_authentication: 'plain'
+  # smtp_authentication: 'plain'
 
   # If your mail server requires authentication, set the username in this setting.
   # Environment Variable Override: PWP__MAIL__SMTP_USER_NAME='apikey'


### PR DESCRIPTION
## Description

For those running local mailservers (e.g. localhost:25), the `smtp_authentication` should be nil.

Fixes #2360 

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
