### PR TITLE
Preliminary: Set rel="no-prefetch" to block browser pre-fetch

### DIFF
--- a/app/views/file_pushes/preliminary.html.erb
+++ b/app/views/file_pushes/preliminary.html.erb
@@ -1,5 +1,5 @@
 <div class="container h-100">
     <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center">
-        <p> <%= link_to _("Click Here to Proceed"), @secret_url, "data-turbo-prefetch": false %> </p>
+        <p> <%= link_to _("Click Here to Proceed"), @secret_url, data: { turbo_prefetch: false }, rel: "no-prefetch" %> </p>
     </div>
 </div>

--- a/app/views/passwords/preliminary.html.erb
+++ b/app/views/passwords/preliminary.html.erb
@@ -1,5 +1,5 @@
 <div class="container h-100">
     <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center">
-        <p> <%= link_to _("Click Here to Proceed"), @secret_url, "data-turbo-prefetch": false %> </p>
+        <p> <%= link_to _("Click Here to Proceed"), @secret_url, data: { turbo_prefetch: false }, rel: "no-prefetch" %> </p>
     </div>
 </div>

--- a/app/views/urls/preliminary.html.erb
+++ b/app/views/urls/preliminary.html.erb
@@ -1,5 +1,5 @@
 <div class="container h-100">
     <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center">
-        <p> <%= link_to _("Click Here to Proceed"), @secret_url, "data-turbo-prefetch": false %> </p>
+        <p> <%= link_to _("Click Here to Proceed"), @secret_url, data: { turbo_prefetch: false }, rel: "no-prefetch" %> </p>
     </div>
 </div>


### PR DESCRIPTION
## Description

This is the second attempt to block browser pre-fetching.  This time by adding `rel="no-prefetch"` to the "Click here to proceed link".

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

#2225 
<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
