### PR TITLE
Run Background Worker in Core Container

### DIFF
--- a/containers/docker/entrypoint.sh
+++ b/containers/docker/entrypoint.sh
@@ -22,7 +22,10 @@ if [ -n "$PWP__THEME" ] || [ -n "$PWP_PRECOMPILE" ]; then
     bundle exec rails assets:precompile
 fi
 
-echo "Password Pusher: starting puma webserver..."
-bundle exec puma -C config/puma.rb
+echo "Password Pusher: starting foreman..."
 
-exec "$@"
+if [ -n "$PWP__NO_WORKER" ] || [ -n "$PWP_PUBLIC_GATEWAY" ]; then
+    exec bundle exec foreman start -m web=1
+else
+    exec bundle exec foreman start -m web=1,worker=1
+fi


### PR DESCRIPTION
## Description

Previously, I introduced the `pwpush-worker` container but haven't brought it past Beta.

This PR is a different approach to simply run the background worker in the same `pglombardo/pwpush` container.

If this change goes well, I may scrap the `pwpush-worker` container.

Running in the single container is just simpler.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
