### PR TITLE
Remove unused text columns from urls and file_pushes tables

### DIFF
--- a/db/migrate/20250515110051_remove_text_from_urls_and_file_pushes.rb
+++ b/db/migrate/20250515110051_remove_text_from_urls_and_file_pushes.rb
@@ -1,0 +1,6 @@
+class RemoveTextFromUrlsAndFilePushes < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :urls, :text, :text
+    remove_column :file_pushes, :text, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_13_074136) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_15_110051) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -50,7 +50,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_13_074136) do
     t.boolean "retrieval_step", default: false
     t.datetime "expired_on"
     t.text "payload_ciphertext", limit: 16777215
-    t.text "text", limit: 16777215
     t.text "note_ciphertext"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -211,7 +210,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_13_074136) do
     t.boolean "retrieval_step", default: false
     t.datetime "expired_on"
     t.text "payload_ciphertext", limit: 2097152
-    t.text "text", limit: 2097152
     t.text "note_ciphertext"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## Description

`text` columns were added mistakenly. They are not used actively and contain any data. So, they removed.

## Related Issue

#3357 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
-- Changes don't need to be tested.
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
-- Changes don't need to be documented..
