### PR TITLE
Add an initializer to customize error of inputs

### DIFF
--- a/config/initializers/customize_error.rb
+++ b/config/initializers/customize_error.rb
@@ -1,0 +1,14 @@
+ActionView::Base.field_error_proc = proc do |html_tag, instance|
+  # Parse the tag safely
+  fragment = Nokogiri::HTML::DocumentFragment.parse(html_tag)
+  element = fragment.children.first
+
+  # Only add class if it's a form field
+  if element && %w[input textarea select].include?(element.name)
+    existing_classes = element["class"].to_s.split
+    element["class"] = (existing_classes + ["is-invalid"]).uniq.join(" ")
+    fragment.to_html.html_safe
+  else
+    html_tag
+  end
+end


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/dfab92d5-94f7-4e43-aa00-8e7ff3950d4f)

For URL pushes, there is a validation for payload. But, it is not easy to notice the input having this issue. Rails is adding a wrapper having `field_with_errors` class as default. Bootstrap don't have this class, so it doesn't show any change in appearance of the input. 

Rails default behavior is updated.
![image](https://github.com/user-attachments/assets/4c88ae71-b74d-4c90-8887-2234172a3c2e)

## Related Issue

--

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
 -- No need to test
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
 -- No need to document
