### PR TITLE
Add a `kind` column to the dashboard

### DIFF
--- a/app/views/pushes/index.html.erb
+++ b/app/views/pushes/index.html.erb
@@ -35,6 +35,7 @@
       <thead>
       <tr>
           <th scope="col"><%= t("pushes.form.name_or_id") %></th>
+          <th scope="col" class="text-center"><%= t("pushes.form.kind") %></th>
           <th scope="col"><%= _('Created') %></th>
           <th scope="col"><%= _('Note') %></th>
           <th scope="col" class="text-center"><%= _('Views') + "-" + _('Days') %></th>
@@ -49,6 +50,7 @@
           <% else %>
             <td><%= push.url_token %></td>
           <% end %>
+          <td class="text-center"><%= push.kind %></td>
           <td><%= I18n.l push.created_at.in_time_zone(Settings.timezone), format: :long %></td>
           <td>
             <% if push.note.blank? %>

--- a/config/locales/pwpx.en.yml
+++ b/config/locales/pwpx.en.yml
@@ -731,6 +731,7 @@ en:
       encryption_tip: Content is encrypted prior to storage and is available to only those with the secret link.
       expiration_label: 'Expire this push and delete after:'
       expiration_tip: All content and files of the push are deleted entirely on expiration.
+      kind: Kind
       name_or_id: Name or ID
       note_label: Reference Note
       note_placeholder: A private note for this push.  Encrypted & visible only to you and your team.

--- a/test/integration/file_push/file_push_index_test.rb
+++ b/test/integration/file_push/file_push_index_test.rb
@@ -42,12 +42,13 @@ class FilePushIndexTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     # Just verify that we have the expected number of th elements
-    assert_select "th", 5 # 5 columns in the table
+    assert_select "th", 6 # 6 columns in the table
 
     # Verify that the table headers exist with the expected content
     assert_select "th", /Name or ID/ # First column should contain 'Name' or 'ID'
-    assert_select "th", /Created/ # Second column
-    assert_select "th", /Note/ # Third column
+    assert_select "th", /Kind/ # Second column
+    assert_select "th", /Created/ # Third column
+    assert_select "th", /Note/ # Fourth column
     assert_select "th", /Views-Days/ # Fourth column
 
     # Verify that our created file push appears in the list

--- a/test/integration/password/password_index_test.rb
+++ b/test/integration/password/password_index_test.rb
@@ -38,13 +38,14 @@ class PasswordIndexTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     # Just verify that we have the expected number of th elements
-    assert_select "th", 5 # 5 columns in the table
+    assert_select "th", 6 # 6 columns in the table
 
     # Verify that the table headers exist with the expected content
     assert_select "th", /Name or ID/ # First column should contain 'Name' or 'ID'
-    assert_select "th", /Created/ # Second column
-    assert_select "th", /Note/ # Third column
-    assert_select "th", /Views-Days/ # Fourth column
+    assert_select "th", /Kind/ # Second column
+    assert_select "th", /Created/ # Third column
+    assert_select "th", /Note/ # Fourth column
+    assert_select "th", /Views-Days/ # Fifth column
 
     # Verify that our created file push appears in the list
     assert_select "td", "Test Password"

--- a/test/integration/url/url_index_test.rb
+++ b/test/integration/url/url_index_test.rb
@@ -39,13 +39,14 @@ class UrlIndexTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     # Just verify that we have the expected number of th elements
-    assert_select "th", 5 # 5 columns in the table
+    assert_select "th", 6 # 6 columns in the table
 
     # Verify that the table headers exist with the expected content
     assert_select "th", /Name or ID/ # First column should contain 'Name' or 'ID'
-    assert_select "th", /Created/ # Second column
-    assert_select "th", /Note/ # Third column
-    assert_select "th", /Views-Days/ # Fourth column
+    assert_select "th", /Kind/ # Second column
+    assert_select "th", /Created/ # Third column
+    assert_select "th", /Note/ # Fourth column
+    assert_select "th", /Views-Days/ # Fifth column
 
     # Verify that our created URL push appears in the list
     assert_select "td", "Test URL"


### PR DESCRIPTION
## Description

It is requested to add a new `kind` column to check push kinds on the dashboard. It is added with this PR.
![image](https://github.com/user-attachments/assets/e68b59c6-e5e9-42a1-9578-258c19d89e14)

## Related Issue

 --

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
 -- No need to document changes