### PR TITLE
Fix environment variables in comments for syllables_count

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -582,7 +582,7 @@ gen:
   # The exact number of syllables that a generated password will have
   #
   # Environment variable override:
-  # PWP__GEN__SYLLABLE_COUNT=3
+  # PWP__GEN__SYLLABLES_COUNT=3
   #
   syllables_count: 3
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -582,7 +582,7 @@ gen:
   # The exact number of syllables that a generated password will have
   #
   # Environment variable override:
-  # PWP__GEN__SYLLABLE_COUNT=3
+  # PWP__GEN__SYLLABLES_COUNT=3
   #
   syllables_count: 3
 


### PR DESCRIPTION
## Description

Correct the environment variable for the syllables_count value.

## Related Issue

None

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
