### PR TITLE
Add QR Code pushes

### DIFF
--- a/app/controllers/api/v1/pushes_controller.rb
+++ b/app/controllers/api/v1/pushes_controller.rb
@@ -84,7 +84,7 @@ class Api::V1::PushesController < Api::BaseController
     param :expire_after_views, Integer, desc: "Expire secret link and delete after this many views."
     param :deletable_by_viewer, %w[true false], desc: "Allow users to delete passwords once retrieved."
     param :retrieval_step, %w[true false], desc: "Helps to avoid chat systems and URL scanners from eating up views."
-    param :kind, %w[text file url], desc: "The kind of push to create. Defaults to 'text'.", required: false
+    param :kind, %w[text file url qr], desc: "The kind of push to create. Defaults to 'text'.", required: false
   end
   formats ["JSON"]
   description <<-EOS
@@ -95,6 +95,7 @@ class Api::V1::PushesController < Api::BaseController
     * Text/password (default)
     * File attachments (requires authentication & subscription)
     * URLs
+    * QR codes
 
     === Required Parameters
 
@@ -153,6 +154,10 @@ class Api::V1::PushesController < Api::BaseController
     @push = Push.new(push_params)
 
     if !push_params[:kind].present?
+      # These are used to determine the default kind based on the request path
+      # for old push records. Their paths are generated based on their kind.
+      # And, QR Code pushes are created by using `/p/` path.
+      # So, it is not necessary to check for a special path.
       @push.kind = if request.path.include?("/f.json")
         "file"
       elsif request.path.include?("/r.json")

--- a/app/controllers/pushes_controller.rb
+++ b/app/controllers/pushes_controller.rb
@@ -301,6 +301,8 @@ class PushesController < BaseController
         "file"
       when "url"
         "url"
+      when "qr"
+        "qr"
       else
         "text"
       end

--- a/app/helpers/pushes_helper.rb
+++ b/app/helpers/pushes_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rqrcode"
+
 module PushesHelper
   def filesize(size)
     units = %w[B KiB MiB GiB TiB Pib EiB ZiB]
@@ -11,5 +13,15 @@ module PushesHelper
     exp = units.size - 1 if exp > units.size - 1
 
     format("%.1f #{units[exp]}", size.to_f / (1024**exp))
+  end
+
+  def qr_code(url)
+    RQRCode::QRCode.new(url).as_svg(
+      offset: 0,
+      color: :currentColor,
+      shape_rendering: "crispEdges",
+      module_size: 6,
+      standalone: true
+    ).html_safe
   end
 end

--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -3,7 +3,7 @@
 require "addressable/uri"
 
 class Push < ApplicationRecord
-  enum :kind, [:text, :file, :url], validate: true
+  enum :kind, [:text, :file, :url, :qr], validate: true
 
   validate :check_enabled_push_kinds
   validates :url_token, presence: true, uniqueness: true
@@ -16,6 +16,7 @@ class Push < ApplicationRecord
     create.after_validation :check_payload_for_text, if: :text?
     create.after_validation :check_files_for_file, if: :file?
     create.after_validation :check_payload_for_url, if: :url?
+    create.after_validation :check_payload_for_qr, if: :qr?
   end
 
   belongs_to :user, optional: true
@@ -135,6 +136,16 @@ class Push < ApplicationRecord
     end
   end
 
+  def check_payload_for_qr
+    if payload.present?
+      if payload.length > 1024
+        errors.add(:payload, t("pushes.create.qr_max_length", count: 1024))
+      end
+    else
+      errors.add(:payload, I18n.t("pushes.create.payload_required"))
+    end
+  end
+
   def set_expire_limits
     self.expire_after_days ||= settings_for_kind.expire_after_days_default
     self.expire_after_views ||= settings_for_kind.expire_after_views_default
@@ -177,6 +188,8 @@ class Push < ApplicationRecord
       Settings.url
     elsif file?
       Settings.files
+    elsif qr?
+      Settings.qr
     end
   end
 
@@ -187,6 +200,10 @@ class Push < ApplicationRecord
 
     if kind == "url" && !(Settings.enable_logins && Settings.enable_url_pushes)
       errors.add(:kind, I18n.t("pushes.url_pushes_disabled"))
+    end
+
+    if kind == "qr" && !(Settings.enable_logins && Settings.enable_qr_pushes)
+      errors.add(:kind, I18n.t("pushes.qr_pushes_disabled"))
     end
   end
 

--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -138,6 +138,7 @@ class Push < ApplicationRecord
 
   def check_payload_for_qr
     if payload.present?
+      # If the push is a QR code, max payload length is 1024 characters
       if payload.length > 1024
         errors.add(:payload, t("pushes.create.qr_max_length", count: 1024))
       end

--- a/app/views/pushes/_qr_form.html.erb
+++ b/app/views/pushes/_qr_form.html.erb
@@ -1,0 +1,196 @@
+<% title(_('Securely Send a Password')) %>
+
+<div class='container'
+    data-controller="knobs pwgen passwords form"
+    data-knobs-tab-name-value="password"
+    data-knobs-lang-day-value="<%= _('Day') %>"
+    data-knobs-lang-days-value="<%= _('Days') %>"
+    data-knobs-default-days-value="<%= @push.settings_for_kind.expire_after_days_default %>"
+    data-knobs-lang-view-value="<%= _('View') %>"
+    data-knobs-lang-views-value="<%= _('Views') %>"
+    data-knobs-default-views-value="<%= @push.settings_for_kind.expire_after_views_default %>"
+    data-knobs-lang-save-value="<%= _('Save') %>"
+    data-knobs-lang-saved-value="<%= _('Saved!') %>"
+    data-knobs-default-retrieval-step-value="<%= @push.settings_for_kind.retrieval_step_default %>"
+    data-knobs-default-deletable-by-viewer-value="<%= @push.settings_for_kind.deletable_pushes_default %>"
+    data-pwgen-use-numbers-default-value="<%= Settings.gen.has_numbers %>"
+    data-pwgen-title-cased-default-value="<%= Settings.gen.title_cased %>"
+    data-pwgen-use-separators-default-value="<%= Settings.gen.use_separators %>"
+    data-pwgen-consonants-default-value="<%= Settings.gen.consonants %>"
+    data-pwgen-vowels-default-value="<%= Settings.gen.vowels %>"
+    data-pwgen-separators-default-value="<%= Settings.gen.separators %>"
+    data-pwgen-min-syllable-length-default-value="<%= Settings.gen.min_syllable_length %>"
+    data-pwgen-max-syllable-length-default-value="<%= Settings.gen.max_syllable_length %>"
+    data-pwgen-syllables-count-default-value="<%= Settings.gen.syllables_count %>"
+    data-knobs-ga-enabled-value="<%= ENV.key?('GA_ENABLE') %>">
+<%= render partial: "shared/topnav" %>
+<%= form_for @push, data: { action: 'form#submit' } do |f| %>
+    <%= f.hidden_field :kind, value: :qr %>
+
+    <div class='row'>
+        <div class='col'>
+            <%= f.text_area(:payload, { class: "form-control",
+                                        rows: 4,
+                                        placeholder: _('Enter the Password or Text to push...'),
+                                        autocomplete: "off",
+                                        spellcheck: "false",
+                                        maxlength: 1024,
+                                        autofocus: true,
+                                        required: true,
+                                        "data-pwgen-target" => "payloadInput",
+                                        "data-passwords-target" => "payloadInput",
+                                        "data-action" => "input->passwords#updateCharacterCount"
+                                         }) %>
+            <div class='position-relative'>
+                <div id="the-count" class="position-absolute bottom-0 end-0 m-2 px-3 opacity-75">
+                    <span id="current" data-passwords-target="currentChars">0</span>
+                    <span id="maximum" data-passwords-target="maximumChars">/ 1048576 <%= _('Characters') %></span>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class='row'>
+        <div class='col-12 col-sm-8 p-3'>
+            <div class='row'>
+                <div><%= _('Expire secret link and delete after:') %></div>
+                <div class='col-10'>
+                    <%= range_field_tag("push_expire_after_days", @push.settings_for_kind.expire_after_days_default,
+                                        { :name => "push[expire_after_days]",
+                                          :class => "form-range",
+                                          :min => @push.settings_for_kind.expire_after_days_min,
+                                          :max => @push.settings_for_kind.expire_after_days_max,
+                                          :step => "1",
+                                          "data-action" => "change->knobs#updateDaysSlider input->knobs#updateDaysSlider",
+                                          "data-knobs-target" => "daysRange"
+                                        }) %>
+                </div>
+                <div class='col-2'>
+                    <div class="form-text" data-knobs-target="daysRangeLabel"><%= @push.settings_for_kind.expire_after_days_default %> <%= _('Days') %></div>
+                </div>
+            </div>
+            <div class='row'>
+                <div class='col-10'>
+                    <%= range_field_tag("push_expire_after_views", @push.settings_for_kind.expire_after_views_default,
+                                        { :name => "push[expire_after_views]",
+                                            :class => "form-range",
+                                            :min => @push.settings_for_kind.expire_after_views_min,
+                                            :max => @push.settings_for_kind.expire_after_views_max,
+                                            :step => "1",
+                                            "data-action" => "change->knobs#updateViewsSlider input->knobs#updateViewsSlider",
+                                            "data-knobs-target" => "viewsRange"
+                                        }) %>
+                </div>
+
+                <div class='col-2'>
+                    <div class="form-text" data-knobs-target="viewsRangeLabel"><%= @push.settings_for_kind.expire_after_views_default %> <%= _('Views') %></div>
+                </div>
+            </div>
+            <div class='row'>
+                <div class='col'>
+                    <p class='text-center form-text'><%= _('(whichever comes first)') %></p>
+                </div>
+            </div>
+
+            <div class='row mb-3'>
+                <div class='col'>
+                    <div class="list-group mx-0">
+                        <% if @push.settings_for_kind.enable_retrieval_step %>
+                            <label class="list-group-item d-flex gap-2">
+                            <%= check_box_tag "push[retrieval_step]", nil, @push.settings_for_kind.retrieval_step_default,
+                                            { class: 'form-check-input flex-shrink-0',
+                                              "data-knobs-target" => "retrievalStepCheckbox" } %>
+                            <span>
+                                <%= _('Use a 1-click retrieval step') %>
+                                <small class="d-block text-muted"><%= _('Helps to avoid chat systems and URL scanners from eating up views.') %></small>
+                            </span>
+                            </label>
+                        <% end %>
+                        <% if @push.settings_for_kind.enable_deletable_pushes %>
+                            <label class="list-group-item d-flex gap-2">
+                            <%= check_box_tag "push[deletable_by_viewer]", nil, @push.settings_for_kind.deletable_pushes_default,
+                                            { class: 'form-check-input flex-shrink-0',
+                                              "data-knobs-target" => "deletableByViewerCheckbox" } %>
+                            <span>
+                                <%= _('Allow immediate deletion') %>
+                                <small class="d-block text-muted"><%= _('Allow users to delete this push once retrieved.') %></small>
+                            </span>
+                            </label>
+                        <% end %>
+                    </div>
+                </div>
+            </div>
+            <div class='row mb-3'>
+                <div class='col'>
+                    <div class="input-group">
+                        <span class="input-group-text"><%= _('Passphrase Lockdown') %></span>
+                        <%= f.text_field(:passphrase, { class: "form-control",
+                                                        autocomplete: "off",
+                                                        placeholder: _('Optional: Require recipients to enter a passphrase to view this push') }) %>
+                    </div>
+                </div>
+            </div>
+            <div class='row'>
+                <div class='col'>
+                    <p class='mb-3'>
+                        <div id='cookie-save'>
+                            <a data-action="click->knobs#saveSettings" href="#"><%= _('Save') %></a> <%= _('the above settings as the page default.') %>
+                        </div>
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class='col-12 col-sm-4 p-3 mt-3'>
+            <div class="row mb-3">
+                <div class="btn-group mb-3" role="group" aria-label="Password Generator button group with nested dropdown">
+                    <button class="btn btn-secondary w-75" type="button"
+                        id='generate_password'
+                        data-knobs-target="generatePasswordButton"
+                        data-action="pwgen#producePassword passwords#updateCharacterCount"><em class="bi bi-cpu"></em> <%= _('Generate Password') %></button>
+                    <button class="btn btn-secondary" type="button" id='configure_generator'
+                        data-action="pwgen#configureGenerator"
+                        data-bs-toggle="modal" data-bs-target="#configureModal">
+                        <em class="bi bi-gear"></em>
+                    </button>
+                </div>
+                <p class='fst-italic fw-light'><%= _('Use the button above to generate a random password.') %></p>
+            </div>
+            <% if user_signed_in? %>
+                <div class='row mb-3'>
+                    <div class="input-group">
+                        <span class="input-group-text"><%= Password.human_attribute_name(:name) %></span>
+                        <%= f.text_field(:name, { class: "form-control",
+                                                placeholder: _('Optional'),
+                                                autocomplete: "off" }) %>
+                    </div>
+                    <div class="form-text" id="basic-addon4"><%= _('A name shown in the dashboard, notifications and emails.') %></div>
+                </div>
+                <div class='row mb-3'>
+                    <div class="input-group">
+                        <span class="input-group-text"><%= _('Reference Note') %></span>
+                        <%= f.text_area(:note, { class: "form-control",
+                                                rows: 1,
+                                                placeholder: _('Optional'),
+                                                autocomplete: "off" }) %>
+                    </div>
+                    <div class="form-text" id="basic-addon4"><%= _('Encrypted and visible only to you') %></div>
+                </div>
+            <% end %>
+            <div class='row my-3 px-5'> <hr> </div>
+            <div class='row mb-3'>
+                <p class='fst-italic'><%= _('Tip: Only enter a password into the box.  Other identifying information can compromise security.') %></p>
+                <p class='fst-italic fw-light'><%= _('All passwords are encrypted prior to storage and are available to only those with the secret link.  Once expired, encrypted passwords are unequivocally deleted from the database.') %></p>
+            </div>
+        </div>
+    </div>
+    <div class='row'>
+        <div class='col'>
+            <p class='my-3'>
+                <button class="form-control btn btn-primary" type="submit" data-form-target="pushit" data-disable-with="Pushing..."><%= _('Push It!') %></button>
+            </p>
+        </div>
+    </div>
+<% end %>
+
+<%= render partial: 'shared/pw_generator_modal', cached: true %>
+
+</div>

