### PR TITLE
Themes: Remove selected.css; generated on boot

### DIFF
--- a/app/assets/stylesheets/themes/selected.css
+++ b/app/assets/stylesheets/themes/selected.css
@@ -1,1 +1,0 @@
-/Users/pglombardo/Projects/apnotic/pwpush/app/assets/stylesheets/themes/default.css


### PR DESCRIPTION
## Description

This file is generated on application boot by `set_theme.js`.  It's not necessary to have it in version control.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
