### PR TITLE
Fix the grey bar under the tab bar

### DIFF
--- a/app/views/shared/_topnav.html.erb
+++ b/app/views/shared/_topnav.html.erb
@@ -1,5 +1,5 @@
 <% if Settings.enable_logins %>
-  <ul class="nav nav-tabs mb-3 overflow-x-scroll flex-nowrap overflow-y-hidden">
+  <ul class="nav nav-tabs mb-3 overflow-x-auto flex-nowrap overflow-y-hidden">
     <li class="nav-item">
       <a class="nav-link <%= @text_tab ? 'active' : '' %>" aria-current="page" href="<%= new_push_path(tab: 'text') %>"><%= _('Passwords') %></a>
     </li>


### PR DESCRIPTION
## Description

#3493 There is scroll bar under the tab bar. It should not be visible if not necessary. It is fixed. 

![image](https://github.com/user-attachments/assets/126c10d5-903f-4ab2-bfcc-509392ce5f92)

## Related Issue

#3493

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
 -- No need to test
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
 -- No need to document
