### PR TITLE
Push Create: Add fix for MariaDB id type conflict

### DIFF
--- a/db/migrate/20250515121325_create_pushes.rb
+++ b/db/migrate/20250515121325_create_pushes.rb
@@ -18,5 +18,30 @@ class CreatePushes < ActiveRecord::Migration[7.2]
       t.references :user, foreign_key: true
       t.timestamps
     end
+  rescue => e
+    # StandardError: An error has occurred, all later migrations canceled: (StandardError)
+    # Column `user_id` on table `pushes` does not match column `id` on `users`, which has type `int(11)`. To resolve this issue, change the type of the `user_id` column on `pushes` to be :integer. (For example `t.integer :user_id`).
+    # Original message: Mysql2::Error: Can't create table `db_name`.`pushes` (errno: 150 "Foreign key constraint is incorrectly formed")
+    Rails.logger.warn("Failed to create pushes table: #{e}")
+    Rails.logger.warn("This is expected if you are using MariaDB")
+
+    create_table(:pushes) do |t|
+      t.integer :kind, null: false
+      t.integer :expire_after_days
+      t.integer :expire_after_views
+      t.boolean :expired, default: false
+      t.string :url_token
+      t.boolean :deletable_by_viewer, default: true
+      t.boolean :retrieval_step, default: false
+      t.datetime :expired_on
+      t.text :payload_ciphertext, limit: 16.megabytes - 1
+      t.text :note_ciphertext
+      t.text :passphrase_ciphertext, limit: 2048
+      t.string :name
+
+      t.index [:url_token], unique: true
+      t.references :user, foreign_key: true, type: :integer
+      t.timestamps
+    end
   end
 end

--- a/db/migrate/20250515121325_create_pushes.rb
+++ b/db/migrate/20250515121325_create_pushes.rb
@@ -19,29 +19,34 @@ class CreatePushes < ActiveRecord::Migration[7.2]
       t.timestamps
     end
   rescue => e
-    # StandardError: An error has occurred, all later migrations canceled: (StandardError)
-    # Column `user_id` on table `pushes` does not match column `id` on `users`, which has type `int(11)`. To resolve this issue, change the type of the `user_id` column on `pushes` to be :integer. (For example `t.integer :user_id`).
-    # Original message: Mysql2::Error: Can't create table `db_name`.`pushes` (errno: 150 "Foreign key constraint is incorrectly formed")
-    Rails.logger.warn("Failed to create pushes table: #{e}")
-    Rails.logger.warn("This is expected if you are using MariaDB")
+    if ActiveRecord::Base.connection.adapter_name.downcase.starts_with?("mysql")
+      # Attempt to resolve an issue with MariaDB: https://github.com/pglombardo/PasswordPusher/issues/3422
+      # StandardError: An error has occurred, all later migrations canceled: (StandardError)
+      # Column `user_id` on table `pushes` does not match column `id` on `users`, which has type `int(11)`. To resolve this issue, change the type of the `user_id` column on `pushes` to be :integer. (For example `t.integer :user_id`).
+      # Original message: Mysql2::Error: Can't create table `db_name`.`pushes` (errno: 150 "Foreign key constraint is incorrectly formed")
+      Rails.logger.warn("Failed to create pushes table: #{e}.  Attempting to create pushes table with integer user_id.")
 
-    create_table(:pushes) do |t|
-      t.integer :kind, null: false
-      t.integer :expire_after_days
-      t.integer :expire_after_views
-      t.boolean :expired, default: false
-      t.string :url_token
-      t.boolean :deletable_by_viewer, default: true
-      t.boolean :retrieval_step, default: false
-      t.datetime :expired_on
-      t.text :payload_ciphertext, limit: 16.megabytes - 1
-      t.text :note_ciphertext
-      t.text :passphrase_ciphertext, limit: 2048
-      t.string :name
+      create_table(:pushes) do |t|
+        t.integer :kind, null: false
+        t.integer :expire_after_days
+        t.integer :expire_after_views
+        t.boolean :expired, default: false
+        t.string :url_token
+        t.boolean :deletable_by_viewer, default: true
+        t.boolean :retrieval_step, default: false
+        t.datetime :expired_on
+        t.text :payload_ciphertext, limit: 16.megabytes - 1
+        t.text :note_ciphertext
+        t.text :passphrase_ciphertext, limit: 2048
+        t.string :name
 
-      t.index [:url_token], unique: true
-      t.references :user, foreign_key: true, type: :integer
-      t.timestamps
+        t.index [:url_token], unique: true
+        t.references :user, foreign_key: true, type: :integer
+        t.timestamps
+      end
+
+    else
+      raise e
     end
   end
 end

--- a/db/migrate/20250515193130_create_audit_log.rb
+++ b/db/migrate/20250515193130_create_audit_log.rb
@@ -28,7 +28,7 @@ class CreateAuditLog < ActiveRecord::Migration[7.2]
 
         t.index :kind
 
-        t.references :user, foreign_key: true, type: :integer
+        t.references :user, foreign_key: false, type: :integer
         t.references :push, null: false, foreign_key: true, type: :integer
         t.timestamps
       end

--- a/db/migrate/20250515193130_create_audit_log.rb
+++ b/db/migrate/20250515193130_create_audit_log.rb
@@ -12,5 +12,29 @@ class CreateAuditLog < ActiveRecord::Migration[7.2]
       t.references :push, null: false, foreign_key: true
       t.timestamps
     end
+  rescue => e
+    if ActiveRecord::Base.connection.adapter_name.downcase.starts_with?("mysql")
+      # Attempt to resolve an issue with MariaDB: https://github.com/pglombardo/PasswordPusher/issues/3422
+      # StandardError: An error has occurred, all later migrations canceled: (StandardError)
+      # Column `user_id` on table `pushes` does not match column `id` on `users`, which has type `int(11)`. To resolve this issue, change the type of the `user_id` column on `pushes` to be :integer. (For example `t.integer :user_id`).
+      # Original message: Mysql2::Error: Can't create table `db_name`.`pushes` (errno: 150 "Foreign key constraint is incorrectly formed")
+      Rails.logger.warn("Failed to create audit_logs table: #{e}.  Attempting to create audit_logs table with integer user_id.")
+
+      create_table :audit_logs do |t|
+        t.string :ip
+        t.string :user_agent
+        t.string :referrer
+        t.integer :kind, null: false
+
+        t.index :kind
+
+        t.references :user, foreign_key: true, type: :integer
+        t.references :push, null: false, foreign_key: true, type: :integer
+        t.timestamps
+      end
+
+    else
+      raise e
+    end
   end
 end


### PR DESCRIPTION
## Description

User reported a integer type mismatch on db migration in #3422.

## Related Issue

#3422 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