--- a/app/views/pushes/_qr_form.html.erb
+++ b/app/views/pushes/_qr_form.html.erb
@@ -44,7 +44,7 @@
             <div class='position-relative'>
                 <div id="the-count" class="position-absolute bottom-0 end-0 m-2 px-3 opacity-75">
                     <span id="current" data-passwords-target="currentChars">0</span>
-                    <span id="maximum" data-passwords-target="maximumChars">/ 1048576 <%= _('Characters') %></span>
+                    <span id="maximum" data-passwords-target="maximumChars">/ 1024 <%= _('Characters') %></span>
                 </div>
             </div>
         </div>

--- a/app/views/pushes/_show_payload.html.erb
+++ b/app/views/pushes/_show_payload.html.erb
@@ -1,0 +1,13 @@
+<div class='text-center m-3'>
+    <p class=""><strong><%= _('Please obtain and securely store this content in a secure manner, such as in a password manager.') %></strong></p>
+    <% if Settings.pw.enable_blur %>
+        <p class="text-muted"><%= _('Your password is blurred out.  Click below to reveal it.') %></p>
+    <% end %>
+    <%= render partial: 'shared/copy_button', cached: true %>
+    </div>
+
+    <% if payload.chomp.match?(/\n/) || payload.length > 100 %>
+    <div class='payload <%= blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white d-flex justify-content-center' id='push_payload' translate='no' data-copy-target="payloadDiv"><pre class='text-break my-5'><%= payload %></pre></div>
+    <% else %>
+    <div class='payload <%= blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white fs-2' id='push_payload' translate='no' data-copy-target="payloadDiv"><pre class='w-100 text-break text-wrap my-5 text-center'><%= payload %></pre></div>
+<% end %>

--- a/app/views/pushes/_show_qr.html.erb
+++ b/app/views/pushes/_show_qr.html.erb
@@ -1,0 +1,4 @@
+<div class='text-center m-3'>
+    <p class=""><strong><%= _('Please obtain and securely store this content in a secure manner, such as in a password manager.') %></strong></p>
+    <%= qr_code(push.payload) %>
+<div>

--- a/app/views/pushes/index.html.erb
+++ b/app/views/pushes/index.html.erb
@@ -55,6 +55,8 @@
               File(s)
             <% elsif push.url? %>
               URL
+            <% elsif push.qr? %>
+              QR Code
             <% else %>
               Text
             <% end %>

--- a/app/views/pushes/new.html.erb
+++ b/app/views/pushes/new.html.erb
@@ -6,4 +6,6 @@
   <%= render "files_form", push: @push %>
 <% elsif @url_tab %>
   <%= render "url_form", push: @push %>
+<% elsif @qr_tab %>
+  <%= render "qr_form", push: @push %>
 <% end %>

--- a/app/views/pushes/show.html.erb
+++ b/app/views/pushes/show.html.erb
@@ -60,23 +60,15 @@
       </div>
     </div>
   </div>
-<% elsif @push.text? %>
+<% elsif @push.text? || @push.qr? %>
   <div class="container-fluid h-100 mx-0 py-0 px-0" data-controller="copy passwords" data-copy-lang-copied-value="<%= _('Copied!') %>">
     <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center">
-      <% unless @push.payload.blank? %>
-          <div class='text-center m-3'>
-            <p class=""><strong><%= _('Please obtain and securely store this content in a secure manner, such as in a password manager.') %></strong></p>
-            <% if Settings.pw.enable_blur %>
-              <p class="text-muted"><%= _('Your password is blurred out.  Click below to reveal it.') %></p>
-            <% end %>
-            <%= render partial: 'shared/copy_button', cached: true %>
-          </div>
-
-          <% if @payload.chomp.match?(/\n/) || @payload.length > 100 %>
-            <div class='payload <%= @blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white d-flex justify-content-center' id='push_payload' translate='no' data-copy-target="payloadDiv"><pre class='text-break my-5'><%= @payload %></pre></div>
-          <% else %>
-            <div class='payload <%= @blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white fs-2' id='push_payload' translate='no' data-copy-target="payloadDiv"><pre class='w-100 text-break text-wrap my-5 text-center'><%= @payload %></pre></div>
-          <% end %>
+      <% if @push.payload.present? %>
+        <% if @push.text? %>
+          <%= render partial: 'pushes/show_payload', locals: { payload: @payload, blur_css_class: @blur_css_class } %>
+        <% else @push.qr? %>
+          <%= render partial: 'pushes/show_qr', locals: { push: @push } %>
+        <% end %>
       <% end %>
       <div class='text-center m-3'>
         <p class="text-muted mt-5">

--- a/app/views/shared/_topnav.html.erb
+++ b/app/views/shared/_topnav.html.erb
@@ -13,5 +13,10 @@
         <a class="nav-link <%= @url_tab ? 'active' : '' %>" aria-current="page" href="<%= new_push_path(tab: 'url') %>"><%= _('URLs') %></a>
       </li>
     <% end %>
