### PR TITLE
Fix Dark Themes: Remove forced bg-light

### DIFF
--- a/app/views/devise/confirmations/show.html.erb
+++ b/app/views/devise/confirmations/show.html.erb
@@ -1,6 +1,6 @@
 
-<div class="container-fluid h-100 mx-0 py-0 px-0 bg-light">
-  <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center bg-light">
+<div class="container-fluid h-100 mx-0 py-0 px-0">
+  <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center">
     <%= link_to t('confirmation_go'), user_confirmation_path({ confirmation_token: h(params[:confirmation_token]), go: true}) %>
   </div>
 </div>

--- a/app/views/file_pushes/show.html.erb
+++ b/app/views/file_pushes/show.html.erb
@@ -1,7 +1,7 @@
 <% plain_title(_('Your Secret Link')) %>
 
-<div class="container-fluid h-100 mx-0 py-0 px-0 bg-light">
-  <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center bg-light" data-controller="copy passwords" data-copy-lang-copied-value="<%= _('Copied!') %>">
+<div class="container-fluid h-100 mx-0 py-0 px-0">
+  <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center" data-controller="copy passwords" data-copy-lang-copied-value="<%= _('Copied!') %>">
     <% if @push.payload.nil? || @push.payload.empty? %>
         <div class='text-center m-3'>
           <p class="display-5"><%= _('The following files have been sent to you.') %></p>

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -21,7 +21,7 @@
 </head>
 
 <body class="d-flex flex-column min-vh-100">
-  <div class="container-fluid d-flex flex-column min-vh-100 justify-content-center align-items-center bg-light">
+  <div class="container-fluid d-flex flex-column min-vh-100 justify-content-center align-items-center">
     <%= render partial: 'shared/alerts' %>
     <main class="col-12 col-sm-8 col-md-6 col-lg-4 text-center">
       <%= link_to root_path(locale: locale.to_s), hreflang: locale.to_s do %>

--- a/app/views/passwords/show.html.erb
+++ b/app/views/passwords/show.html.erb
@@ -1,7 +1,7 @@
 <% plain_title(_('Your Secret Link')) %>
 
-<div class="container-fluid h-100 mx-0 py-0 px-0 bg-light" data-controller="copy passwords" data-copy-lang-copied-value="<%= _('Copied!') %>">
-  <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center bg-light">
+<div class="container-fluid h-100 mx-0 py-0 px-0" data-controller="copy passwords" data-copy-lang-copied-value="<%= _('Copied!') %>">
+  <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center">
     <% unless @push.payload.empty? %>
         <div class='text-center m-3'>
           <p class=""><strong><%= _('Please obtain and securely store this content in a secure manner, such as in a password manager.') %></strong></p>


### PR DESCRIPTION
## Description

This PR fixes a bunch of problems across many themes related to dark mode.

Also, push delivery pages now show up in Dark mode.  😎 

![Screenshot 2025-02-26 at 14 20 51](https://github.com/user-attachments/assets/522cf862-e5b3-462a-a4a8-8c87398854ff)
![Screenshot 2025-02-26 at 14 21 42](https://github.com/user-attachments/assets/52c01090-92a6-4070-a9c8-bf10b5969658)
![Screenshot 2025-02-26 at 14 20 57](https://github.com/user-attachments/assets/e4a27943-b2a0-4c09-ad38-221ded416c07)


<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
