### PR TITLE
Add environment variable to disable Turbo Drive

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,11 @@ import "@hotwired/turbo-rails"
 import "@rails/activestorage"
 import "bootstrap"
 import "./controllers"
+
+// Check if Turbo Drive should be disabled
+const turboDriveEnabled = document.querySelector('meta[name="turbo-drive-enabled"]')?.content === 'true'
+
+if (!turboDriveEnabled) {
+  console.log("⚡ Turbo Drive is disabled via environment variable")
+  Turbo.session.drive = false
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
 
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+  <%= tag.meta name: 'turbo-drive-enabled', content: ENV['TURBO_DRIVE_ENABLED'].to_s.downcase == 'true' %>
 </head>
 
 <body class="d-flex flex-column min-vh-100">


### PR DESCRIPTION
## Description

Adds support for a new environment variable `TURBO_DRIVE_ENABLED` documented here: https://docs.pwpush.com/docs/self-hosted-configuration/

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