+    <% if Settings.enable_qr_pushes %>
+      <li class="nav-item">
+        <a class="nav-link <%= @qr_tab ? 'active' : '' %>" aria-current="page" href="<%= new_push_path(tab: 'qr') %>"><%= _('QR Codes ᴮᴱᵀᴬ') %></a>
+      </li>
+    <% end %>
   </ul>
 <% end %>

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -36,6 +36,19 @@ enable_url_pushes: false
 #
 enable_file_pushes: false
 
+### QR Code Pushes
+#
+# Enable or disable QR code based pushes.  These allow you to share QR codes securely.
+# Like regular pushes, they expire after a set time or amount of views.
+#
+# Note that `enable_logins` is required for QR code based pushes to work.  It is a
+# feature for logged in users only.
+#
+# Environment variable override:
+# PWP__ENABLE_QR_PUSHES='false'
+#
+enable_qr_pushes: false
+
 ### Logins (User accounts)
 #
 # Logins are disabled by default since they require an MTA (email) server
@@ -538,6 +551,83 @@ files:
     # Environment Variable Override: PWP__FILES__AS__CONTAINER=''
     container: ''
 
+## Expiration Settings for QR Code Pushes
+#
+qr:
+  # Expire QR Code Pushes After XX Days
+  #
+  # Controls the "Expire After Days" for QR Code Pushes
+  #
+  # Environment variable overrides:
+  # PWP__URL__EXPIRE_AFTER_DAYS_DEFAULT=7
+  # PWP__URL__EXPIRE_AFTER_DAYS_MIN=1
+  # PWP__URL__EXPIRE_AFTER_DAYS_MAX=90
+  #
+  expire_after_days_default: 7
+  expire_after_days_min: 1
+  expire_after_days_max: 90
+
+  # Expire QR Code Pushes After XX Views
+  #
+  # Controls the "Expire After Views" form settings in Password#new
+  #
+  # Environment variable overrides:
+  # PWP__QR__EXPIRE_AFTER_VIEWS_DEFAULT=5
+  # PWP__QR__EXPIRE_AFTER_VIEWS_MIN=1
+  # PWP__QR__EXPIRE_AFTER_VIEWS_MAX=100
+  #
+  expire_after_views_default: 5
+  expire_after_views_min: 1
+  expire_after_views_max: 100
+
+  # Retrieval Step for QR Code Pushes
+  #
+  # This enables or disables the "1-click retrieval step" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__QR__ENABLE_RETRIEVAL_STEP='false'
+  #
+  enable_retrieval_step: true
+
+  # Default Form Value for the Retrieval Step
+  #
+  # When the retrieval step is enabled (above), what is the default value on the form?
+  #
+  # When true, secret URLs will be generated as /r/xxxxxxxx/r which will show a page
+  # requiring a click to view the page /r/xxxxxxxx
+  #
+  # Environment variable override:
+  # PWP__QR__RETRIEVAL_STEP_DEFAULT='true'
+  #
+  retrieval_step_default: false
+
+  # Deletable QR Code Pushes
+  #
+  # default: true
+  #
+  # This enables or disables the "Allow Immediate Deletion" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__QR__ENABLE_DELETABLE_PUSHES='false'
+  #
+  enable_deletable_pushes: true
+
+  # Deletable Pushes Default Value
+  #
+  # default: true
+  #
+  # When this is set to true, this option does two things:
+  #   1. Sets the default check state for the "Allow viewers to
+  #       optionally delete password before expiration" checkbox
+  #   2. JSON API: Sets the default value for newly pushed passwords if
+  #       unspecified
+  #
+  # Environment variable override:
+  # PWP__PW__DELETABLE_PUSHES_DEFAULT='false'
+  #
+  deletable_pushes_default: true
 
 ### Password Generator Defaults
 #

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -559,9 +559,9 @@ qr:
   # Controls the "Expire After Days" for QR Code Pushes
   #
   # Environment variable overrides:
-  # PWP__URL__EXPIRE_AFTER_DAYS_DEFAULT=7
-  # PWP__URL__EXPIRE_AFTER_DAYS_MIN=1
-  # PWP__URL__EXPIRE_AFTER_DAYS_MAX=90
+  # PWP__QR__EXPIRE_AFTER_DAYS_DEFAULT=7
+  # PWP__QR__EXPIRE_AFTER_DAYS_MIN=1
+  # PWP__QR__EXPIRE_AFTER_DAYS_MAX=90
   #
   expire_after_days_default: 7
   expire_after_days_min: 1
@@ -594,8 +594,8 @@ qr:
   #
   # When the retrieval step is enabled (above), what is the default value on the form?
   #
-  # When true, secret URLs will be generated as /r/xxxxxxxx/r which will show a page
-  # requiring a click to view the page /r/xxxxxxxx
+  # When true, secret URLs will be generated as /p/xxxxxxxx/r which will show a page
+  # requiring a click to view the page /p/xxxxxxxx
   #
   # Environment variable override:
   # PWP__QR__RETRIEVAL_STEP_DEFAULT='true'
@@ -619,13 +619,12 @@ qr:
   # default: true
   #
   # When this is set to true, this option does two things:
-  #   1. Sets the default check state for the "Allow viewers to
-  #       optionally delete password before expiration" checkbox
-  #   2. JSON API: Sets the default value for newly pushed passwords if
+  #   1. Sets the default check state for the "Allow users to delete this push once retrieved." checkbox
+  #   2. JSON API: Sets the default value for newly pushed pushs if
   #       unspecified
   #
   # Environment variable override:
-  # PWP__PW__DELETABLE_PUSHES_DEFAULT='false'
+  # PWP__QR__DELETABLE_PUSHES_DEFAULT='false'
   #
   deletable_pushes_default: true
 

--- a/config/locales/pwpx.en.yml
+++ b/config/locales/pwpx.en.yml
@@ -807,6 +807,7 @@ en:
       none: None
       title: New Push
       unknown: Unknown
+    qr_pushes_disabled: QR Code pushes are disabled.
     settings: Settings
     show:
       click_to_reveal: The content is blurred out. Click below to reveal it.
@@ -825,7 +826,6 @@ en:
     update:
       successful: Push was successfully updated.
     url_pushes_disabled: URL pushes are disabled.
-    qr_pushes_disabled: QR Code pushes are disabled.
     view:
       one: 1 view
       other: "%{count} views"

--- a/config/locales/pwpx.en.yml
+++ b/config/locales/pwpx.en.yml
@@ -825,6 +825,7 @@ en:
     update:
       successful: Push was successfully updated.
     url_pushes_disabled: URL pushes are disabled.
+    qr_pushes_disabled: QR Code pushes are disabled.
     view:
       one: 1 view
       other: "%{count} views"

--- a/config/routes/pushes.rb
+++ b/config/routes/pushes.rb
@@ -9,6 +9,7 @@ constraints(format: :html) do
   get "/r/:url_token/r", to: redirect(path: "/p/%{url_token}/r", status: 301)
   get "/r/:url_token/passphrase", to: redirect(path: "/p/%{url_token}/passphrase", status: 301)
 
+  get "/qr_preview", to: "pushes#qr_preview"
   resources :p, controller: :pushes, as: :pushes, except: %i[edit update destroy] do
     get "preview", on: :member
     get "print_preview", on: :member

--- a/config/routes/pwp_api.rb
+++ b/config/routes/pwp_api.rb
@@ -15,6 +15,8 @@ constraints(format: :json) do
   resources :p, controller: "api/v1/pushes", as: :json_pushes, except: %i[new index edit update] do
     get "preview", on: :member
     get "audit", on: :member
+    get "active", on: :collection
+    get "expired", on: :collection
   end
 
   # File pushes only enabled when logins are enabled.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -538,6 +538,83 @@ files:
     # Environment Variable Override: PWP__FILES__AS__CONTAINER=''
     container: ''
 
+## Expiration Settings for QR Pushes
+#
+qr:
+  # Expire QR Code Pushes After XX Days
+  #
+  # Controls the "Expire After Days" for QR Code Pushes
+  #
+  # Environment variable overrides:
+  # PWP__QR__EXPIRE_AFTER_DAYS_DEFAULT=7
+  # PWP__QR__EXPIRE_AFTER_DAYS_MIN=1
+  # PWP__QR__EXPIRE_AFTER_DAYS_MAX=90
+  #
+  expire_after_days_default: 7
+  expire_after_days_min: 1
+  expire_after_days_max: 90
+
+  # Expire QR Code Pushes After XX Views
+  #
+  # Controls the "Expire After Views" form settings in Password#new
+  #
+  # Environment variable overrides:
+  # PWP__QR__EXPIRE_AFTER_VIEWS_DEFAULT=5
+  # PWP__QR__EXPIRE_AFTER_VIEWS_MIN=1
+  # PWP__QR__EXPIRE_AFTER_VIEWS_MAX=100
+  #
+  expire_after_views_default: 5
+  expire_after_views_min: 1
+  expire_after_views_max: 100
+
+  # Retrieval Step for QR Code Pushes
+  #
+  # This enables or disables the "1-click retrieval step" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__QR__ENABLE_RETRIEVAL_STEP='false'
+  #
+  enable_retrieval_step: true
+
+  # Default Form Value for the Retrieval Step
+  #
+  # When the retrieval step is enabled (above), what is the default value on the form?
+  #
+  # When true, secret URLs will be generated as /p/xxxxxxxx/r which will show a page
+  # requiring a click to view the page /p/xxxxxxxx
+  #
+  # Environment variable override:
+  # PWP__QR__RETRIEVAL_STEP_DEFAULT='true'
+  #
+  retrieval_step_default: false
+
+  # Deletable QR Code Pushes
+  #
+  # default: true
+  #
+  # This enables or disables the "Allow Immediate Deletion" feature entirely.  For the default value
+  # when it is enabled here, see the next setting.
+  #
+  # Environment variable override:
+  # PWP__QR__ENABLE_DELETABLE_PUSHES='false'
+  #
+  enable_deletable_pushes: true
+
+  # Deletable Pushes Default Value
+  #
+  # default: true
+  #
+  # When this is set to true, this option does two things:
+  #   1. Sets the default check state for the "Allow viewers to
+  #       optionally delete password before expiration" checkbox
+  #   2. JSON API: Sets the default value for newly pushed passwords if
+  #       unspecified
+  #
+  # Environment variable override:
+  # PWP__QR__DELETABLE_PUSHES_DEFAULT='false'
+  #
+  deletable_pushes_default: true
 
 ### Password Generator Defaults
 #

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,6 +36,19 @@ enable_url_pushes: false
 #
 enable_file_pushes: false
 
