### PR TITLE
Add a default host for emails sent/shown locally

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,6 +40,7 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :mailbin
   config.action_mailer.perform_deliveries = true
+  config.action_mailer.default_url_options = {host: "127.0.0.1:5100"}
 
   config.logger = Logger.new($stdout) if Settings.log_to_stdout
   config.log_level = :debug


### PR DESCRIPTION
## Description

With #3342, the host used for emails sent/shown emails is removed mistakenly. It prevents to send emails locally.
![image](https://github.com/user-attachments/assets/2e02db45-0961-46b9-96c1-148a4d35d14e)

So, a default host is added.

## Related Issue

#3342 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
-- I haven't added any test
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
