### PR TITLE
Admin: Add admin dashboard to account menu

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -37,6 +37,11 @@
               <%= _('Account') %>
             </a>
             <ul class="dropdown-menu" aria-labelledby="accountDropdownMenuLink">
+              <% if current_user.admin? %>
+                <li>
+                  <%= link_to _('Admin Dashboard'), admin_root_path, class: "dropdown-item" %>
+                </li>
+              <% end %>
               <li>
                 <%= link_to _('Edit Login Details'), edit_user_registration_path, class: "dropdown-item" %>
               </li>


### PR DESCRIPTION
## Description

For users that are marked as administrators, new admin menu item for easier access.

![pwpush-admin-menu-item](https://github.com/user-attachments/assets/4cf4b758-df49-49e8-b8dc-d71c119f8df2)


<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
