### PR TITLE
Fix: Deleting Push with Last View yields Error 500

### DIFF
--- a/app/controllers/file_pushes_controller.rb
+++ b/app/controllers/file_pushes_controller.rb
@@ -261,19 +261,16 @@ class FilePushesController < BaseController
   description "Expires a push immediately.  Must be authenticated & owner of the push _or_ the push must " \
               "have been created with _deleteable_by_viewer_."
   def destroy
-    is_owner = false
-
-    if user_signed_in?
-      # Check if logged in user owns the file_push to be expired
-      if @push.user_id == current_user.id
-        is_owner = true
-      else
-        redirect_to :root, notice: _("That push does not belong to you.")
-        return
+    # Check if the push is deletable by the viewer or if the user is the owner
+    if @push.deletable_by_viewer == false && @push.user_id != current_user&.id
+      respond_to do |format|
+        format.html {
+          redirect_to :root, notice: _("That push is not deletable by viewers and does not belong to you.")
+        }
+        format.json {
+          render json: {error: _("That push is not deletable by viewers and does not belong to you.")}, status: :unprocessable_entity
+        }
       end
-    elsif @push.deletable_by_viewer == false
-      # Anonymous user - assure deletable_by_viewer enabled
-      redirect_to :root, notice: _("That push is not deletable by viewers.")
       return
     end
 
@@ -296,13 +293,7 @@ class FilePushesController < BaseController
     respond_to do |format|
       if @push.save
         format.html do
-          if is_owner && !ENV.key?("PWP_PUBLIC_GATEWAY")
-            redirect_to audit_file_push_path(@push),
-              notice: _("The push content has been deleted and the secret URL expired.")
-          else
-            redirect_to @push,
-              notice: _("The push content has been deleted and the secret URL expired.")
-          end
+          redirect_to @push, notice: _("The push content has been deleted and the secret URL expired.")
         end
         format.json { render json: @push, status: :ok }
       else

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -272,18 +272,12 @@ class UrlsController < BaseController
   description "Expires a push immediately.  Must be authenticated & owner of the push _or_ the " \
               "push must have been created with _deleteable_by_viewer_."
   def destroy
-    is_owner = false
-
-    if user_signed_in?
-      # Check if logged in user owns the url to be expired
-      if @push.user_id == current_user.id
-        is_owner = true
-      else
-        redirect_to :root, notice: _("That push does not belong to you.")
-        return
+    # Check ownership
+    if @push.user_id != current_user&.id
+      respond_to do |format|
+        format.html { redirect_to :root, notice: _("That push does not belong to you.") }
+        format.json { render json: {error: _("That push does not belong to you.")}, status: :unprocessable_entity }
       end
-    else
-      redirect_to :root, notice: _("That push does not belong to you.")
       return
     end
 
@@ -305,13 +299,7 @@ class UrlsController < BaseController
     respond_to do |format|
       if @push.save
         format.html do
-          if is_owner && !ENV.key?("PWP_PUBLIC_GATEWAY")
-            redirect_to audit_url_path(@push),
-              notice: _("The push content has been deleted and the secret URL expired.")
-          else
-            redirect_to @push,
-              notice: _("The push content has been deleted and the secret URL expired.")
-          end
+          redirect_to @push, notice: _("The push content has been deleted and the secret URL expired.")
         end
         format.json { render json: @push, status: :ok }
       else

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,7 +17,6 @@
     <%= invisible_captcha %>
   </div>
 
-
   <div class="form-floating">
     <input class="form-control" autocomplete="new-password" type="password" name="user[password_confirmation]" id="user_password_confirmation" required>
     <%= f.label I18n.t('devise.registrations.password_confirmation'), for: :user_password_confirmation %>

--- a/app/views/file_pushes/show.html.erb
+++ b/app/views/file_pushes/show.html.erb
@@ -51,7 +51,7 @@
             <%= _('(whichever occurs first).') %>
         <% end %>
       </p>
-      <% if @push.deletable_by_viewer %>
+      <% if @push.deletable_by_viewer && @push.views_remaining.positive? %>
         <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#deleteModal">
           <em class="bi bi-trash"></em> <%= _('Delete This Secret Link Now') %>
         </button>
@@ -60,7 +60,7 @@
   </div>
 </div>
 
-<% if @push.deletable_by_viewer %>
+<% if @push.deletable_by_viewer && @push.views_remaining.positive? %>
   <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true" data-controller="form">
     <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content">

--- a/app/views/passwords/show.html.erb
+++ b/app/views/passwords/show.html.erb
@@ -32,7 +32,7 @@
             <%= _('(whichever occurs first).') %>
         <% end %>
       </p>
-      <% if @push.deletable_by_viewer %>
+      <% if @push.deletable_by_viewer && @push.views_remaining.positive? %>
         <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#deleteModal">
           <em class="bi bi-trash"></em> <%= _('Delete This Secret Link Now') %>
         </button>
@@ -44,7 +44,7 @@
   </div>
 </div>
 
-<% if @push.deletable_by_viewer %>
+<% if @push.deletable_by_viewer && @push.views_remaining.positive? %>
   <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true" data-controller="form">
     <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     draw :public_pushes
 
     # Add a route that handles the root path and returns a 404 error
-    get "/", to: proc { |env| [404, {"Content-Type" => "text/html"}, ["<h1>Not Found</h1>"]] }
+    root to: proc { |env| [404, {"Content-Type" => "text/html"}, ["<h1>Not Found</h1>"]] }
   else
     draw :admin
     draw :users


### PR DESCRIPTION
## Description

- **Simplify expire checks and response**
- **Only show delete button if any views remain**
- **Gateway: define a root path**

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

 #2522
<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
