### PR TITLE
Login: Lock accounts after 10 failed attempts

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -211,7 +211,7 @@ Devise.setup do |config|
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  config.maximum_attempts = 20
+  config.maximum_attempts = 10
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
   config.unlock_in = 1.hour


### PR DESCRIPTION
## Description

If a user has 10 failed login attempts the account is locked and an email is sent to the email address for the account.

From the sent email, the user can unlock his/her account.

This PR lowers the failed attempts from 20 to 10.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
#2798 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
