### PR TITLE
🛠 Fix image entrypoint path

### DIFF
--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -130,4 +130,4 @@ RUN chmod +x /usr/local/bin/docker-entrypoint
 
 USER pwpusher
 EXPOSE 5100
-ENTRYPOINT ["docker-entrypoint"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -124,6 +124,10 @@ COPY --from=build-env --chown=pwpusher:pwpusher ${APP_ROOT} ${APP_ROOT}
 RUN bundle config set without "${BUNDLE_WITHOUT}" \
     && bundle config set deployment "${BUNDLE_DEPLOYMENT}"
 
+# Copy entrypoint inside container
+COPY containers/docker/entrypoint.sh /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
 USER pwpusher
 EXPOSE 5100
-ENTRYPOINT ["containers/docker/entrypoint.sh"]
+ENTRYPOINT ["docker-entrypoint"]

--- a/containers/docker/Dockerfile.public-gateway
+++ b/containers/docker/Dockerfile.public-gateway
@@ -2,6 +2,10 @@ FROM pglombardo/pwpush:latest
 
 ENV PWP_PUBLIC_GATEWAY=true
 
+# Copy entrypoint inside container
+COPY containers/docker/entrypoint.sh /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
 USER pwpusher
 EXPOSE 5100
-ENTRYPOINT ["containers/docker/entrypoint.sh"]
+ENTRYPOINT ["docker-entrypoint"]

--- a/containers/docker/Dockerfile.public-gateway
+++ b/containers/docker/Dockerfile.public-gateway
@@ -8,4 +8,4 @@ RUN chmod +x /usr/local/bin/docker-entrypoint
 
 USER pwpusher
 EXPOSE 5100
-ENTRYPOINT ["docker-entrypoint"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/containers/docker/Dockerfile.worker
+++ b/containers/docker/Dockerfile.worker
@@ -7,4 +7,4 @@ COPY containers/docker/worker-entrypoint.sh /usr/local/bin/docker-entrypoint
 RUN chmod +x /usr/local/bin/docker-entrypoint
 
 USER pwpusher
-ENTRYPOINT ["docker-entrypoint"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/containers/docker/Dockerfile.worker
+++ b/containers/docker/Dockerfile.worker
@@ -2,5 +2,9 @@ FROM pglombardo/pwpush:latest
 
 ENV PWP_WORKER=true
 
+# Copy entrypoint inside container
+COPY containers/docker/worker-entrypoint.sh /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
 USER pwpusher
-ENTRYPOINT ["containers/docker/worker-entrypoint.sh"]
+ENTRYPOINT ["docker-entrypoint"]


### PR DESCRIPTION
This PR fixes the container image by properly including the `entrypoint.sh` script, which was previously missing from the image filesystem.

**✅ Changes made:**

- Added containers/docker/entrypoint.sh to the image using COPY.
- Set the correct ENTRYPOINT path to /usr/local/bin/entrypoint.sh.
- Ensured the script has executable permissions.

This change ensures the container can start properly, avoiding the following runtime error:

> OCI runtime create failed: runc create failed: unable to start container process: exec: "containers/docker/entrypoint.sh": stat containers/docker/entrypoint.sh: no such file or directory: unknown

Let me know if you prefer a more concise or formal tone.