### PR TITLE
Add `name` to pushes

### DIFF
--- a/app/controllers/api/v1/file_pushes_controller.rb
+++ b/app/controllers/api/v1/file_pushes_controller.rb
@@ -125,7 +125,6 @@ class Api::V1::FilePushesController < Api::BaseController
 
       {
         "url_token": "quyul5r5w18",
-        "name": null,
         "created_at": "2023-10-20T15:32:01Z",
         "expire_after_days": 2,
         "expire_after_views": 5,

--- a/app/controllers/api/v1/file_pushes_controller.rb
+++ b/app/controllers/api/v1/file_pushes_controller.rb
@@ -98,6 +98,7 @@ class Api::V1::FilePushesController < Api::BaseController
   param :file_push, Hash, "Push details", required: true do
     param :payload, String, desc: "The URL encoded secret text to share.", required: true
     param :passphrase, String, desc: "Require recipients to enter this passphrase to view the created push."
+    param :name, String, desc: "Visible only to the push creator.", allow_blank: true
     param :note, String,
       desc: "If authenticated, the URL encoded note for this push.  Visible only to the push creator.", allow_blank: true
     param :expire_after_days, Integer, desc: "Expire secret link and delete after this many days."
@@ -124,6 +125,7 @@ class Api::V1::FilePushesController < Api::BaseController
 
       {
         "url_token": "quyul5r5w18",
+        "name": null,
         "created_at": "2023-10-20T15:32:01Z",
         "expire_after_days": 2,
         "expire_after_views": 5,
@@ -297,6 +299,7 @@ class Api::V1::FilePushesController < Api::BaseController
           "url_token": "fkwjfvhall92",
           "created_at": "2023-10-20T15:32:01Z",
           "expires_on": "2023-10-23T15:32:01Z",
+          "name": null,
           ...
         },
         ...
@@ -463,7 +466,7 @@ class Api::V1::FilePushesController < Api::BaseController
 
   def file_push_params
     params.require(:file_push).permit(:payload, :expire_after_days, :expire_after_views,
-      :retrieval_step, :deletable_by_viewer, :note, :passphrase, files: [])
+      :retrieval_step, :deletable_by_viewer, :name, :note, :passphrase, files: [])
   end
 
   def print_preview_params

--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -142,7 +142,6 @@ class Api::V1::PasswordsController < Api::BaseController
         "expires_at": "2023-10-20T15:32:01Z",
         "views_remaining": 10,
         "passphrase": null,
-        "name": null,
         "note": null,
         ...
       }

--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -382,7 +382,6 @@ class Api::V1::PasswordsController < Api::BaseController
       [
         {
           "url_token": "fkwjfvhall92",
-          "name": null,
           "created_at": "2023-10-20T15:32:01Z",
           "expires_on": "2023-10-23T15:32:01Z",
           "expire_after_days": 7,

--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -93,6 +93,7 @@ class Api::V1::PasswordsController < Api::BaseController
   param :password, Hash, "Push details", required: true do
     param :payload, String, desc: "The URL encoded password or secret text to share.", required: true
     param :passphrase, String, desc: "Require recipients to enter this passphrase to view the created push."
+    param :name, String, desc: "Visible only to the push creator.", allow_blank: true
     param :note, String, desc: "If authenticated, the URL encoded note for this push.  Visible only to the push creator.", allow_blank: true
     param :expire_after_days, Integer, desc: "Expire secret link and delete after this many days."
     param :expire_after_views, Integer, desc: "Expire secret link and delete after this many views."
@@ -141,6 +142,7 @@ class Api::V1::PasswordsController < Api::BaseController
         "expires_at": "2023-10-20T15:32:01Z",
         "views_remaining": 10,
         "passphrase": null,
+        "name": null,
         "note": null,
         ...
       }
@@ -177,6 +179,7 @@ class Api::V1::PasswordsController < Api::BaseController
     create_detect_retrieval_step(@push, params)
 
     @push.payload = params[:password][:payload]
+    @push.name = params[:password][:name]
     @push.note = params[:password].fetch(:note, "")
     @push.passphrase = params[:password].fetch(:passphrase, "")
 
@@ -332,6 +335,7 @@ class Api::V1::PasswordsController < Api::BaseController
           {
             "url_token": "fkwjfvhall92",
             "created_at": "2023-10-20T15:32:01Z",
+            "name": null,
             "expire_after_days": 7,
             "expire_after_views": 1,
             "expired": false,
@@ -378,6 +382,7 @@ class Api::V1::PasswordsController < Api::BaseController
       [
         {
           "url_token": "fkwjfvhall92",
+          "name": null,
           "created_at": "2023-10-20T15:32:01Z",
           "expires_on": "2023-10-23T15:32:01Z",
           "expire_after_days": 7,
@@ -506,6 +511,6 @@ class Api::V1::PasswordsController < Api::BaseController
 
   def password_params
     params.require(:password).permit(:payload, :expire_after_days, :expire_after_views,
-      :retrieval_step, :deletable_by_viewer, :note)
+      :retrieval_step, :deletable_by_viewer, :name, :note)
   end
 end

--- a/app/controllers/api/v1/urls_controller.rb
+++ b/app/controllers/api/v1/urls_controller.rb
@@ -289,6 +289,7 @@ class Api::V1::UrlsController < Api::BaseController
       [
         {
           "url_token": "fkwjfvhall92",
+          "name": null,
           "created_at": "2023-10-20T15:32:01Z",
           "expires_on": "2023-10-23T15:32:01Z",
           ...
@@ -334,7 +335,6 @@ class Api::V1::UrlsController < Api::BaseController
           "url_token": "fkwjfvhall92",
           "created_at": "2023-10-20T15:32:01Z",
           "expires_on": "2023-10-23T15:32:01Z",
-          "name": null,
           ...
         },
         ...

--- a/app/controllers/api/v1/urls_controller.rb
+++ b/app/controllers/api/v1/urls_controller.rb
@@ -111,7 +111,6 @@ class Api::V1::UrlsController < Api::BaseController
         "created_at": "2023-10-20T15:32:01Z",
         "expire_after_days": 2,
         "expire_after_views": 10,
-        "name": null
         ...
       }
   EOS

--- a/app/controllers/api/v1/urls_controller.rb
+++ b/app/controllers/api/v1/urls_controller.rb
@@ -82,6 +82,7 @@ class Api::V1::UrlsController < Api::BaseController
   param :url, Hash, "Push details", required: true do
     param :payload, String, desc: "The URL encoded URL to redirect to.", required: true
     param :passphrase, String, desc: "Require recipients to enter this passphrase to view the created push."
+    param :name, String, desc: "Visible only to the push creator.", allow_blank: true
     param :note, String,
       desc: "If authenticated, the URL encoded note for this push.  Visible only to the push creator.", allow_blank: true
     param :expire_after_days, Integer, desc: "Expire secret link and delete after this many days."
@@ -110,6 +111,7 @@ class Api::V1::UrlsController < Api::BaseController
         "created_at": "2023-10-20T15:32:01Z",
         "expire_after_days": 2,
         "expire_after_views": 10,
+        "name": null
         ...
       }
   EOS
@@ -142,6 +144,7 @@ class Api::V1::UrlsController < Api::BaseController
     create_detect_retrieval_step(@push, params)
 
     @push.payload = params[:url][:payload]
+    @push.name = params[:url][:name]
     @push.note = params[:url][:note] if params[:url].fetch(:note, "").present?
     @push.passphrase = params[:url].fetch(:passphrase, "")
 
@@ -331,6 +334,7 @@ class Api::V1::UrlsController < Api::BaseController
           "url_token": "fkwjfvhall92",
           "created_at": "2023-10-20T15:32:01Z",
           "expires_on": "2023-10-23T15:32:01Z",
+          "name": null,
           ...
         },
         ...
@@ -424,6 +428,6 @@ class Api::V1::UrlsController < Api::BaseController
   end
 
   def url_params
-    params.require(:url).permit(:payload, :expire_after_days, :expire_after_views, :retrieval_step, :note, :passphrase)
+    params.require(:url).permit(:payload, :expire_after_days, :expire_after_views, :retrieval_step, :name, :note, :passphrase)
   end
 end

--- a/app/controllers/file_pushes_controller.rb
+++ b/app/controllers/file_pushes_controller.rb
@@ -323,7 +323,7 @@ class FilePushesController < BaseController
 
   def file_push_params
     params.require(:file_push).permit(:payload, :expire_after_days, :expire_after_views,
-      :retrieval_step, :deletable_by_viewer, :note, :passphrase, files: [])
+      :retrieval_step, :deletable_by_viewer, :name, :note, :passphrase, files: [])
   end
 
   def print_preview_params

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -133,6 +133,7 @@ class PasswordsController < BaseController
     create_detect_retrieval_step(@push, params)
 
     @push.payload = params[:password][:payload]
