### PR TITLE
Allow Anonymous=false: Fix after sign up redirect path

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -78,6 +78,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super(resource)
   # end
 
+  def after_inactive_sign_up_path_for(resource)
+    new_user_session_path
+  end
+
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)

--- a/config/routes/users.rb
+++ b/config/routes/users.rb
@@ -1,15 +1,16 @@
-devise_for :users, skip: :registrations, controllers: {
-  sessions: "users/sessions",
-  passwords: "users/passwords",
-  unlocks: "users/unlocks",
-  confirmations: "users/confirmations"
-}
-
 allowed_reg_routes = if Settings.disable_signups
   %i[edit update]
 else
   %i[new create edit update]
 end
+
+devise_for :users, skip: :registrations, controllers: {
+  sessions: "users/sessions",
+  passwords: "users/passwords",
+  unlocks: "users/unlocks",
+  confirmations: "users/confirmations",
+  registrations: "users/registrations"
+}
 
 devise_scope :user do
   resource :registration,
@@ -18,8 +19,8 @@ devise_scope :user do
     path_names: {new: "sign_up"},
     controller: "users/registrations",
     as: :user_registration do
-    get :cancel
-    get :token
-    delete :token, action: :regen_token
-  end
+      get :cancel
+      get :token
+      delete :token, action: :regen_token
+    end
 end


### PR DESCRIPTION
## Description

Reported by a user via email who was using `PWP__ALLOW_ANONYMOUS=false`:

```
"after creating an account it doesnt show the pop up which tells 
me to verify my e-mail. It rather shows the same pop up which 
can be confusing for the end user.
```

This PR changes the after sign up path when account confirmation is required (pretty much always).

Now after sign up when `PWP__ALLOW_ANONYMOUS=false`, you get this:

![Screenshot 2024-11-06 at 09 26 48](https://github.com/user-attachments/assets/02d21dcc-feba-4a92-a3be-341b579b1ffc)


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
