### PR TITLE
Update the version of the mission_control-jobs gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,6 +131,6 @@ gem "turnout2024", require: "turnout"
 
 gem "solid_queue", "~> 1.1"
 
-gem "mission_control-jobs", "~> 0.5.0"
+gem "mission_control-jobs", "~> 1.0.2"
 
 gem "overmind", "~> 2.5", group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,7 +366,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mission_control-jobs (0.5.0)
+    mission_control-jobs (1.0.2)
       actioncable (>= 7.1)
       actionpack (>= 7.1)
       activejob (>= 7.1)
@@ -677,7 +677,7 @@ DEPENDENCIES
   minitest
   minitest-rails (>= 6.1.0)
   minitest-reporters
-  mission_control-jobs (~> 0.5.0)
+  mission_control-jobs (~> 1.0.2)
   mysql2
   oj
   overcommit

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,12 @@ module PasswordPusher
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # https://github.com/rails/mission_control-jobs?tab=readme-ov-file#custom-authentication
+    # Use the Admin::ApplicationController for authentication
+    config.mission_control.jobs.base_controller_class = "Admin::ApplicationController"
+    config.mission_control.jobs.http_basic_auth_enabled = false
+
     puts "Password Pusher Version: #{Version.current}"
   end
 

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -36,4 +36,21 @@ class AdminDashboardTest < ActionDispatch::IntegrationTest
     assert_response :success
     sign_out @mr_admin
   end
+
+  def test_background_jobs_available_to_admin_user
+    @mr_admin = users(:mr_admin)
+    sign_in @mr_admin
+    get "/admin/jobs"
+    assert_response :success
+    sign_out @mr_admin
+  end
+
+  def test_background_jobs_not_available_to_user
+    @luca = users(:luca)
+    @luca.confirm
+    sign_in @luca
+    get "/admin/jobs"
+    assert_response :not_found
+    sign_out @luca
+  end
 end

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -37,7 +37,7 @@ class AdminDashboardTest < ActionDispatch::IntegrationTest
     sign_out @mr_admin
   end
 
-  def test_background_jobs_available_to_admin_user
+  def test_background_jobs_dashboard_available_to_admin_user
     @mr_admin = users(:mr_admin)
     sign_in @mr_admin
     get "/admin/jobs"
@@ -45,7 +45,7 @@ class AdminDashboardTest < ActionDispatch::IntegrationTest
     sign_out @mr_admin
   end
 
-  def test_background_jobs_not_available_to_user
+  def test_background_jobs_dashboard_not_available_to_non_admin_user
     @luca = users(:luca)
     @luca.confirm
     sign_in @luca


### PR DESCRIPTION
## Description

A stylesheet used by mission_control-jobs is loaded by using CDN. This isn't acceptable by GDPR. [This issue fixed by gem contributors](https://github.com/rails/mission_control-jobs/commit/d43649cdddace2ec5ab2236f74ef41f06f4bc21d) with the latest version. So, the gem is upgraded.

## Related Issue

#3460

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
  -- No need to document