+    @push.name = params[:password][:name]
     @push.note = params[:password].fetch(:note, "")
     @push.passphrase = params[:password].fetch(:passphrase, "")
 
@@ -337,7 +338,7 @@ class PasswordsController < BaseController
 
   def password_params
     params.require(:password).permit(:payload, :expire_after_days, :expire_after_views,
-      :retrieval_step, :deletable_by_viewer, :note)
+      :retrieval_step, :deletable_by_viewer, :name, :note)
   end
 
   def print_preview_params

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -126,6 +126,7 @@ class UrlsController < BaseController
     create_detect_retrieval_step(@push, params)
 
     @push.payload = params[:url][:payload]
+    @push.name = params[:url][:name]
     @push.note = params[:url][:note] if params[:url].fetch(:note, "").present?
     @push.passphrase = params[:url].fetch(:passphrase, "")
 
@@ -304,7 +305,7 @@ class UrlsController < BaseController
   end
 
   def url_params
-    params.require(:url).permit(:payload, :expire_after_days, :expire_after_views, :retrieval_step, :note, :passphrase)
+    params.require(:url).permit(:payload, :expire_after_days, :expire_after_views, :retrieval_step, :name, :note, :passphrase)
   end
 
   def print_preview_params

--- a/app/models/file_push.rb
+++ b/app/models/file_push.rb
@@ -76,6 +76,7 @@ class FilePush < ApplicationRecord
     attr_hash.delete("id")
 
     attr_hash.delete("passphrase")
+    attr_hash.delete("name") unless owner
     attr_hash.delete("note") unless owner
     attr_hash.delete("payload") unless payload
 

--- a/app/models/password.rb
+++ b/app/models/password.rb
@@ -66,6 +66,7 @@ class Password < ApplicationRecord
     attr_hash.delete("id")
 
     attr_hash.delete("passphrase")
+    attr_hash.delete("name") unless owner
     attr_hash.delete("note") unless owner
     attr_hash.delete("payload") unless payload
 

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -66,6 +66,7 @@ class Url < ApplicationRecord
     attr_hash.delete("id")
 
     attr_hash.delete("passphrase")
+    attr_hash.delete("name") unless owner
     attr_hash.delete("note") unless owner
     attr_hash.delete("payload") unless payload
 

--- a/app/views/file_pushes/active.html.erb
+++ b/app/views/file_pushes/active.html.erb
@@ -20,7 +20,7 @@
     <table class="table table-striped table-bordered table-sm table-hover caption-top align-middle" aria-label='<%= _('Active Pushes') %>'>
       <thead>
       <tr>
-          <th scope="col"><%= _('Push ID') %></th>
+          <th scope="col"><%= t("pushes.form.name_or_id") %></th>
           <th scope="col"><%= _('Created') %></th>
           <th scope="col"><%= _('Note') %></th>
           <th scope="col" class="text-center"><%= _('File Count') %></th>
