### PR TITLE
Throttling fix & Add protection against login brute forcing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ gem "mysql2"
 gem "pg"
 gem "sqlite3", force_ruby_platform: true
 
-group :production do
+group :production, :development do
   gem "rack-attack"
 end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -31,14 +31,16 @@ if defined? Rack::Attack
     unless Rails.env.test?
       # Throttle all requests by IP
       #
-      throttle("req/ip", limit: Settings.throttling.minute, period: 1.minute) do |req|
-        req.ip # unless req.path.start_with?('/assets')
+      if Settings.throttling&.minute.present?
+        throttle("req/minute/ip", limit: Settings.throttling.minute, period: 1.minute) do |req|
+          req.ip unless req.path.start_with?("/assets")
+        end
       end
 
       # Throttle API requests by IP address
       #
-      throttle("api/ip", limit: Settings.throttling.second, period: 1.second) do |req|
-        if req.path == "/api"
+      if Settings.throttling&.second.present?
+        throttle("req/second/ip", limit: Settings.throttling.second, period: 1.second) do |req|
           req.ip
         end
       end
@@ -55,11 +57,11 @@ if defined? Rack::Attack
 
     # Throttle POST requests to /users/sign_in by IP address
     #
-    # throttle("logins/ip", limit: 5, period: 20.seconds) do |req|
-    #   if req.path == "/users/sign_in" && req.post?
-    #     req.ip
-    #   end
-    # end
+    throttle("logins/ip", limit: 5, period: 20.seconds) do |req|
+      if req.path == "/users/sign_in" && req.post?
+        req.ip
+      end
+    end
 
     # Throttle POST requests to /users/sign_in by email param
     #
@@ -68,12 +70,12 @@ if defined? Rack::Attack
     # denied, but that's not very common and shouldn't happen to you. (Knock
     # on wood!)
     #
-    # throttle("logins/email", limit: 5, period: 20.seconds) do |req|
-    #   if req.path == "/users/sign_in" && req.post?
-    #     # Normalize the email, using the same logic as your authentication process, to
-    #     # protect against rate limit bypasses. Return the normalized email if present, nil otherwise.
-    #     req.params["email"].to_s.downcase.gsub(/\s+/, "").presence
-    #   end
-    # end
+    throttle("logins/email", limit: 5, period: 20.seconds) do |req|
+      if req.path == "/users/sign_in" && req.post?
+        # Normalize the email, using the same logic as your authentication process, to
+        # protect against rate limit bypasses. Return the normalized email if present, nil otherwise.
+        req.params["email"].to_s.downcase.gsub(/\s+/, "").presence
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR fixes #2684 and enables login brute force protections:

* Throttle POST requests to `/users/sign_in` by email param
* Limit POST requests to `/users/sign_in` to 5 per 20 seconds

These changes also mean that you can now disable throttling entirely by commenting out the `throttling.minute` and `throttling.second` values in `settings.yml`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
#2684

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
