### PR TITLE
Retrieve URL with passphrase parameter

### DIFF
--- a/app/controllers/pushes_controller.rb
+++ b/app/controllers/pushes_controller.rb
@@ -27,7 +27,7 @@ class PushesController < BaseController
 
       # The passphrase can be passed in the params or in the cookie (default)
       # JSON requests must pass the passphrase in the params
-      has_passphrase = cookies[name] == @push.passphrase_ciphertext
+      has_passphrase = params[:passphrase] == @push.passphrase || cookies[name] == @push.passphrase_ciphertext
 
       unless has_passphrase
         # Passphrase hasn't been provided or is incorrect


### PR DESCRIPTION


## Description

When different push types are unified in #3380, [the logic used to check `passphrase` parameter is removed](https://github.com/pglombardo/PasswordPusher/pull/3380/files#diff-51761cd4f455de5f04da31d60dcf56fbd40648618179ee4a66c6b5652495c83cL66-L67) mistakenly. The condition is updated.

## Related Issue

#3505 3505

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
  -- No need to document