### PR TITLE
New Cloudflare Setting: Optionally fetch CF IPs on container boot.

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -714,6 +714,21 @@ throttling:
 #   - '1.2.3.4'
 #   - '2.3.4.5'
 
+## Cloudflare Proxy
+#
+# If you are using Cloudflare as a proxy, you will need to set the following
+# value to true.  This will cause the application to fetch the list of Cloudflare
+# proxy IP addresses and add them to the list of trusted proxies.
+#
+# Note that on application boot, this will trigger two HTTPs requests to fetch
+# the list of Cloudflare IP addresses.  The requests each have a timeout of 15 seconds
+# and may delay on container boot.
+#
+# Environment Variable Override:
+# PWP__CLOUDFLARE_PROXY='false'
+#
+cloudflare_proxy: false
+
 ### Mail Server Configuration
 #
 # When logins are enabled, an SMTP server is required to send emails to users

--- a/config/initializers/cloudflare_proxy.rb
+++ b/config/initializers/cloudflare_proxy.rb
@@ -1,0 +1,40 @@
+require "net/http"
+
+if Settings.cloudflare_proxy
+  def fetch_with_timeout(url, timeout: 15)
+    uri = URI(url)
+    Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: timeout, read_timeout: timeout) do |http|
+      request = Net::HTTP::Get.new(uri)
+      http.request(request).body
+    end
+  rescue => e
+    Rails.logger.warn "Failed to fetch #{url}: #{e.message}"
+    ""
+  end
+
+  Rails.logger.info "Fetching latest Cloudflare IPs..."
+
+  cf_ipv4_url = "https://www.cloudflare.com/ips-v4"
+  cf_ipv6_url = "https://www.cloudflare.com/ips-v6"
+
+  begin
+    # Fetch Cloudflare IP ranges with timeout
+    ipv4 = fetch_with_timeout(cf_ipv4_url).split("\n")
+    ipv6 = fetch_with_timeout(cf_ipv6_url).split("\n")
+    cloudflare_ips = ipv4 + ipv6
+  rescue => e
+    Rails.logger.warn "Failed to fetch Cloudflare IPs: #{e.message}"
+    cloudflare_ips = [] # Fallback to no Cloudflare IPs
+  end
+
+  # Add Cloudflare IPs to existing trusted proxies
+  Rails.application.config.action_dispatch.trusted_proxies ||= []
+  Rails.application.config.action_dispatch.trusted_proxies += cloudflare_ips.filter_map do |ip|
+    IPAddr.new(ip)
+  rescue ArgumentError => e
+    Rails.logger.warn "Invalid IP format skipped: #{ip} (#{e.message})"
+    nil
+  end
+
+  Rails.logger.info "Cloudflare IPs added to trusted proxies."
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -714,6 +714,21 @@ throttling:
 #   - '1.2.3.4'
 #   - '2.3.4.5'
 
+## Cloudflare Proxy
+#
+# If you are using Cloudflare as a proxy, you will need to set the following
+# value to true.  This will cause the application to fetch the list of Cloudflare
+# proxy IP addresses and add them to the list of trusted proxies.
+#
+# Note that on application boot, this will trigger two HTTPs requests to fetch
+# the list of Cloudflare IP addresses.  The requests each have a timeout of 15 seconds
+# and may delay on container boot.
+#
+# Environment Variable Override:
+# PWP__CLOUDFLARE_PROXY='false'
+#
+cloudflare_proxy: false
+
 ### Mail Server Configuration
 #
 # When logins are enabled, an SMTP server is required to send emails to users


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

With recent releases only local proxies are trusted by default.  There is a [setting](https://github.com/pglombardo/PasswordPusher/blob/master/config/settings.yml#L698-L715) that allows you to add IPs to this list but in cases where Cloudflare has a long list or often change IPs this can be troublesome.

This PR adds `PWP__CLOUDFLARE_PROXY=false` and a `cloudflare_proxy: false` in your `settings.yml`.  Set one of these to `true` to enable fetching of CloudFlare IPs on container boot.

See #2799 for the discussion.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
#2799

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
