### PR TITLE
Passphrase: Increase cookie security

### DIFF
--- a/app/controllers/file_pushes_controller.rb
+++ b/app/controllers/file_pushes_controller.rb
@@ -95,7 +95,14 @@ class FilePushesController < BaseController
     if @push.passphrase == params[:passphrase]
       # Passphrase is valid
       # Set the passphrase cookie
-      cookies[name] = {value: @push.passphrase_ciphertext, expires: 10.minutes.from_now}
+      cookies[name] = {
+        value: @push.passphrase_ciphertext,
+        expires: 3.minutes.from_now,
+        secure: Rails.env.production?, # Only send the cookie over HTTPS in production
+        httponly: true,                # Prevent JavaScript access to the cookie
+        same_site: :strict             # Restrict the cookie to same-site requests
+      }
+
       # Redirect to the payload
       redirect_to file_push_path(@push.url_token)
     else

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -94,7 +94,14 @@ class PasswordsController < BaseController
     if @push.passphrase == params[:passphrase]
       # Passphrase is valid
       # Set the passphrase cookie
-      cookies[name] = {value: @push.passphrase_ciphertext, expires: 10.minutes.from_now}
+      cookies[name] = {
+        value: @push.passphrase_ciphertext,
+        expires: 3.minutes.from_now,
+        secure: Rails.env.production?, # Only send the cookie over HTTPS in production
+        httponly: true,                # Prevent JavaScript access to the cookie
+        same_site: :strict             # Restrict the cookie to same-site requests
+      }
+
       # Redirect to the payload
       redirect_to password_path(@push.url_token)
     else

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -94,7 +94,14 @@ class UrlsController < BaseController
     if @push.passphrase == params[:passphrase]
       # Passphrase is valid
       # Set the passphrase cookie
-      cookies[name] = {value: @push.passphrase_ciphertext, expires: 10.minutes.from_now}
+      cookies[name] = {
+        value: @push.passphrase_ciphertext,
+        expires: 3.minutes.from_now,
+        secure: Rails.env.production?, # Only send the cookie over HTTPS in production
+        httponly: true,                # Prevent JavaScript access to the cookie
+        same_site: :strict             # Restrict the cookie to same-site requests
+      }
+
       # Redirect to the payload
       redirect_to url_path(@push.url_token)
     else


### PR DESCRIPTION
## Description

Increase passphrase cookie storage:

* Only send the cookie over HTTPS in production
* Prevent JavaScript access to the cookie
* Restrict the cookie to same-site requests

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