+### QR Code Pushes
+#
+# Enable or disable QR code based pushes.  These allow you to share QR codes securely.
+# Like regular pushes, they expire after a set time or amount of views.
+#
+# Note that `enable_logins` is required for QR code based pushes to work.  It is a
+# feature for logged in users only.
+#
+# Environment variable override:
+# PWP__ENABLE_QR_PUSHES='false'
+#
+enable_qr_pushes: false
+
 ### Logins (User accounts)
 #
 # Logins are disabled by default since they require an MTA (email) server
@@ -221,7 +234,7 @@ timezone: 'America/New_York'
 
 ## Expiration Settings for Password Pushes
 #
-pw:
+pw: 
   # Expire Password Pushes After XX Days
   #
   # Controls the "Expire After Days" for Password Pushes
@@ -538,7 +551,7 @@ files:
     # Environment Variable Override: PWP__FILES__AS__CONTAINER=''
     container: ''
 
-## Expiration Settings for QR Pushes
+## Expiration Settings for QR Code Pushes
 #
 qr:
   # Expire QR Code Pushes After XX Days
@@ -606,9 +619,8 @@ qr:
   # default: true
   #
   # When this is set to true, this option does two things:
-  #   1. Sets the default check state for the "Allow viewers to
-  #       optionally delete password before expiration" checkbox
-  #   2. JSON API: Sets the default value for newly pushed passwords if
+  #   1. Sets the default check state for the "Allow users to delete this push once retrieved." checkbox
+  #   2. JSON API: Sets the default value for newly pushed pushs if
   #       unspecified
   #
   # Environment variable override:

--- a/test/controllers/qr_push_controller_test.rb
+++ b/test/controllers/qr_push_controller_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrPushControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+  end
+
+  teardown do
+    @luca = users(:luca)
+    sign_out @luca
+  end
+
+  test "New push form is NOT available anonymous" do
+    get new_push_path(tab: "qr")
+    assert_redirected_to new_user_session_path
+  end
+
+  test '"index" should redirect anonymous to user sign in' do
+    get pushes_path
+    assert_response :redirect
+    follow_redirect!
+    assert response.body.include?("You need to sign in or sign up before continuing.")
+  end
+
+  test "logged in users can access their dashboard" do
+    @luca = users(:luca)
+    @luca.confirm
+    sign_in @luca
+
+    get pushes_path
+    assert_response :success
+    assert response.body.include?("You currently have no pushes.")
+
+    get pushes_path(filter: "active")
+    assert_response :success
+    assert response.body.include?("You currently have no active pushes.")
+
+    get pushes_path(filter: "expired")
+    assert_response :success
+    assert response.body.include?("You currently have no expired pushes.")
+  end
+
+  test "logged in users with pushes can access their dashboard" do
+    @luca = users(:luca)
+    @luca.confirm
+    sign_in @luca
+
+    no_push_text = "You currently have no pushes."
+    get pushes_path
+    assert_response :success
+    assert response.body.include?(no_push_text)
+
+    get new_push_path(tab: "qr")
+    assert_response :success
+    assert response.body.include?("Tip: Only enter a password into the box")
+
+    post pushes_path params: {
+      push: {
+        kind: "qr",
+        payload: "testqr"
+      }
+    }
+    assert_response :redirect
+
+    get pushes_path
+    assert_response :success
+    assert_not response.body.include?(no_push_text)
+  end
+
+  test "get active dashboard with token" do
+    @luca = users(:luca)
+    @luca.confirm
+
+    get active_json_pushes_path(format: :json),
+      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+  end
+
+  test "get expired dashboard with token" do
+    @luca = users(:luca)
+    @luca.confirm
+
+    get expired_json_pushes_path(format: :json),
+      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+  end
+
+  test "override base url" do
+    Settings.override_base_url = "testqr"
+
+    @luca = users(:luca)
+    @luca.confirm
+    sign_in @luca
+
+    post pushes_path params: {
+      push: {
+        kind: "qr",
+        payload: "testqr"
+      }
+    }
+    assert_response :redirect
+
+    follow_redirect!
+    assert_response :success
+
+    assert response.body.include?("testqr")
+  end
+end

--- a/test/integration/qr/qr_anonymous_access_test.rb
+++ b/test/integration/qr/qr_anonymous_access_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrAnonymousAccessTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+
+    Rails.application.reload_routes!
+  end
+
+  teardown do
+    Settings.disable_signups = false
+  end
+
+  def test_anonymous_disabled_signups_no_signup_link
+    Settings.disable_signups = true
+
+    get new_push_path(tab: "qr")
+    assert_response :redirect
+
+    follow_redirect!
+
+    assert response.body.include?("You need to sign in or sign up before continuing.")
+  end
+
+  def test_anonymous_enabled_signups_with_signup_link
+    get new_push_path(tab: "qr")
+    assert_response :redirect
+
+    follow_redirect!
+
+    assert_select ".alert", {text: "You need to sign in or sign up before continuing.", count: 1}
+  end
+
+  def test_access_for_anonymous
+    get pushes_path
+    assert_response :redirect
+
+    post pushes_path, params: {blah: "blah"}
+    assert_response :bad_request
+
+    get new_push_path(tab: "qr")
+    assert_response :redirect
+
+    follow_redirect!
+
+    assert response.body.include?("You need to sign in or sign up before continuing.")
+  end
+end

