### PR TITLE
Fix: Continued Alpine Adjustments

### DIFF
--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -23,7 +23,8 @@ RUN apk add --no-cache \
     tzdata \
     yaml-dev \
     yarn \
-    pkgconf
+    pkgconf \
+    openssl-dev
 
 
 ENV APP_ROOT=/opt/PasswordPusher


### PR DESCRIPTION
## Description

Things that previously built without issue are now failing.  I believe this is due to a base layer change.

```
#16 1967.5 current directory:
#16 1967.5 /opt/PasswordPusher/vendor/bundle/ruby/3.4.0/gems/puma-6.6.0/ext/puma_http11
#16 1967.5 /usr/local/bin/ruby extconf.rb
#16 1967.5 checking for pkg-config for openssl... *** extconf.rb failed ***
#16 1967.5 Could not create Makefile due to some reason, probably lack of necessary
#16 1967.5 libraries and/or headers.  Check the mkmf.log file for more details.  You may
#16 1967.5 need configuration options.
```

This PR adds openssl-dev.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
