### PR TITLE
Fix Workers Count: Set default count of 2

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,8 +8,8 @@ environment rails_env
 
 case rails_env
 when "production"
-  require "concurrent-ruby"
-  workers_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Concurrent.available_processor_count })
+  # Default to 2 workers.  To override, set the WEB_CONCURRENCY environment variable
+  workers_count = Integer(ENV.fetch("WEB_CONCURRENCY") { 2 })
   workers workers_count if workers_count > 1
 
   preload_app!


### PR DESCRIPTION
## Description

A recent commit changed the calculation of the number of puma workers to boot.  It was based on CPU count which in some cases would launch 10+ workers.

This is unnecessary.  pwpush.com and it's high traffic volume is handled with just 3 workers.

A default of 2 workers is more than sufficient for self-hosted instances.

If you need to increase the number of workers, set the environment variable `WEB_CONCURRENCY` to the number of desired workers.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