--- a/test/integration/qr/qr_audit_test.rb
+++ b/test/integration/qr/qr_audit_test.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrAuditTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+
+    # Create a user
+    @luca = users(:luca)
+    @paul = users(:one)
+    sign_in @luca
+  end
+
+  teardown do
+    sign_out :user
+  end
+
+  def test_user_can_view_audit_logs_for_own_push
+    # Create a new push
+    post pushes_path, params: {
+      push: {
+        kind: "qr",
+        payload: "audit_test_text_payload",
+        expire_after_days: 7,
+        expire_after_views: 5
+      }
+    }
+    follow_redirect!
+
+    url_token = request.url.match("/p/(.*)/preview")[1]
+    push = Push.find_by(url_token: url_token)
+
+    get audit_push_path(push)
+    assert_response :success
+    assert_select "h4", {text: /Audit Log for Push ID: #{push.url_token}/}
+    assert_select ".list-group-item-primary", {text: /Created on/, count: 1}
+  end
+
+  def test_user_cannot_view_audit_logs_for_other_users
+    # Create a new push
+    post pushes_path, params: {
+      push: {
+        kind: "qr",
+        payload: "audit_test_text_payload",
+        expire_after_days: 7,
+        expire_after_views: 5
+      }
+    }
+    follow_redirect!
+
+    url_token = request.url.match("/p/(.*)/preview")[1]
+    push = Push.find_by(url_token: url_token)
+
+    sign_out :user
+    sign_in @paul
+    get audit_push_path(push)
+    assert_response :redirect
+
+    # Verify redirect with access denied message
+    follow_redirect!
+
+    assert_select ".alert", {text: /That push doesn't belong to you/, count: 1}
+  end
+
+  def test_anonymous_user_cannot_view_audit_logs
+    post pushes_path, params: {
+      push: {
+        kind: "qr",
+        payload: "audit_test_text_payload",
+        expire_after_days: 7,
+        expire_after_views: 5
+      }
+    }
+    follow_redirect!
+
+    url_token = request.url.match("/p/(.*)/preview")[1]
+    push = Push.find_by(url_token: url_token)
+
+    sign_out @luca
+
+    get audit_push_path(push)
+    assert_response :redirect
+
+    # Should redirect to sign in
+    follow_redirect!
+    assert_select "h2", {text: /Log In/}
+  end
+
+  def test_audit_log_shows_creation_event_html_elements
+    # Create a new push
+    post pushes_path, params: {
+      push: {
+        kind: "qr",
+        payload: "audit_test_text_payload",
+        expire_after_days: 7,
+        expire_after_views: 5
+      }
+    }
+    follow_redirect!
+
+    url_token = request.url.match("/p/(.*)/preview")[1]
+    push = Push.find_by(url_token: url_token)
+
+    # View the audit log
+    get audit_push_path(push)
+    assert_response :success
+
+    # Check HTML elements for creation event
+    assert_select "h4", {text: /Audit Log for Push ID: #{push.url_token}/}
+    assert_select ".list-group-item-primary", {text: /Created on/, count: 1}
+  end
+
+  def test_audit_log_shows_view_event_html_elements
+    # Create a new push
+    post pushes_path, params: {
+      push: {
+        kind: "qr",
+        payload: "audit_test_text_payload",
+        expire_after_days: 7,
+        expire_after_views: 5
+      }
+    }
+
+    # View the push
+    get push_path(@luca.pushes.last)
+    assert_response :success
+
+    # View the audit log
+    get audit_push_path(@luca.pushes.last)
+    assert_response :success
+
+    # Check HTML elements for view event
+    assert_select ".list-group-item-success", {text: /Successful view/, count: 1}
+  end
+
+  def test_audit_log_shows_failed_passphrase_event_html_elements
+    # Create a push with passphrase
+    post pushes_path, params: {
+      push: {
+        kind: "qr",
+        payload: "passphrase_protected_payload",
+        expire_after_days: 7,
+        expire_after_views: 5,
+        passphrase: "correct-passphrase"
+      }
+    }
+    follow_redirect!
+
+    url_token = request.url.match("/p/(.*)/preview")[1]
+    push = Push.find_by(url_token: url_token)
+
+    # Attempt to view with wrong passphrase
+    post access_push_path(push), params: {passphrase: "wrong-passphrase"}
+
+    # View the audit log
+    get audit_push_path(push)
+    assert_response :success
+
+    assert_select ".list-group-item-warning", {text: /Failed passphrase attempt/, count: 1}
+  end
+
+  def test_audit_log_shows_expire_event_html_elements
+    # Create a push with passphrase
+    post pushes_path, params: {
+      push: {
+        kind: "qr",
+        payload: "passphrase_protected_payload",
+        expire_after_days: 7,
+        expire_after_views: 5,
+        passphrase: "correct-passphrase"
+      }
+    }
+    follow_redirect!
+
+    url_token = request.url.match("/p/(.*)/preview")[1]
+    push = Push.find_by(url_token: url_token)
+
+    # Expire the push
+    delete expire_push_path(push)
+    follow_redirect!
+
+    # View the audit log
+    get audit_push_path(push)
+    assert_response :success
+
+    assert_select ".list-group-item-danger", {text: /Manually expired on/, count: 1}
+  end
+
+  def test_audit_log_shows_failed_view_event_html_elements
+    # Create a push
+    post pushes_path, params: {
+      push: {
+        kind: "qr",
+        payload: "asdf",
+        expire_after_days: 7,
+        expire_after_views: 1
+      }
+    }
+    follow_redirect!
+
+    url_token = request.url.match("/p/(.*)/preview")[1]
+    push = Push.find_by(url_token: url_token)
+
+    # View the push once to use up the view
+    get push_path(push)
+    assert_response :success
+
+    # Try to view again (should fail)
+    get push_path(push)
+    assert_response :success
+
+    # View the audit log
+    get audit_push_path(push)
+    assert_response :success
+
+    # Check HTML elements for failed view event
+    assert_select ".list-group-item-warning", {text: /Failed view attempt/, count: 1}
+  end
+end

--- a/test/integration/qr/qr_authenticated_test.rb
+++ b/test/integration/qr/qr_authenticated_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrAuthenticatedTest < ActionDispatch::IntegrationTest
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+  end
+
+  def test_authenticated_json_creation
+    post passwords_path(format: :json),
+      params: {password: {kind: "qr", payload: "testpw"}},
+      headers: {"Authorization" => "Bearer #{users(:luca).authentication_token}"}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("payload") == false # No payload on create response
+  end
+
+  def test_authenticated_json_creation_with_bad_token
+    post passwords_path(format: :json),
+      params: {password: {kind: "qr", payload: "testpw"}},
+      headers: {"Authorization" => "Bearer 00000200000000001000000000000000"}
+    assert_response :unauthorized
+  end
+end

--- a/test/integration/qr/qr_creation_test.rb
+++ b/test/integration/qr/qr_creation_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrCreationTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+    Rails.application.reload_routes!
+
+    @luca = users(:luca)
+    @luca.confirm
+    sign_in @luca
+  end
+
+  teardown do
+    sign_out @luca
+  end
+
+  def test_textarea_has_safeties
+    get new_push_path(tab: "qr")
+    assert_response :success
+
+    # Validate some elements
+    text_area = css_select "textarea#push_payload.form-control"
+
+    assert text_area.attribute("spellcheck")
+    assert text_area.attribute("spellcheck").value == "false"
+
+    assert text_area.attribute("autocomplete")
+    assert text_area.attribute("autocomplete").value == "off"
+
+    assert text_area.attribute("autofocus")
+    assert text_area.attribute("autofocus").value == "autofocus"
+
+    assert text_area.attribute("required")
+    assert text_area.attribute("required").value == "required"
+
+    assert text_area.attribute("maxlength")
+    assert text_area.attribute("maxlength").value == "1024"
+  end
+
+  def test_url_creation
+    get new_push_path(tab: "qr")
+    assert_response :success
+
+    post pushes_path, params: {push: {kind: "qr", payload: "testqr"}}
+    assert_response :redirect
+
+    # Preview page
+    follow_redirect!
+    assert_response :success
+    assert_select "h2", "Your push has been created."
+
+    # Password page
+    get request.url.sub("/preview", "")
+    assert_response :success
+
+    # Validate some elements
+    p_tags = assert_select "p"
+    assert p_tags[0].text == "Please obtain and securely store this content in a secure manner, such as in a password manager."
+    assert p_tags[1].text.include?("This secret link and all content will be deleted")
+
+    # Assert that the right password is in the page
+    svg = css_select "svg"
+    assert(svg)
+    rect_elements = svg.css("rect")
+    assert_equal 222, rect_elements.length
+  end
+end

--- a/test/integration/qr/qr_deletion_test.rb
+++ b/test/integration/qr/qr_deletion_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrDeletionTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+
+    @luca = users(:luca)
+    @luca.confirm
+    sign_in @luca
+  end
+
+  def test_anonymous_qr_deletion
+    assert Settings.qr.enable_deletable_pushes == true
+    # create
+    post pushes_path, params: {push: {kind: "qr", payload: "testqr", deletable_by_viewer: "on"}}
+    assert_response :redirect
+
+    # preview
+    follow_redirect!
+    assert_response :success
+    assert_select "h2", "Your push has been created."
+
+    # view the push
+    get request.url.sub("/preview", "")
+    assert_response :success
+
+    # Assert that the right qr is in the page
+    svg = css_select "svg"
+    assert(svg)
+    rect_elements = svg.css("rect")
+    assert_equal 222, rect_elements.length
+
+    # Expire the push
+    delete expire_push_path(request.url.match(/\/p\/(.*)/)[1])
+    assert_response :redirect
+
+    # Get redirected to the push that is now expired
+    follow_redirect!
+    assert_response :success
+    assert response.body.include?("We apologize but this secret link has expired.")
+
+    # Retrieve the preliminary page.  It should show expired too.
+    get preliminary_push_path(Push.last)
+    assert_response :success
+    assert response.body.include?("We apologize but this secret link has expired.")
+  end
+
+  def test_delete_already_expired_goes_to_expired_path
+    assert Settings.pw.enable_deletable_pushes == true
+    # create
+    post pushes_path, params: {push: {kind: "qr", payload: "testqr", deletable_by_viewer: "on", expire_after_views: 1}}
+    assert_response :redirect
+
+    # preview
+    follow_redirect!
+    assert_response :success
+    assert_select "h2", "Your push has been created."
+
+    push_url = request.url.sub("/preview", "")
+
+    # view the push
+    get push_url
+    assert_response :success
+
+    # Assert that the right QR Code is in the page
+    svg = css_select "svg"
+    assert(svg)
+    rect_elements = svg.css("rect")
+    assert_equal 222, rect_elements.length
+
+    # view the push again should give expired page
+    get push_url
+    assert_response :success
+
+    expired_p = css_select "p.text-center"
+    assert(expired_p)
+    assert(expired_p.first.content.include?("We apologize but this secret link has expired."))
+
+    # Delete the already expired push
+    delete expire_push_path(request.url.match(/\/p\/(.*)/)[1])
+    assert_response :redirect
+
+    # Get redirected to the push that is now expired
+    follow_redirect!
+    assert_response :success
+    assert response.body.include?("We apologize but this secret link has expired.")
+
+    # Retrieve the preliminary page.  It should show expired too.
+    get preliminary_push_path(Push.last)
+    assert_response :success
+    assert response.body.include?("We apologize but this secret link has expired.")
+  end
+end

--- a/test/integration/qr/qr_index_test.rb
+++ b/test/integration/qr/qr_index_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrIndexTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+
+    @luca = users(:luca)
+    @luca.confirm
+    sign_in @luca
+  end
+
+  teardown do
+    sign_out :user
+  end
+
+  def test_active
+    get new_push_path(tab: "qr")
+    assert_response :success
+
+    post pushes_path, params: {
+      push: {
+        kind: "qr",
+        payload: "testqr",
+        name: "Test Password"
+      }
+    }
+    assert_response :redirect
+
+    follow_redirect!
+    assert_response :success
+    assert_select "h2", "Your push has been created."
+
+    get pushes_path(filter: "active")
+    assert_response :success
+
+    # Just verify that we have the expected number of th elements
+    assert_select "th", 6 # 6 columns in the table
+
+    # Verify that the table headers exist with the expected content
+    assert_select "th", /Name or ID/ # First column should contain 'Name' or 'ID'
+    assert_select "th", /Kind/ # Second column
+    assert_select "th", /Created/ # Third column
+    assert_select "th", /Note/ # Fourth column
+    assert_select "th", /Views-Days/ # Fifth column
+
+    # Verify that our created file push appears in the list
+    assert_select "td", "Test Password"
+
+    # Verify the push controls buttons
+    # Since this is an active push, both Preview and Audit buttons should be present
+    assert_select "div[aria-label='Push Controls']", 1 do |controls|
+      assert_select controls.first, "a", 2 # Should have 2 buttons (Preview and Audit)
+
+      # Check the text content of the buttons
+      assert_select controls.first, "a", text: "Preview", count: 1
+      assert_select controls.first, "a", text: "Audit", count: 1
+    end
+
+    # Expire the push
+    delete expire_push_path(@luca.pushes.last)
+    assert_response :redirect
+    follow_redirect!
+
+    # Verify the push is now expired
+    assert @luca.pushes.last.expired
+
+    # Check the expired pushes list
+    get pushes_path(filter: "expired")
+    assert_response :success
+
+    # Verify the push controls buttons
+    # Since this is an expired push, only Audit button should be present
+    assert_select "div[aria-label='Push Controls']", 1 do |controls|
+      assert_select controls.first, "a", 1 # Should have 1 buttons (Audit)
+
+      # Check the text content of the buttons
+      assert_select controls.first, "a", text: "Audit", count: 1
+    end
+  end
+end

--- a/test/integration/qr/qr_json_audit_test.rb
+++ b/test/integration/qr/qr_json_audit_test.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrJsonAuditTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+  end
+
+  def test_audit_response_for_authenticated
+    Settings.enable_logins = true
+
+    @luca = users(:luca)
+    @luca.confirm
+
+    # Create a push
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr", expire_after_views: 2}},
+      headers: {"X-User-Email": @luca.email,
+                "X-User-Token": @luca.authentication_token}, as: :json
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("url_token")
+    url_token = res["url_token"]
+
+    # Generate views on that push
+    3.times do
+      get "/p/#{url_token}.json"
+      assert_response :success
+    end
+
+    # Get the Audit Log
+    get "/p/#{url_token}/audit.json",
+      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}, as: :json
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert res.key?("views")
+    assert_equal res["views"].length, 4
+
+    first_view = res["views"].first
+    assert first_view.key?("ip")
+    assert first_view.key?("user_agent")
+    assert first_view.key?("referrer")
+    assert first_view.key?("created_at")
+    assert first_view.key?("updated_at")
+    assert first_view.key?("kind")
+    assert_equal res["views"].map { |view| view.except("created_at", "updated_at") }, [{"ip" => "127.0.0.1", "user_agent" => "", "referrer" => "", "kind" => "creation"}, {"ip" => "127.0.0.1", "user_agent" => "", "referrer" => "", "kind" => "view"}, {"ip" => "127.0.0.1", "user_agent" => "", "referrer" => "", "kind" => "view"}, {"ip" => "127.0.0.1", "user_agent" => "", "referrer" => "", "kind" => "failed_view"}]
+  end
+
+  def test_audit_response_for_created_expired_successful_and_unsuccessful_views
+    Settings.enable_logins = true
+
+    @luca = users(:luca)
+    @luca.confirm
+
+    # Create a push
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr", passphrase: "asdf", expire_after_views: 3}},
+      headers: {"X-User-Email": @luca.email,
+                "X-User-Token": @luca.authentication_token}, as: :json
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("url_token")
+    url_token = res["url_token"]
+
+    # Generate views on that push
+    2.times do
+      get "/p/#{url_token}.json?passphrase=asdf"
+      assert_response :success
+    end
+
+    # Generate unsuccessful views on that push because of wrong passphrase
+    get "/p/#{url_token}.json"
+    assert_response :unauthorized
+
+    delete password_path(url_token, format: :json),
+      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}, as: :json
+    assert_response :success
+
+    # Generate views on that push
+    2.times do
+      get "/p/#{url_token}.json"
+      assert_response :success
+    end
+
+    # Get the Audit Log
+    get "/p/#{url_token}/audit.json",
+      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}, as: :json
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("views")
+    assert_equal res["views"].length, 7
+
+    first_view = res["views"].first
+    assert first_view.key?("ip")
+    assert first_view.key?("user_agent")
+    assert first_view.key?("referrer")
+    assert first_view.key?("created_at")
+    assert first_view.key?("updated_at")
+    assert first_view.key?("kind")
+    assert_equal res["views"].map { |view| view.except("created_at", "updated_at") }, [{"ip" => "127.0.0.1", "user_agent" => "", "referrer" => "", "kind" => "creation"}, {"ip" => "127.0.0.1", "user_agent" => "", "referrer" => "", "kind" => "view"}, {"ip" => "127.0.0.1", "user_agent" => "", "referrer" => "", "kind" => "view"}, {"ip" => "127.0.0.1", "user_agent" => "", "referrer" => "", "kind" => "failed_passphrase"}, {"ip" => "127.0.0.1", "user_agent" => "", "referrer" => "", "kind" => "expire"}, {"ip" => "127.0.0.1", "user_agent" => "", "referrer" => "", "kind" => "failed_view"}, {"ip" => "127.0.0.1", "user_agent" => "", "referrer" => "", "kind" => "failed_view"}]
+  end
+
+  def test_no_token_no_audit_log
+    Settings.enable_logins = true
+
+    @luca = users(:luca)
+    @luca.confirm
+
+    # Create a push
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr", expire_after_views: 2}},
+      headers: {"X-User-Email": @luca.email,
+                "X-User-Token": @luca.authentication_token}, as: :json
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("url_token")
+    url_token = res["url_token"]
+
+    # Generate views on that push
+    3.times do
+      get "/p/#{url_token}.json"
+      assert_response :success
+    end
+
+    # Get the Audit Log without a token
+    get "/p/#{url_token}/audit.json", as: :json
+    assert_response :unauthorized
+  end
+
+  def test_no_audit_log_for_anonymous_pushes
+    Settings.enable_logins = true
+
+    @luca = users(:luca)
+    @luca.confirm
+
+    # Create an anonymous push
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr", expire_after_views: 2}}, as: :json
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("url_token")
+    url_token = res["url_token"]
+
+    # Generate views on that push
+    3.times do
+      get "/p/#{url_token}.json"
+      assert_response :success
+    end
+
+    # Get the Audit Log with a token
+    get "/p/#{url_token}/audit.json", as: :json
+    assert_response :unauthorized
+  end
+end

