### PR TITLE
Public Gateway: Add legacy route redirects

### DIFF
--- a/config/routes/public_pushes.rb
+++ b/config/routes/public_pushes.rb
@@ -1,11 +1,16 @@
+# File pushes redirects - with query string preservation
+get "/f/:url_token", to: redirect(path: "/p/%{url_token}", status: 301)
+get "/f/:url_token/r", to: redirect(path: "/p/%{url_token}/r", status: 301)
+get "/f/:url_token/passphrase", to: redirect(path: "/p/%{url_token}/passphrase", status: 301)
+
+# URL pushes redirects - with query string preservation
+get "/r/:url_token", to: redirect(path: "/p/%{url_token}", status: 301)
+get "/r/:url_token/r", to: redirect(path: "/p/%{url_token}/r", status: 301)
+get "/r/:url_token/passphrase", to: redirect(path: "/p/%{url_token}/passphrase", status: 301)
+
 resources :p, controller: :pushes, as: :pushes, except: %i[edit update new create destroy] do
-  # get "preview", on: :member
-  # get "print_preview", on: :member
   get "passphrase", on: :member
   post "access", on: :member
   get "r", on: :member, as: "preliminary", action: "preliminary"
   delete "expire", on: :member
-  # get "audit", on: :member
-  # get "active", on: :collection
-  # get "expired", on: :collection
 end


### PR DESCRIPTION
## Description

@ecoutinho found in #3427 that legacy routes were not being properly redirected in the public gateway container.   This PR fixes the route redirects.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
