### PR TITLE
Fix: Downcase theme selection

### DIFF
--- a/set_theme.js
+++ b/set_theme.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 
 // Get the theme name from the environment variable, default to "default"
-const theme = process.env.PWP__THEME || "default";
+const theme = (process.env.PWP__THEME || "default").toLowerCase();
 
 // Define paths
 const themesDir = path.resolve(__dirname, "./app/assets/stylesheets/themes");


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
The new theme selection doesn't downcase the name to match the filename.  Fixed.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
#2905

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [X] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