--- a/test/integration/qr/qr_json_creation_test.rb
+++ b/test/integration/qr/qr_json_creation_test.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrJsonCreationTest < ActionDispatch::IntegrationTest
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+  end
+
+  def test_basic_json_creation
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr"}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("payload") == false # No payload on create response
+    assert res.key?("url_token")
+    assert res.key?("name")
+    assert_equal "", res["name"]
+    assert res.key?("expired")
+    assert_equal false, res["expired"]
+    assert res.key?("deleted")
+    assert_equal false, res["deleted"]
+    assert res.key?("deletable_by_viewer")
+    assert_equal res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal res.except("url_token", "created_at", "updated_at", "html_url", "json_url"), {"expire_after_views" => 5,
+      "expired" => false,
+      "retrieval_step" => false,
+      "expired_on" => nil,
+      "passphrase" => "",
+      "expire_after_days" => 7,
+      "days_remaining" => 7,
+      "views_remaining" => 5,
+      "deleted" => false,
+      "deletable_by_viewer" => true,
+      "note" => "",
+      "name" => ""}
+
+    assert_equal Settings.pw.deletable_pushes_default, res["deletable_by_viewer"]
+    assert res.key?("days_remaining")
+    assert_equal Settings.pw.expire_after_days_default, res["days_remaining"]
+    assert res.key?("views_remaining")
+    assert_equal Settings.pw.expire_after_views_default, res["views_remaining"]
+
+    # These should be default values since we didn't specify them in the params
+    assert res.key?("expire_after_days")
+    assert_equal Settings.pw.expire_after_days_default, res["expire_after_days"]
+    assert res.key?("expire_after_views")
+    assert_equal Settings.pw.expire_after_views_default, res["expire_after_views"]
+  end
+
+  def test_json_creation_with_uncommon_characters
+    post json_pushes_path(format: :json), params: {password: {payload: "£¬"}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("payload") == false # No payload on create response
+    assert res.key?("url_token")
+    assert res.key?("expired")
+    assert_equal false, res["expired"]
+    assert res.key?("deleted")
+    assert_equal false, res["deleted"]
+    assert res.key?("deletable_by_viewer")
+    assert_equal Settings.pw.deletable_pushes_default, res["deletable_by_viewer"]
+    assert res.key?("days_remaining")
+    assert_equal Settings.pw.expire_after_days_default, res["days_remaining"]
+    assert res.key?("views_remaining")
+    assert_equal Settings.pw.expire_after_views_default, res["views_remaining"]
+
+    # These should be default values since we didn't specify them in the params
+    assert res.key?("expire_after_days")
+    assert_equal Settings.pw.expire_after_days_default, res["expire_after_days"]
+    assert res.key?("expire_after_views")
+    assert_equal Settings.pw.expire_after_views_default, res["expire_after_views"]
+
+    # Validate payload
+    get "/p/#{res["url_token"]}.json"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("payload")
+    assert_equal "£¬", res["payload"]
+  end
+
+  def test_deletable_by_viewer
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr", deletable_by_viewer: "true"}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("deletable_by_viewer")
+    assert_equal true, res["deletable_by_viewer"]
+  end
+
+  def test_not_deletable_by_viewer
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr", deletable_by_viewer: "false"}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("deletable_by_viewer")
+    assert_equal false, res["deletable_by_viewer"]
+  end
+
+  def test_deletable_by_viewer_absent_is_default
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr"}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("deletable_by_viewer")
+    assert_equal Settings.pw.enable_deletable_pushes, res["deletable_by_viewer"]
+  end
+
+  def test_custom_days_expiration
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr", expire_after_days: 1}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert res.key?("days_remaining")
+    assert_equal 1, res["days_remaining"]
+
+    assert res.key?("expire_after_days")
+    assert_equal 1, res["expire_after_days"]
+  end
+
+  def test_custom_views_expiration
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr", expire_after_views: 5}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert res.key?("views_remaining")
+    assert_equal 5, res["views_remaining"]
+
+    assert res.key?("expire_after_days")
+    assert_equal 5, res["expire_after_views"]
+  end
+
+  def test_creation_with_kind_on_endpoint_starting_with_p
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr"}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    url_token = res["url_token"]
+    push = Push.find_by(url_token:)
+    assert_equal push.kind, "qr"
+  end
+
+  def test_bad_request
+    post json_pushes_path(format: :json), params: {}
+    assert_response :bad_request
+
+    res = JSON.parse(@response.body)
+    assert res == {"error" => "param is missing or the value is empty: password"}
+  end
+end

--- a/test/integration/qr/qr_json_deletion_test.rb
+++ b/test/integration/qr/qr_json_deletion_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrJsonDeletionTest < ActionDispatch::IntegrationTest
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+  end
+
+  def test_deletion
+    # Create password
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr"}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("payload") == false
+    assert res.key?("url_token")
+    assert res.key?("expired")
+    assert_equal false, res["expired"]
+    assert res.key?("deleted")
+    assert_equal false, res["deleted"]
+    assert res.key?("deletable_by_viewer")
+    assert_equal Settings.pw.deletable_pushes_default, res["deletable_by_viewer"]
+    assert res.key?("days_remaining")
+    assert_equal Settings.pw.expire_after_days_default, res["days_remaining"]
+    assert res.key?("views_remaining")
+    assert_equal Settings.pw.expire_after_views_default, res["views_remaining"]
+
+    # Delete the new password via json e.g. /p/<url_token>.json
+    delete "/p/#{res["url_token"]}.json"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("payload") == false
+    assert res.key?("url_token")
+    assert res.key?("expired")
+    assert_equal true, res["expired"]
+    assert res.key?("expired_on")
+    assert_not_nil res["expired_on"]
+    assert res.key?("deleted")
+    assert_equal true, res["deleted"]
+    assert_equal res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "html_url", "json_url", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal res.except("url_token", "created_at", "updated_at", "expired_on", "html_url", "json_url"), {"expire_after_views" => 5,
+      "expired" => true,
+      "deletable_by_viewer" => true,
+      "retrieval_step" => false,
+      "passphrase" => nil,
+      "expire_after_days" => 7,
+      "days_remaining" => 7,
+      "views_remaining" => 5,
+      "deleted" => true}
+
+    assert res.key?("deletable_by_viewer")
+    assert_equal Settings.pw.deletable_pushes_default, res["deletable_by_viewer"]
+    assert res.key?("days_remaining")
+    assert_equal Settings.pw.expire_after_days_default, res["days_remaining"]
+    assert res.key?("views_remaining")
+    assert_equal Settings.pw.expire_after_views_default, res["views_remaining"]
+
+    # Now try to retrieve the password again
+    get "/p/#{res["url_token"]}.json"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("payload")
+    assert_nil res["payload"]
+    assert res.key?("url_token")
+    assert res.key?("expired")
+    assert_equal true, res["expired"]
+    assert res.key?("deleted")
+    assert_equal true, res["deleted"]
+    assert res.key?("deletable_by_viewer")
+    assert_equal Settings.pw.deletable_pushes_default, res["deletable_by_viewer"]
+    assert res.key?("days_remaining")
+    assert_equal Settings.pw.expire_after_days_default, res["days_remaining"]
+    assert res.key?("views_remaining")
+    assert_equal Settings.pw.expire_after_views_default - 1, res["views_remaining"]
+  end
+end

--- a/test/integration/qr/qr_json_passphrase_test.rb
+++ b/test/integration/qr/qr_json_passphrase_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrJsonPassphraseTest < ActionDispatch::IntegrationTest
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+  end
+
+  def test_basic_json_passphrase
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testpw", passphrase: "asdf"}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("payload") == false # No payload on create response
+    assert res.key?("url_token")
+    assert res.key?("passphrase")
+    assert_equal "asdf", res["passphrase"]
+
+    url_token = res["url_token"]
+
+    # Now try to retrieve the password directly
+    # We should get an error because we didn't provide a passphrase
+    get "/p/#{url_token}.json"
+    assert_response :unauthorized
+
+    res = JSON.parse(@response.body)
+    assert res.key?("error")
+    assert_equal "That passphrase is incorrect.", res["error"]
+
+    # Now try to retrieve the password with the correct passphrase
+    get "/p/#{url_token}.json?passphrase=asdf"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("expired")
+    assert_equal false, res["expired"]
+    assert res.key?("deleted")
+    assert_equal false, res["deleted"]
+    assert res.key?("payload")
+    assert_equal "testpw", res["payload"]
+  end
+
+  def test_basic_json_bad_passphrase
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testpw", passphrase: "asdf"}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert_not res.key?("payload")
+    assert res.key?("url_token")
+    assert res.key?("passphrase")
+
+    url_token = res["url_token"]
+    failed_passphrase_log_count = AuditLog.where(kind: :failed_passphrase).count
+
+    # Now try to retrieve the password directly
+    # We should get an error because we didn't provide a passphrase
+    get "/p/#{url_token}.json"
+    assert_response :unauthorized
+
+    res = JSON.parse(@response.body)
+    assert res.key?("error")
+    assert_equal "That passphrase is incorrect.", res["error"]
+    assert_equal failed_passphrase_log_count + 1, AuditLog.where(kind: :failed_passphrase).count
+
+    # Now try to retrieve the password with the correct passphrase
+    get "/p/#{url_token}.json?passphrase=badpassphrase"
+    assert_response :unauthorized
+
+    res = JSON.parse(@response.body)
+    assert res.key?("error")
+    assert_equal "That passphrase is incorrect.", res["error"]
+    assert_equal failed_passphrase_log_count + 2, AuditLog.where(kind: :failed_passphrase).count
+  end
+end

--- a/test/integration/qr/qr_json_preview_test.rb
+++ b/test/integration/qr/qr_json_preview_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "uri"
+
+class QrJsonPreviewTest < ActionDispatch::IntegrationTest
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+  end
+
+  def test_preview_anonymous_response
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr", expire_after_views: 2}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("url_token")
+
+    get "/p/#{res["url_token"]}/preview.json"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("url")
+  end
+
+  def test_authenticated_preview_response
+    Settings.enable_logins = true
+
+    @luca = users(:luca)
+    @luca.confirm
+
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr", expire_after_views: 2}},
+      headers: {"X-User-Email": @luca.email,
+                "X-User-Token": @luca.authentication_token}, as: :json
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("url_token")
+
+    url_token = res["url_token"]
+
+    get "/p/#{url_token}/preview.json",
+      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}, as: :json
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("url")
+    uri = URI.parse(res["url"])
+    assert_not (uri.path =~ /#{url_token}/).nil?
+  end
+
+  def test_override_base_url
+    Settings.override_base_url = "https://example.com:12345"
+
+    post json_pushes_path(format: :json), params: {password: {
+      payload: "testqr",
+      expire_after_views: 2
+    }}
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("url_token")
+
+    get "/p/#{res["url_token"]}/preview.json"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("url")
+
+    uri = URI.parse(res["url"])
+    assert uri.host == "example.com"
+    assert uri.port == 12345
+    assert uri.scheme == "https"
+    assert_not (uri.path =~ /#{res["url_token"]}/).nil?
+  end
+end

--- a/test/integration/qr/qr_json_retrieval_test.rb
+++ b/test/integration/qr/qr_json_retrieval_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrJsonRetrievalTest < ActionDispatch::IntegrationTest
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+  end
+
+  def test_view_with_passphrase
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr", expire_after_views: 2, passphrase: "asdf"}}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    url_token = res["url_token"]
+
+    # Now try to retrieve the password without the passphrase
+    get "/p/#{url_token}.json"
+    assert_response :unauthorized
+
+    res = JSON.parse(@response.body)
+    assert res.key?("error")
+
+    # Now try to retrieve the password WITH the passphrase
+    get "/p/#{url_token}.json?passphrase=asdf"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("payload")
+    assert_equal "testqr", res["payload"]
+  end
+
+  def test_view_expiration
+    post json_pushes_path(format: :json), params: {password: {kind: "qr", payload: "testqr", expire_after_views: 2}}
+    assert_response :success
+
+    # Push a password with two views
+    res = JSON.parse(@response.body)
+    assert res.key?("payload") == false # No payload on create response
+    assert res.key?("url_token")
+    assert res.key?("expired")
+    assert_equal false, res["expired"]
+    assert res.key?("deleted")
+    assert_equal false, res["deleted"]
+    assert res.key?("deletable_by_viewer")
+    assert_equal Settings.pw.deletable_pushes_default, res["deletable_by_viewer"]
+    assert res.key?("days_remaining")
+    assert_equal 2, res["views_remaining"]
+    assert res.key?("expire_after_days")
+    assert_equal 2, res["expire_after_views"]
+
+    # Now try to retrieve the password for the first time
+    get "/p/#{res["url_token"]}.json"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("expired")
+    assert_equal false, res["expired"]
+    assert res.key?("deleted")
+    assert_equal false, res["deleted"]
+    assert res.key?("payload")
+    assert_equal "testqr", res["payload"]
+    assert res.key?("views_remaining")
+    assert_equal 1, res["views_remaining"]
+    assert res.key?("expire_after_views")
+    assert_equal 2, res["expire_after_views"]
+
+    # ...and the second view
+    get "/p/#{res["url_token"]}.json"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("expired")
+    assert_equal false, res["expired"]
+    assert res.key?("deleted")
+    assert_equal false, res["deleted"]
+    assert res.key?("payload")
+    assert_equal "testqr", res["payload"]
+    assert res.key?("views_remaining")
+    assert_equal 0, res["views_remaining"]
+    assert res.key?("expire_after_views")
+    assert_equal 2, res["expire_after_views"]
+
+    # Check the record directly; it should be expired after the last view
+    password = Push.find_by!(url_token: res["url_token"])
+    assert password.expired
+    assert_nil password.payload
+    assert_equal 0, password.views_remaining
+
+    # With the third view, we should have an expired password
+    get "/p/#{res["url_token"]}.json"
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res.key?("expired")
+    assert_equal true, res["expired"]
+    assert res.key?("expired_on")
+    assert_not_nil res["expired_on"]
+    assert res.key?("deleted")
+    assert_equal false, res["deleted"]
+    assert res.key?("payload")
+    assert_nil res["payload"]
+    assert res.key?("views_remaining")
+    assert_equal 0, res["views_remaining"]
+    assert res.key?("expire_after_views")
+    assert_equal 2, res["expire_after_views"]
+    assert_equal res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "html_url", "json_url", "passphrase", "payload", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal res.except("url_token", "created_at", "updated_at", "expired_on", "html_url", "json_url"), {"expire_after_views" => 2,
+      "expired" => true,
+      "deletable_by_viewer" => true,
+      "retrieval_step" => false,
+      "passphrase" => nil,
+      "expire_after_days" => 7,
+      "days_remaining" => 7,
+      "views_remaining" => 0,
+      "deleted" => false,
+      "payload" => nil,
+      "files" => []}
+  end
+end

--- a/test/integration/qr/qr_notfound_test.rb
+++ b/test/integration/qr/qr_notfound_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrNotfoundTest < ActionDispatch::IntegrationTest
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+  end
+
+  def test_password_not_found
+    # Non existant push should return the expired page
+    get "/p/doesnotexist"
+    assert_response :success
+
+    # Validate the expiration page
+    p_tags = assert_select "p"
+    assert p_tags[0].text.include?("We apologize but this secret link has expired.")
+  end
+
+  def test_password_preliminary_not_found
+    # Non existant push should return the expired page
+    get "/p/doesnotexist/r"
+    assert_response :success
+
+    # Validate the expiration page
+    p_tags = assert_select "p"
+    assert p_tags[0].text.include?("We apologize but this secret link has expired.")
+  end
+end

--- a/test/integration/qr/qr_passphrase_test.rb
+++ b/test/integration/qr/qr_passphrase_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrPassphraseTest < ActionDispatch::IntegrationTest
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+
+    @luca = users(:luca)
+    @luca.confirm
+    sign_in @luca
+  end
+
+  teardown do
+    sign_out :user
+  end
+
+  def test_password_passphrase
+    get new_push_path(tab: "text")
+    assert_response :success
+
+    post pushes_path, params: {push: {kind: "qr", payload: "testqr", passphrase: "asdf"}}
+    assert_response :redirect
+
+    # Preview page
+    follow_redirect!
+    assert_response :success
+    assert_select "h2", "Your push has been created."
+
+    # Attempt to retrieve the password without the passphrase
+    get request.url.sub("/preview", "")
+    assert_response :redirect
+
+    # We should get redirected to the passphrase page
+    follow_redirect!
+    assert_response :success
+
+    # We should be on the passphrase page now
+
+    # Validate passphrase form
+    forms = css_select "form"
+    assert_select "form input", 1
+    input = css_select "input#passphrase.form-control"
+    assert_equal input.first.attributes["placeholder"].value, "Enter the secret passphrase provided with this URL"
+
+    # Provide the value passphrase
+    post forms.first.attributes["action"].value, params: {passphrase: "asdf"}
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+
+    # We should be on the password#show page now
+    p_tags = assert_select "p"
+    assert p_tags[0].text == "Please obtain and securely store this content in a secure manner, such as in a password manager."
+    assert p_tags[1].text.include?("This secret link and all content will be deleted")
+  end
+
+  def test_password_bad_passphrase
+    get new_push_path(tab: "text")
+    assert_response :success
+
+    post pushes_path, params: {push: {kind: "qr", payload: "testqr", passphrase: "asdf"}}
+    assert_response :redirect
+
+    # Preview page
+    follow_redirect!
+    assert_response :success
+    assert_select "h2", "Your push has been created."
+
+    # Attempt to retrieve the password without the passphrase
+    get request.url.sub("/preview", "")
+    assert_response :redirect
+
+    # We should get redirected to the passphrase page
+    follow_redirect!
+    assert_response :success
+
+    # We should be on the passphrase page now
+
+    # Validate passphrase form
+    forms = css_select "form"
+    assert_select "form input", 1
+    input = css_select "input#passphrase.form-control"
+    failed_passphrase_log_count = AuditLog.where(kind: :failed_passphrase).count
+    assert_equal input.first.attributes["placeholder"].value, "Enter the secret passphrase provided with this URL"
+
+    # Provide a bad passphrase
+    post forms.first.attributes["action"].value, params: {passphrase: "bad-passphrase"}
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+    assert_equal failed_passphrase_log_count + 1, AuditLog.where(kind: :failed_passphrase).count
+
+    # We should be back on the passphrase page now with an error message
+    divs = css_select "div.alert-warning"
+    assert divs.first.content.include?("That passphrase is incorrect")
+
+    css_select "form"
+    assert_select "form input", 1
+    input = css_select "input#passphrase.form-control"
+    assert_equal input.first.attributes["placeholder"].value, "Enter the secret passphrase provided with this URL"
+  end
+end

--- a/test/integration/qr/qr_requested_locale_test.rb
+++ b/test/integration/qr/qr_requested_locale_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrRequestedLocaleTest < ActionDispatch::IntegrationTest
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_qr_pushes = true
+
+    @luca = users(:luca)
+    @luca.confirm
+    sign_in @luca
+  end
+
+  def test_requested_locale
+    get new_push_path(tab: "qr")
+    assert_response :success
+
+    post pushes_path, params: {push: {kind: "qr", payload: "testqr", passphrase: "asdf", retrieval_step: true}}
+    assert_response :redirect
+
+    # Preview page
+    follow_redirect!
+    assert_response :success
+    assert_select "h2", "Your push has been created."
+
+    # Retrieve the push with a locale
+    push_with_locale = request.url.sub("/preview", "") + "/r?locale=es"
+    get push_with_locale
+    assert_response :success
+    assert_select "html[lang=es]"
+
+    links = assert_select("a")
+    assert_equal 1, links.count
+
+    push_with_locale = links.first.attributes["href"].value
+    get push_with_locale
+
+    # Redirected to the passphrase page
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+    assert_select "html[lang=es]"
+
+    # We should be on the passphrase page now
+
+    # Validate passphrase form
+    forms = css_select "form"
+    assert_select "form input", 1
+
+    # Provide the value passphrase
+    post forms.first.attributes["action"].value, params: {passphrase: "asdf"}
+    assert_response :redirect
+    follow_redirect!
+
+    # We should be on the password#show page now
+    assert_response :success
+    assert_select "html[lang=es]"
+  end
+
+  def test_requested_locale_without_passphrase
+    get new_push_path(tab: "qr")
+    assert_response :success
+
+    post pushes_path, params: {push: {kind: "qr", payload: "testqr", retrieval_step: true}}
+    assert_response :redirect
+
+    # Preview page
+    follow_redirect!
+    assert_response :success
+    assert_select "h2", "Your push has been created."
+
+    # Retrieve the push with a locale
+    push_with_locale = request.url.sub("/preview", "") + "/r?locale=es"
+    get push_with_locale
+    assert_response :success
+    assert_select "html[lang=es]"
+
+    links = assert_select("a")
+    assert_equal 1, links.count
+
+    push_with_locale = links.first.attributes["href"].value
+    get push_with_locale
+
+    # We should be on the password#show page now
+    assert_response :success
+    assert_select "html[lang=es]"
+  end
+end

--- a/test/models/qr_test.rb
+++ b/test/models/qr_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QrTest < ActiveSupport::TestCase
+  setup do
+    @default_enable_qr_pushes = Settings.enable_qr_pushes
+    @default_enable_logins = Settings.enable_logins
+
+    Settings.enable_qr_pushes = true
+    Settings.enable_logins = true
+  end
+
+  teardown do
+    Settings.enable_qr_pushes = @default_enable_qr_pushes
+    Settings.enable_logins = @default_enable_logins
+  end
+
+  test "should create QR Code push with name" do
+    qr = Push.new(
+      kind: "qr",
+      payload: "testqr",
+      name: "Test QR Code"
+    )
+    assert qr.save
+    assert_equal "Test QR Code", qr.name
+  end
+
+  test "should save QR Code push without name" do
+    qr = Push.new(
+      kind: "qr",
+      payload: "testqr"
+    )
+    assert qr.save
+    assert_equal "", qr.name
+  end
+
+  test "should include name in json representation when owner is true" do
+    qr = Push.new(
+      kind: "qr",
+      payload: "testqr",
+      name: "Test QR Code",
+      expire_after_days: 7,
+      expire_after_views: 10
+    )
+    assert qr.save
+
+    json = JSON.parse(qr.to_json({owner: true}))
+    assert_equal "Test QR Code", json["name"]
+  end
+
+  test "should not include name in json representation when owner is false" do
+    qr = Push.new(
+      kind: "qr",
+      payload: "testqr",
+      name: "Test QR Code",
+      expire_after_days: 7,
+      expire_after_views: 10
+    )
+    assert qr.save
+
+    json = JSON.parse(qr.to_json({}))
+    assert_not json.key?("name")
+  end
+end


### PR DESCRIPTION
## Description

It is requested to use QR Code for pushes. So, this feature is implemented a new `qr` kind.

## Related Issue

#2525

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [x] I've added documentation as necessary so users can easily use and understand this feature/fix.
  -- I have added very limited documentation for QR pushes.