@@ -32,7 +32,11 @@
       <tbody class="table-group-divider">
       <% for push in @pushes do %>
         <tr>
-          <td><%= push.url_token %></td>
+          <% if push.name.present? %>
+            <td><%= push.name %></td>
+          <% else %>
+            <td><%= push.url_token %></td>
+          <% end %>
           <td><%= I18n.l push.created_at.in_time_zone(Settings.timezone), format: :long %></td>
           <td>
             <% if push.note.blank? %>

--- a/app/views/file_pushes/new.html.erb
+++ b/app/views/file_pushes/new.html.erb
@@ -121,6 +121,15 @@
         <div class='col'>
             <div class='row mb-3'>
                 <div class="input-group">
+                    <span class="input-group-text"><%= FilePush.human_attribute_name("name") %></span>
+                    <%= f.text_field(:name, { class: "form-control",
+                                            placeholder: _('Optional'),
+                                            autocomplete: "off" }) %>
+                </div>
+                <div class="form-text" id="basic-addon4"><%= _('A name shown in the dashboard, notifications and emails.') %></div>
+            </div>
+            <div class='row mb-3'>
+                <div class="input-group">
                     <span class="input-group-text"><%= _('Message') %></span>
                     <%= f.text_area(:payload, { class: "form-control",
                                             rows: 3,

--- a/app/views/file_pushes/new.html.erb
+++ b/app/views/file_pushes/new.html.erb
@@ -121,7 +121,7 @@
         <div class='col'>
             <div class='row mb-3'>
                 <div class="input-group">
-                    <span class="input-group-text"><%= FilePush.human_attribute_name("name") %></span>
+                    <span class="input-group-text"><%= FilePush.human_attribute_name(:name) %></span>
                     <%= f.text_field(:name, { class: "form-control",
                                             placeholder: _('Optional'),
                                             autocomplete: "off" }) %>

--- a/app/views/passwords/active.html.erb
+++ b/app/views/passwords/active.html.erb
@@ -20,7 +20,7 @@
     <table class="table table-striped table-bordered table-sm table-hover caption-top align-middle" aria-label='<%= _('Active Pushes') %>'>
       <thead>
       <tr>
-          <th scope="col"><%= _('Push ID') %></th>
+          <th scope="col"><%= t("pushes.form.name_or_id") %></th>
           <th scope="col"><%= _('Created') %></th>
           <th scope="col"><%= _('Note') %></th>
           <th scope="col" class="text-center"><%= _('Views') %></th>
@@ -31,7 +31,11 @@
       <tbody class="table-group-divider">
       <% for push in @pushes do %>
         <tr>
-          <td><%= push.url_token %></td>
+          <% if push.name.present? %>
+            <td><%= push.name %></td>
+          <% else %>
+            <td><%= push.url_token %></td>
+          <% end %>
           <td><%= I18n.l push.created_at.in_time_zone(Settings.timezone), format: :long %></td>
           <td>
             <% if push.note.blank? %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -153,6 +153,15 @@
             <% if user_signed_in? %>
                 <div class='row mb-3'>
                     <div class="input-group">
+                        <span class="input-group-text"><%= Password.human_attribute_name("name") %></span>
+                        <%= f.text_field(:name, { class: "form-control",
+                                                placeholder: _('Optional'),
+                                                autocomplete: "off" }) %>
+                    </div>
+                    <div class="form-text" id="basic-addon4"><%= _('A name shown in the dashboard, notifications and emails.') %></div>
+                </div>
+                <div class='row mb-3'>
+                    <div class="input-group">
                         <span class="input-group-text"><%= _('Reference Note') %></span>
                         <%= f.text_area(:note, { class: "form-control",
                                                 rows: 1,

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -153,7 +153,7 @@
             <% if user_signed_in? %>
                 <div class='row mb-3'>
                     <div class="input-group">
-                        <span class="input-group-text"><%= Password.human_attribute_name("name") %></span>
+                        <span class="input-group-text"><%= Password.human_attribute_name(:name) %></span>
                         <%= f.text_field(:name, { class: "form-control",
                                                 placeholder: _('Optional'),
                                                 autocomplete: "off" }) %>

--- a/app/views/urls/active.html.erb
+++ b/app/views/urls/active.html.erb
@@ -20,7 +20,7 @@
     <table class="table table-striped table-bordered table-sm table-hover caption-top align-middle" aria-label='<%= _('Active Pushes') %>'>
       <thead>
       <tr>
-          <th scope="col"><%= _('Push ID') %></th>
+          <th scope="col"><%= t("pushes.form.name_or_id") %></th>
           <th scope="col"><%= _('Created') %></th>
           <th scope="col"><%= _('Note') %></th>
           <th scope="col" class="text-center"><%= _('Views') %></th>
@@ -31,7 +31,11 @@
       <tbody class="table-group-divider">
       <% for push in @pushes do %>
         <tr>
-          <td><%= push.url_token %></td>
+          <% if push.name.present? %>
+            <td><%= push.name %></td>
+          <% else %>
+            <td><%= push.url_token %></td>
+          <% end %>
           <td><%= I18n.l push.created_at.in_time_zone(Settings.timezone), format: :long %></td>
           <td>
             <% if push.note.blank? %>

--- a/app/views/urls/new.html.erb
+++ b/app/views/urls/new.html.erb
@@ -105,7 +105,7 @@
         <div class='col'>
             <div class='row mb-3'>
                 <div class="input-group">
-                    <span class="input-group-text"><%= Url.human_attribute_name("name") %></span>
+                    <span class="input-group-text"><%= Url.human_attribute_name(:name) %></span>
                     <%= f.text_field(:name, { class: "form-control",
                                             placeholder: _('Optional'),
                                             autocomplete: "off" }) %>

--- a/app/views/urls/new.html.erb
+++ b/app/views/urls/new.html.erb
@@ -105,6 +105,15 @@
         <div class='col'>
             <div class='row mb-3'>
                 <div class="input-group">
+                    <span class="input-group-text"><%= Url.human_attribute_name("name") %></span>
+                    <%= f.text_field(:name, { class: "form-control",
+                                            placeholder: _('Optional'),
+                                            autocomplete: "off" }) %>
+                </div>
+                <div class="form-text" id="basic-addon4"><%= _('A name shown in the dashboard, notifications and emails.') %></div>
+            </div>
+            <div class='row mb-3'>
+                <div class="input-group">
                     <span class="input-group-text"><%= _('Reference Note') %></span>
                     <%= f.text_area(:note, { class: "form-control",
                                             rows: 1,

--- a/config/locales/pwpx.en.yml
+++ b/config/locales/pwpx.en.yml
@@ -136,6 +136,14 @@ en:
       save: Save Policy
       team_policy: Team Policy
       team_policy_help: A team policy is a set of rules that apply to all pushes made by members of this team.
+  activerecord:
+    attributes:
+      file_push:
+        name: Name
+      password:
+        name: Name
+      url:
+        name: Name
   admin:
     config:
       menu_item: Configuration
@@ -723,6 +731,7 @@ en:
       encryption_tip: Content is encrypted prior to storage and is available to only those with the secret link.
       expiration_label: 'Expire this push and delete after:'
       expiration_tip: All content and files of the push are deleted entirely on expiration.
+      name_or_id: Name or ID
       note_label: Reference Note
       note_placeholder: A private note for this push.  Encrypted & visible only to you and your team.
       passphrase_lockdown: Passphrase Lockdown

--- a/db/migrate/20250513074136_add_name_to_models.rb
+++ b/db/migrate/20250513074136_add_name_to_models.rb
@@ -1,0 +1,7 @@
+class AddNameToModels < ActiveRecord::Migration[7.2]
+  def change
+    add_column :passwords, :name, :string
+    add_column :file_pushes, :name, :string
+    add_column :urls, :name, :string  
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_08_192458) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_13_074136) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_08_192458) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "passphrase_ciphertext", limit: 2048
+    t.string "name"
     t.index ["url_token"], name: "index_file_pushes_on_url_token", unique: true
     t.index ["user_id"], name: "index_file_pushes_on_user_id"
   end
@@ -74,6 +75,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_08_192458) do
     t.text "payload_ciphertext", limit: 16777215
     t.text "note_ciphertext"
     t.text "passphrase_ciphertext", limit: 2048
+    t.string "name"
     t.index ["url_token"], name: "index_passwords_on_url_token", unique: true
     t.index ["user_id"], name: "index_passwords_on_user_id"
   end
@@ -214,6 +216,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_08_192458) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "passphrase_ciphertext", limit: 2048
+    t.string "name"
     t.index ["url_token"], name: "index_urls_on_url_token", unique: true
     t.index ["user_id"], name: "index_urls_on_user_id"
   end

--- a/test/integration/file_push/file_push_active_test.rb
+++ b/test/integration/file_push/file_push_active_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FilePushActiveTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_file_pushes = true
+    Rails.application.reload_routes!
+    @luca = users(:luca)
+    @luca.confirm
+    sign_in @luca
+  end
+
+  teardown do
+    sign_out :user
+  end
+
+  def test_active
+    get new_file_push_path
+    assert_response :success
+
+    post file_pushes_path, params: {
+      file_push: {
+        payload: "Message",
+        files: [
+          fixture_file_upload("monkey.png", "image/jpeg")
+        ],
+        name: "Test File Push"
+      }
+    }
+    assert_response :redirect
+
+    follow_redirect!
+    assert_response :success
+    assert_select "h2", "Your push has been created."
+
+    push = active_file_pushes_path
+    get push
+    assert_response :success
+
+    # Just verify that we have the expected number of th elements
+    assert_select "th", 7 # 7 columns in the table
+
+    # Verify that the table headers exist with the expected content
+    assert_select "th", /Name or ID/ # First column should contain 'Name' or 'ID'
+    assert_select "th", /Created/ # Second column
+    assert_select "th", /Note/ # Third column
+    assert_select "th", /File Count/ # Fourth column
+    assert_select "th", /Views/ # Fifth column
+    assert_select "th", /Days/ # Sixth column
+    
+    # Verify that our created file push appears in the list
+    assert_select "td", "Test File Push"
+  end
+end

--- a/test/integration/file_push/file_push_json_creation_test.rb
+++ b/test/integration/file_push/file_push_json_creation_test.rb
@@ -28,8 +28,7 @@ class FilePushJsonCreationTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
     assert res.key?("payload") == false # No payload on create response
     assert res.key?("url_token")
-    assert res.key?("name")
-    assert_nil res["name"]
+    assert res.key?("name") == false
     assert res.key?("expired")
     assert_equal false, res["expired"]
     assert res.key?("deleted")
@@ -46,25 +45,6 @@ class FilePushJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal Settings.files.expire_after_days_default, res["expire_after_days"]
     assert res.key?("expire_after_views")
     assert_equal Settings.files.expire_after_views_default, res["expire_after_views"]
-  end
-
-
-  def test_basic_json_creation_with_name
-    post file_pushes_path(format: :json), params: {
-                                            file_push: {
-                                              payload: "Message",
-                                              files: [
-                                                fixture_file_upload("monkey.png", "image/jpeg")
-                                              ],
-                                              name: "Test File Push"
-                                            }
-                                          },
-      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
-    assert_response :success
-
-    res = JSON.parse(@response.body)
-    assert res.key?("name")
-    assert_equal "Test File Push", res["name"]
   end
 
   def test_json_creation_with_uncommon_characters

--- a/test/integration/file_push/file_push_json_creation_test.rb
+++ b/test/integration/file_push/file_push_json_creation_test.rb
@@ -28,6 +28,8 @@ class FilePushJsonCreationTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
     assert res.key?("payload") == false # No payload on create response
     assert res.key?("url_token")
+    assert res.key?("name")
+    assert_nil res["name"]
     assert res.key?("expired")
     assert_equal false, res["expired"]
     assert res.key?("deleted")

--- a/test/integration/file_push/file_push_json_creation_test.rb
+++ b/test/integration/file_push/file_push_json_creation_test.rb
@@ -46,6 +46,25 @@ class FilePushJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal Settings.files.expire_after_views_default, res["expire_after_views"]
   end
 
+
+  def test_basic_json_creation_with_name
+    post file_pushes_path(format: :json), params: {
+                                            file_push: {
+                                              payload: "Message",
+                                              files: [
+                                                fixture_file_upload("monkey.png", "image/jpeg")
+                                              ],
+                                              name: "Test File Push"
+                                            }
+                                          },
+      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("name")
+    assert_equal "Test File Push", res["name"]
+  end
+
   def test_json_creation_with_uncommon_characters
     post file_pushes_path(format: :json), params: {
                                             file_push: {

--- a/test/integration/password/password_active_test.rb
+++ b/test/integration/password/password_active_test.rb
@@ -2,12 +2,11 @@
 
 require "test_helper"
 
-class FilePushActiveTest < ActionDispatch::IntegrationTest
+class PasswordActiveTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
     Settings.enable_logins = true
-    Settings.enable_file_pushes = true
     Rails.application.reload_routes!
     @luca = users(:luca)
     @luca.confirm
@@ -38,7 +37,7 @@ class FilePushActiveTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     # Just verify that we have the expected number of th elements
-    assert_select "th", 6 # 7 columns in the table
+    assert_select "th", 6 # 6 columns in the table
 
     # Verify that the table headers exist with the expected content
     assert_select "th", /Name or ID/ # First column should contain 'Name' or 'ID'

--- a/test/integration/password/password_active_test.rb
+++ b/test/integration/password/password_active_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FilePushActiveTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_file_pushes = true
+    Rails.application.reload_routes!
+    @luca = users(:luca)
+    @luca.confirm
+    sign_in @luca
+  end
+
+  teardown do
+    sign_out :user
+  end
+
+  def test_active
+    get new_password_path
+    assert_response :success
+
+    post passwords_path, params: {
+      password: {
+        payload: "testpw",
+        name: "Test Password"
+      }
+    }
+    assert_response :redirect
+
+    follow_redirect!
+    assert_response :success
+    assert_select "h2", "Your push has been created."
+
+    get active_passwords_path
+    assert_response :success
+
+    # Just verify that we have the expected number of th elements
+    assert_select "th", 6 # 7 columns in the table
+
+    # Verify that the table headers exist with the expected content
+    assert_select "th", /Name or ID/ # First column should contain 'Name' or 'ID'
+    assert_select "th", /Created/ # Second column
+    assert_select "th", /Note/ # Third column
+    assert_select "th", /Views/ # Fifth column
+    assert_select "th", /Days/ # Sixth column
+
+    # Verify that our created file push appears in the list
+    assert_select "td", "Test Password"
+  end
+end

--- a/test/integration/password/password_json_creation_test.rb
+++ b/test/integration/password/password_json_creation_test.rb
@@ -10,6 +10,8 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
     assert res.key?("payload") == false # No payload on create response
     assert res.key?("url_token")
+    assert res.key?("name")
+    assert_nil res["name"]
     assert res.key?("expired")
     assert_equal false, res["expired"]
     assert res.key?("deleted")
@@ -26,6 +28,15 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal Settings.pw.expire_after_days_default, res["expire_after_days"]
     assert res.key?("expire_after_views")
     assert_equal Settings.pw.expire_after_views_default, res["expire_after_views"]
+  end
+
+  def test_basic_json_creation_with_name
+    post passwords_path(format: :json), params: {password: {payload: "testpw", name: "Test Password"}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("name")
+    assert_equal "Test Password", res["name"]
   end
 
   def test_json_creation_with_uncommon_characters

--- a/test/integration/password/password_json_creation_test.rb
+++ b/test/integration/password/password_json_creation_test.rb
@@ -10,8 +10,7 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
     assert res.key?("payload") == false # No payload on create response
     assert res.key?("url_token")
-    assert res.key?("name")
-    assert_nil res["name"]
+    assert res.key?("name") == false
     assert res.key?("expired")
     assert_equal false, res["expired"]
     assert res.key?("deleted")
@@ -28,15 +27,6 @@ class PasswordJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal Settings.pw.expire_after_days_default, res["expire_after_days"]
     assert res.key?("expire_after_views")
     assert_equal Settings.pw.expire_after_views_default, res["expire_after_views"]
-  end
-
-  def test_basic_json_creation_with_name
-    post passwords_path(format: :json), params: {password: {payload: "testpw", name: "Test Password"}}
-    assert_response :success
-
-    res = JSON.parse(@response.body)
-    assert res.key?("name")
-    assert_equal "Test Password", res["name"]
   end
 
   def test_json_creation_with_uncommon_characters

--- a/test/integration/url/url_active_test.rb
+++ b/test/integration/url/url_active_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UrlActiveTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_url_pushes = true
+    Rails.application.reload_routes!
+    @luca = users(:luca)
+    @luca.confirm
+    sign_in @luca
+  end
+
+  teardown do
+    sign_out :user
+  end
+
+  def test_active
+    get new_url_path
+    assert_response :success
+
+    post urls_path, params: {
+      url: {
+        payload: "https://the0x00.dev",
+        name: "Test URL"
+      }
+    }
+    assert_response :redirect
+
+    follow_redirect!
+    assert_response :success
+    assert_select "h2", "Your push has been created."
+
+    get active_urls_path
+    assert_response :success
+
+    # Just verify that we have the expected number of th elements
+    assert_select "th", 6 # 6 columns in the table
+
+    # Verify that the table headers exist with the expected content
+    assert_select "th", /Name or ID/ # First column should contain 'Name' or 'ID'
+    assert_select "th", /Created/ # Second column
+    assert_select "th", /Note/ # Third column
+    assert_select "th", /Views/ # Fourth column
+    assert_select "th", /Days/ # Fifth column
+
+    # Verify that our created URL push appears in the list
+    assert_select "td", "Test URL"
+  end
+end

--- a/test/integration/url/url_json_creation_test.rb
+++ b/test/integration/url/url_json_creation_test.rb
@@ -21,8 +21,7 @@ class UrlJsonCreationTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
     assert res.key?("payload") == false # No payload on create response
     assert res.key?("url_token")
-    assert res.key?("name")
-    assert_nil res["name"]
+    assert res.key?("name") == false
     assert res.key?("expired")
     assert_equal false, res["expired"]
     assert res.key?("deleted")
@@ -38,15 +37,6 @@ class UrlJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal Settings.url.expire_after_days_default, res["expire_after_days"]
     assert res.key?("expire_after_views")
     assert_equal Settings.url.expire_after_views_default, res["expire_after_views"]
-  end
-
-  def test_basic_json_creation_with_name
-    post urls_path(format: :json), params: {url: {payload: "https://the0x00.dev", name: "Test URL"}}, headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
-    assert_response :success
-
-    res = JSON.parse(@response.body)
-    assert res.key?("name")
-    assert_equal "Test URL", res["name"]
   end
 
   def test_custom_days_expiration

--- a/test/integration/url/url_json_creation_test.rb
+++ b/test/integration/url/url_json_creation_test.rb
@@ -21,6 +21,8 @@ class UrlJsonCreationTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
     assert res.key?("payload") == false # No payload on create response
     assert res.key?("url_token")
+    assert res.key?("name")
+    assert_nil res["name"]
     assert res.key?("expired")
     assert_equal false, res["expired"]
     assert res.key?("deleted")
@@ -36,6 +38,15 @@ class UrlJsonCreationTest < ActionDispatch::IntegrationTest
     assert_equal Settings.url.expire_after_days_default, res["expire_after_days"]
     assert res.key?("expire_after_views")
     assert_equal Settings.url.expire_after_views_default, res["expire_after_views"]
+  end
+
+  def test_basic_json_creation_with_name
+    post urls_path(format: :json), params: {url: {payload: "https://the0x00.dev", name: "Test URL"}}, headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("name")
+    assert_equal "Test URL", res["name"]
   end
 
   def test_custom_days_expiration

--- a/test/models/file_push_test.rb
+++ b/test/models/file_push_test.rb
@@ -15,15 +15,6 @@ class FilePushTest < ActiveSupport::TestCase
     assert file_push.save
     assert_equal "Test File Push", file_push.name
   end
-
-  test "should save file push without name" do
-    file_push = FilePush.new(
-      payload: "test payload",
-      user: @user
-    )
-    assert file_push.save
-    assert_nil file_push.name
-  end
   
   test "should include name in json representation" do
     file_push = FilePush.new(
@@ -37,5 +28,27 @@ class FilePushTest < ActiveSupport::TestCase
     
     json = JSON.parse(file_push.to_json({}))
     assert_equal "Test File Push", json["name"]
+  end
+
+  test "should save file push without name" do
+    file_push = FilePush.new(
+      payload: "test payload",
+      user: @user
+    )
+    assert file_push.save
+    assert_nil file_push.name
+  end
+
+  test "should include name as nil in json representation" do
+    file_push = FilePush.new(
+      payload: "test payload",
+      user: @user,
+      expire_after_days: 7,
+      expire_after_views: 10
+    )
+    assert file_push.save
+    
+    json = JSON.parse(file_push.to_json({}))
+    assert_nil json["name"]
   end
 end

--- a/test/models/file_push_test.rb
+++ b/test/models/file_push_test.rb
@@ -1,29 +1,36 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "active_storage/engine"
 
 class FilePushTest < ActiveSupport::TestCase
+  include ActionDispatch::TestProcess
+
   setup do
     @user = users(:luca)
   end
   test "should create file push with name" do
     file_push = FilePush.new(
-      payload: "test payload",
       name: "Test File Push",
       user: @user
     )
+    file = fixture_file_upload("monkey.png", "image/jpeg")
+    file_push.files.attach(file)
+
     assert file_push.save
     assert_equal "Test File Push", file_push.name
   end
   
   test "should include name in json representation" do
     file_push = FilePush.new(
-      payload: "test payload",
       name: "Test File Push",
       user: @user,
       expire_after_days: 7,
       expire_after_views: 10
     )
+    file = fixture_file_upload("monkey.png", "image/jpeg")
+    file_push.files.attach(file)
+
     assert file_push.save
     
     json = JSON.parse(file_push.to_json({}))
@@ -32,20 +39,24 @@ class FilePushTest < ActiveSupport::TestCase
 
   test "should save file push without name" do
     file_push = FilePush.new(
-      payload: "test payload",
       user: @user
     )
+    file = fixture_file_upload("monkey.png", "image/jpeg")
+    file_push.files.attach(file)
+
     assert file_push.save
     assert_nil file_push.name
   end
 
   test "should include name as nil in json representation" do
     file_push = FilePush.new(
-      payload: "test payload",
       user: @user,
       expire_after_days: 7,
       expire_after_views: 10
     )
+    file = fixture_file_upload("monkey.png", "image/jpeg")
+    file_push.files.attach(file)
+    
     assert file_push.save
     
     json = JSON.parse(file_push.to_json({}))

--- a/test/models/file_push_test.rb
+++ b/test/models/file_push_test.rb
@@ -21,22 +21,6 @@ class FilePushTest < ActiveSupport::TestCase
     assert_equal "Test File Push", file_push.name
   end
   
-  test "should include name in json representation" do
-    file_push = FilePush.new(
-      name: "Test File Push",
-      user: @user,
-      expire_after_days: 7,
-      expire_after_views: 10
-    )
-    file = fixture_file_upload("monkey.png", "image/jpeg")
-    file_push.files.attach(file)
-
-    assert file_push.save
-    
-    json = JSON.parse(file_push.to_json({}))
-    assert_equal "Test File Push", json["name"]
-  end
-
   test "should save file push without name" do
     file_push = FilePush.new(
       user: @user
@@ -48,8 +32,25 @@ class FilePushTest < ActiveSupport::TestCase
     assert_nil file_push.name
   end
 
-  test "should include name as nil in json representation" do
+  test "should include name in json representation when owner is true" do
     file_push = FilePush.new(
+      name: "Test File Push",
+      user: @user,
+      expire_after_days: 7,
+      expire_after_views: 10
+    )
+    file = fixture_file_upload("monkey.png", "image/jpeg")
+    file_push.files.attach(file)
+
+    assert file_push.save
+    
+    json = JSON.parse(file_push.to_json({ owner: true }))
+    assert_equal "Test File Push", json["name"]
+  end
+
+  test "should not include name in json representation when owner is false" do
+    file_push = FilePush.new(
+      name: "Test File Push",
       user: @user,
       expire_after_days: 7,
       expire_after_views: 10

--- a/test/models/file_push_test.rb
+++ b/test/models/file_push_test.rb
@@ -3,7 +3,39 @@
 require "test_helper"
 
 class FilePushTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @user = users(:luca)
+  end
+  test "should create file push with name" do
+    file_push = FilePush.new(
+      payload: "test payload",
+      name: "Test File Push",
+      user: @user
+    )
+    assert file_push.save
+    assert_equal "Test File Push", file_push.name
+  end
+
+  test "should save file push without name" do
+    file_push = FilePush.new(
+      payload: "test payload",
+      user: @user
+    )
+    assert file_push.save
+    assert_nil file_push.name
+  end
+  
+  test "should include name in json representation" do
+    file_push = FilePush.new(
+      payload: "test payload",
+      name: "Test File Push",
+      user: @user,
+      expire_after_days: 7,
+      expire_after_views: 10
+    )
+    assert file_push.save
+    
+    json = JSON.parse(file_push.to_json({}))
+    assert_equal "Test File Push", json["name"]
+  end
 end

--- a/test/models/password_test.rb
+++ b/test/models/password_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PasswordTest < ActiveSupport::TestCase
+  test "should create password with name" do
+    password = Password.new(
+      payload: "test_payload",
+      name: "Test Password"
+    )
+    assert password.save
+    assert_equal "Test Password", password.name
+  end
+
+  test "should include name in json representation" do
+    password = Password.new(
+      payload: "test_payload",
+      name: "Test Password",
+      expire_after_days: 7,
+      expire_after_views: 10
+    )
+    assert password.save
+
+    json = JSON.parse(password.to_json({}))
+    assert_equal "Test Password", json["name"]
+  end
+
+  test "should save password without name" do
+    password = Password.new(
+      payload: "test_payload"
+    )
+    assert password.save
+    assert_nil password.name
+  end
+
+  test "should include name as nil in json representation" do
+    password = Password.new(
+      payload: "test_payload",
+      expire_after_days: 7,
+      expire_after_views: 10
+    )
+    assert password.save
+
+    json = JSON.parse(password.to_json({}))
+    assert_nil json["name"]
+  end
+end

--- a/test/models/password_test.rb
+++ b/test/models/password_test.rb
@@ -12,7 +12,28 @@ class PasswordTest < ActiveSupport::TestCase
     assert_equal "Test Password", password.name
   end
 
-  test "should include name in json representation" do
+  test "should save password without name" do
+    password = Password.new(
+      payload: "test_payload"
+    )
+    assert password.save
+    assert_nil password.name
+  end
+
+  test "should include name in json representation when owner is true" do
+    password = Password.new(
+      payload: "test_payload",
+      name: "Test Password",
+      expire_after_days: 7,
+      expire_after_views: 10
+    )
+    assert password.save
+
+    json = JSON.parse(password.to_json({ owner: true }))
+    assert_equal "Test Password", json["name"]
+  end
+
+  test "should not include name in json representation when owner is false" do
     password = Password.new(
       payload: "test_payload",
       name: "Test Password",
@@ -22,26 +43,6 @@ class PasswordTest < ActiveSupport::TestCase
     assert password.save
 
     json = JSON.parse(password.to_json({}))
-    assert_equal "Test Password", json["name"]
-  end
-
-  test "should save password without name" do
-    password = Password.new(
-      payload: "test_payload"
-    )
-    assert password.save
-    assert_nil password.name
-  end
-
-  test "should include name as nil in json representation" do
-    password = Password.new(
-      payload: "test_payload",
-      expire_after_days: 7,
-      expire_after_views: 10
-    )
-    assert password.save
-
-    json = JSON.parse(password.to_json({}))
-    assert_nil json["name"]
+    assert_not json.key?("name")
   end
 end

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -3,7 +3,33 @@
 require "test_helper"
 
 class UrlTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should create url with name" do
+    url = Url.new(
+      payload: "https://example.com",
+      name: "Test URL"
+    )
+    assert url.save
+    assert_equal "Test URL", url.name
+  end
+
+  test "should save url without name" do
+    url = Url.new(
+      payload: "https://example.com"
+    )
+    assert url.save
+    assert_nil url.name
+  end
+
+  test "should include name in json representation" do
+    url = Url.new(
+      payload: "https://example.com",
+      name: "Test URL",
+      expire_after_days: 7,
+      expire_after_views: 10
+    )
+    assert url.save
+
+    json = JSON.parse(url.to_json({}))
+    assert_equal "Test URL", json["name"]
+  end
 end

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -12,7 +12,28 @@ class UrlTest < ActiveSupport::TestCase
     assert_equal "Test URL", url.name
   end
 
-  test "should include name in json representation" do
+  test "should save url without name" do
+    url = Url.new(
+      payload: "https://example.com"
+    )
+    assert url.save
+    assert_nil url.name
+  end
+
+  test "should include name in json representation when owner is true" do
+    url = Url.new(
+      payload: "https://example.com",
+      name: "Test URL",
+      expire_after_days: 7,
+      expire_after_views: 10
+    )
+    assert url.save
+
+    json = JSON.parse(url.to_json({ owner: true }))
+    assert_equal "Test URL", json["name"]
+  end
+
+  test "should not include name in json representation when owner is false" do
     url = Url.new(
       payload: "https://example.com",
       name: "Test URL",
@@ -22,26 +43,6 @@ class UrlTest < ActiveSupport::TestCase
     assert url.save
 
     json = JSON.parse(url.to_json({}))
-    assert_equal "Test URL", json["name"]
-  end
-
-  test "should save url without name" do
-    url = Url.new(
-      payload: "https://example.com"
-    )
-    assert url.save
-    assert_nil url.name
-  end
-
-  test "should include name as nil in json representation" do
-    url = Url.new(
-      payload: "https://example.com",
-      expire_after_days: 7,
-      expire_after_views: 10
-    )
-    assert url.save
-
-    json = JSON.parse(url.to_json({}))
-    assert_nil json["name"]
+    assert_not json.key?("name")
   end
 end

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -12,14 +12,6 @@ class UrlTest < ActiveSupport::TestCase
     assert_equal "Test URL", url.name
   end
 
-  test "should save url without name" do
-    url = Url.new(
-      payload: "https://example.com"
-    )
-    assert url.save
-    assert_nil url.name
-  end
-
   test "should include name in json representation" do
     url = Url.new(
       payload: "https://example.com",
@@ -31,5 +23,25 @@ class UrlTest < ActiveSupport::TestCase
 
     json = JSON.parse(url.to_json({}))
     assert_equal "Test URL", json["name"]
+  end
+
+  test "should save url without name" do
+    url = Url.new(
+      payload: "https://example.com"
+    )
+    assert url.save
+    assert_nil url.name
+  end
+
+  test "should include name as nil in json representation" do
+    url = Url.new(
+      payload: "https://example.com",
+      expire_after_days: 7,
+      expire_after_views: 10
+    )
+    assert url.save
+
+    json = JSON.parse(url.to_json({}))
+    assert_nil json["name"]
   end
 end

--- a/test/unit/password_test.rb
+++ b/test/unit/password_test.rb
@@ -9,6 +9,27 @@ class PasswordTest < Minitest::Test
     assert password.save
   end
 
+  def test_save_with_name
+    # Test that name can be set and retrieved
+    password = Password.new(name: "Test Password")
+    password.validate!
+    assert password.save
+    assert_equal "Test Password", password.name
+  end
+
+  def test_name_in_json
+    # Test that name is included in the JSON representation
+    password = Password.new(
+      payload: "test_payload",
+      name: "Test Password"
+    )
+    password.validate!
+    assert password.save
+
+    json = JSON.parse(password.to_json({}))
+    assert_equal "Test Password", json["name"]
+  end
+
   def test_expired_check
     password = Password.new(payload: "asdf")
     password.validate!
@@ -38,6 +59,7 @@ class PasswordTest < Minitest::Test
 
     assert push.retrieval_step == Settings.pw.retrieval_step_default if Settings.pw.enable_retrieval_step
     assert push.deletable_by_viewer == Settings.pw.deletable_pushes_default if Settings.pw.enable_deletable_pushes
+    assert_nil push.name
   end
 
   def test_days_expiration

--- a/test/unit/password_test.rb
+++ b/test/unit/password_test.rb
@@ -9,27 +9,6 @@ class PasswordTest < Minitest::Test
     assert password.save
   end
 
-  def test_save_with_name
-    # Test that name can be set and retrieved
-    password = Password.new(name: "Test Password")
-    password.validate!
-    assert password.save
-    assert_equal "Test Password", password.name
-  end
-
-  def test_name_in_json
-    # Test that name is included in the JSON representation
-    password = Password.new(
-      payload: "test_payload",
-      name: "Test Password"
-    )
-    password.validate!
-    assert password.save
-
-    json = JSON.parse(password.to_json({}))
-    assert_equal "Test Password", json["name"]
-  end
-
   def test_expired_check
     password = Password.new(payload: "asdf")
     password.validate!

--- a/test/unit/password_unit_test.rb
+++ b/test/unit/password_unit_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class PasswordTest < Minitest::Test
+class PasswordUnitTest < Minitest::Test
   def test_save
     password = Password.new
     password.validate!

--- a/test/unit/password_unit_test.rb
+++ b/test/unit/password_unit_test.rb
@@ -38,7 +38,6 @@ class PasswordUnitTest < Minitest::Test
 
     assert push.retrieval_step == Settings.pw.retrieval_step_default if Settings.pw.enable_retrieval_step
     assert push.deletable_by_viewer == Settings.pw.deletable_pushes_default if Settings.pw.enable_deletable_pushes
-    assert_nil push.name
   end
 
   def test_days_expiration


### PR DESCRIPTION
## Description

"name" attribute is added into `Url`, `Password` and `FilePush` models. Also, related views and API endpoints are updated. Tests are added, too.

## Related Issue

#3336 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [x] I've added documentation as necessary so users can easily use and understand this feature/fix.
