### PR TITLE
Fix the Chinese translation of 'Optional'

### DIFF
--- a/config/locales/gettext/zh_CN/app.po
+++ b/config/locales/gettext/zh_CN/app.po
@@ -915,7 +915,7 @@ msgstr "加密且对接收方可见"
 #: ../../../app/views/passwords/new.html.erb:159
 #: ../../../app/views/urls/new.html.erb:111
 msgid "Optional"
-msgstr "选修的"
+msgstr "可选的"
 
 #: ../../../app/views/file_pushes/new.html.erb:141
 #: ../../../app/views/passwords/new.html.erb:162


### PR DESCRIPTION
## Description

Update to correct Chinese text.

## Related Issue

N/A

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist


- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
