### PR TITLE
New Login Session Timeout Config Option

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -51,6 +51,26 @@ enable_file_pushes: false
 #
 enable_logins: false
 
+## Login Session Timeout
+#
+# The duration you want to timeout the user session without activity. After this
+# time the user will be asked for credentials again.
+#
+# Default: 2 hours
+#
+# Examples:
+#
+# login_session_timeout: "15 minutes"
+# login_session_timeout: "6 hours"
+# login_session_timeout: "1 day"
+# login_session_timeout: "3 weeks"
+# login_session_timeout: "1 month"
+#
+# Environment variable override:
+# PWP__LOGIN_SESSION_TIMEOUT='2 hours'
+#
+login_session_timeout: "2 hours"
+
 ## Disable Signups
 #
 # Disallow new user accounts to be created in the application.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -191,7 +191,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 2.hours
+  config.timeout_in = Settings.login_session_timeout.to_s.strip.split(" ").then { |n, u| n.to_i.send(u.downcase.to_sym) }
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -51,6 +51,26 @@ enable_file_pushes: false
 #
 enable_logins: false
 
+## Login Session Timeout
+#
+# The duration you want to timeout the user session without activity. After this
+# time the user will be asked for credentials again.
+#
+# Default: 2 hours
+#
+# Examples:
+#
+# login_session_timeout: "15 minutes"
+# login_session_timeout: "6 hours"
+# login_session_timeout: "1 day"
+# login_session_timeout: "3 weeks"
+# login_session_timeout: "1 month"
+#
+# Environment variable override:
+# PWP__LOGIN_SESSION_TIMEOUT='2 hours'
+#
+login_session_timeout: "2 hours"
+
 ## Disable Signups
 #
 # Disallow new user accounts to be created in the application.


### PR DESCRIPTION
## Description

In `settings.yml`:
```
## Login Session Timeout
#
# The duration you want to timeout the user session without activity. After this
# time the user will be asked for credentials again.
#
# Default: 2 hours
#
# Examples:
#
# login_session_timeout: "15 minutes"
# login_session_timeout: "6 hours"
# login_session_timeout: "1 day"
# login_session_timeout: "3 weeks"
# login_session_timeout: "1 month"
#
# Environment variable override:
# PWP__LOGIN_SESSION_TIMEOUT='2 hours'
#
```


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
