### PR TITLE
Security: Only trust local proxies unless overidden

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -695,6 +695,24 @@ throttling:
   # Environment Variable Override: PWP__THROTTLING__SECOND='20'
   second: 60
 
+### Trusted Proxies
+#
+# By default, Password Pusher will only proxy related headers from proxies on
+# the local network.  If you are using a proxy that is not on the local network,
+# you will need to add the IP address of the proxy to the list below.
+#
+# This is useful if you are using a remote reverse proxy such as Cloudflare to
+# serve the application.  If local, you can leave this setting as is.
+# 
+# Multiple IP addresses can be added by separating them with a comma.
+#
+# Environment Variable Override:
+# PWP__TRUSTED_PROXIES='<ipaddress>'
+# PWP__TRUSTED_PROXIES='<ipaddress1>,<ipaddress2>'
+#
+# trusted_proxies:
+#   - '1.2.3.4'
+#   - '2.3.4.5'
 
 ### Mail Server Configuration
 #

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -118,6 +118,19 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
 
+  # The list of trusted proxies from which we will accept proxy related headers.
+  config.action_dispatch.trusted_proxies = [
+    "127.0.0.1",         # Localhost
+    /^::1$/,             # IPv6 localhost
+    /192\.168\.\d{1,3}\.\d{1,3}/, # Local network
+    /10\.\d{1,3}\.\d{1,3}\.\d{1,3}/ # Private networks
+  ]
+
+  if Settings.trusted_proxies.present?
+    trusted_proxies = Settings.trusted_proxies.split(",").map(&:strip)
+    config.action_dispatch.trusted_proxies.concat(trusted_proxies)
+  end
+
   # If a user sets the allowed_hosts setting, we need to add the domain(s) to the list of allowed hosts
   if Settings.allowed_hosts.present?
     if Settings.allowed_hosts.is_a?(Array)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,6 +54,19 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = ENV.key?("FORCE_SSL")
 
+  # The list of trusted proxies from which we will accept proxy related headers.
+  config.action_dispatch.trusted_proxies = [
+    "127.0.0.1",         # Localhost
+    /^::1$/,             # IPv6 localhost
+    /192\.168\.\d{1,3}\.\d{1,3}/, # Local network
+    /10\.\d{1,3}\.\d{1,3}\.\d{1,3}/ # Private networks
+  ]
+
+  if Settings.trusted_proxies.present?
+    trusted_proxies = Settings.trusted_proxies.split(",").map(&:strip)
+    config.action_dispatch.trusted_proxies.concat(trusted_proxies)
+  end
+
   # Logging
   config.logger = if ENV["RAILS_LOG_TO_STDOUT"].present? || Settings.log_to_stdout
     # Log to STDOUT by default

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -695,6 +695,24 @@ throttling:
   # Environment Variable Override: PWP__THROTTLING__SECOND='20'
   second: 60
 
+### Trusted Proxies
+#
+# By default, Password Pusher will only proxy related headers from proxies on
+# the local network.  If you are using a proxy that is not on the local network,
+# you will need to add the IP address of the proxy to the list below.
+#
+# This is useful if you are using a remote reverse proxy such as Cloudflare to
+# serve the application.  If local, you can leave this setting as is.
+# 
+# Multiple IP addresses can be added by separating them with a comma.
+#
+# Environment Variable Override:
+# PWP__TRUSTED_PROXIES='<ipaddress>'
+# PWP__TRUSTED_PROXIES='<ipaddress1>,<ipaddress2>'
+#
+# trusted_proxies:
+#   - '1.2.3.4'
+#   - '2.3.4.5'
 
 ### Mail Server Configuration
 #


### PR DESCRIPTION
## Description

This PR adds a rule to only trust proxies on the local network.

This fixes a weakness where the `X-Forwarded-For` header could be spoofed by unauthorized clients to bypass the rate limiter.

This can be overridden by the new `trusted_proxies` setting:

```yaml
### Trusted Proxies
#
# By default, Password Pusher will only proxy related headers from proxies on
# the local network.  If you are using a proxy that is not on the local network,
# you will need to add the IP address of the proxy to the list below.
#
# This is useful if you are using a remote reverse proxy such as Cloudflare to
# serve the application.  If local, you can leave this setting as is.
# 
# Multiple IP addresses can be added by separating them with a comma.
#
# Environment Variable Override:
# PWP__TRUSTED_PROXIES='<ipaddress>'
# PWP__TRUSTED_PROXIES='<ipaddress1>,<ipaddress2>'
#
# trusted_proxies:
#   - '1.2.3.4'
#   - '2.3.4.5'
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [x] I've added documentation as necessary so users can easily use and understand this feature/fix.
