### PR TITLE
fix database service names in docker-compose-xx.yml

### DIFF
--- a/containers/docker/docker-compose-mariadb.yml
+++ b/containers/docker/docker-compose-mariadb.yml
@@ -16,7 +16,7 @@ services:
   pwpush:
     image: docker.io/pglombardo/pwpush:latest
     environment:
-      DATABASE_URL: 'mysql2://passwordpusher_user:passwordpusher_passwd@mysql:3306/passwordpusher_db'
+      DATABASE_URL: 'mysql2://passwordpusher_user:passwordpusher_passwd@db:3306/passwordpusher_db'
     ports:
       - "5100:5100"
     depends_on:

--- a/containers/docker/docker-compose-mysql.yml
+++ b/containers/docker/docker-compose-mysql.yml
@@ -16,7 +16,7 @@ services:
   pwpush:
     image: docker.io/pglombardo/pwpush:latest
     environment:
-      DATABASE_URL: 'mysql2://passwordpusher_user:passwordpusher_passwd@mysql:3306/passwordpusher_db'
+      DATABASE_URL: 'mysql2://passwordpusher_user:passwordpusher_passwd@db:3306/passwordpusher_db'
     ports:
       - "5100:5100"
     depends_on:


### PR DESCRIPTION
## Description

This pull request addresses issues in the `docker-compose-mysql.yml` and `docker-compose-mariadb.yml` files related to the naming of the database services. Currently, both the MySQL and MariaDB containers have inconsistent service names. The MySQL container is defined under the service name `db`, while the application container attempts to connect to it using the name `mysql`. Similarly, the MariaDB container is also misconfigured. These discrepancies can lead to connection issues, particularly when the stack is integrated into a more complex environment, such as when the container is behind a reverse proxy. Using the correct service names is also a cleaner and more maintainable approach, regardless of the environment in which the stack is deployed.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.

After making these changes, I ran the Docker Compose setup and verified that the application can now connect to both the MySQL and MariaDB databases without any issues.
