### PR TITLE
Add fields to API responses of active and expired pushes

### DIFF
--- a/app/views/pushes/_push.json.jbuilder
+++ b/app/views/pushes/_push.json.jbuilder
@@ -20,16 +20,6 @@ if %w[create active expired].include?(controller.action_name)
   json.name push.name
 end
 
-if %w[active expired].include?(controller.action_name) && push.file?
-  json.files do
-    json.array! push.files do |file|
-      json.filename file.filename.to_s
-      json.content_type file.content_type
-      json.url rails_blob_url(file)
-    end
-  end
-end
-
 if controller.action_name == "show"
   json.payload push.payload
 

--- a/app/views/pushes/_push.json.jbuilder
+++ b/app/views/pushes/_push.json.jbuilder
@@ -15,9 +15,19 @@ json.extract! push, :expire_after_views,
 json.json_url secret_url(push) + ".json"
 json.html_url secret_url(push)
 
-if controller.action_name == "create"
+if %w[create active expired].include?(controller.action_name)
   json.note push.note
   json.name push.name
+end
+
+if %w[active expired].include?(controller.action_name) && push.file?
+  json.files do
+    json.array! push.files do |file|
+      json.filename file.filename.to_s
+      json.content_type file.content_type
+      json.url rails_blob_url(file)
+    end
+  end
 end
 
 if controller.action_name == "show"

--- a/test/integration/file_push/file_push_json_active_test.rb
+++ b/test/integration/file_push/file_push_json_active_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FilePushJsonActiveTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_file_pushes = true
+    Rails.application.reload_routes!
+
+    @luca = users(:luca)
+    @luca.confirm
+  end
+
+  def test_basic_json_expired
+    post file_pushes_path(format: :json),
+      params: {
+        file_push: {
+          payload: "Message",
+          name: "Test File Push",
+          note: "This is a test file push",
+          files: [
+            fixture_file_upload("monkey.png", "image/jpeg")
+          ]
+        }
+      },
+      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+
+    get active_file_pushes_path(format: :json), headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    first_res = res.first
+    assert_not first_res.key?("payload")
+    assert first_res.key?("url_token")
+    assert first_res.key?("name")
+    assert_equal "Test File Push", first_res["name"]
+    assert first_res.key?("note")
+    assert_equal "This is a test file push", first_res["note"]
+    assert first_res.key?("expired")
+    assert_equal false, first_res["expired"]
+    assert first_res.key?("expired_on")
+    assert first_res.key?("deleted")
+    assert_equal false, first_res["deleted"]
+    assert first_res.key?("deletable_by_viewer")
+    assert_equal true, first_res["deletable_by_viewer"]
+    assert first_res.key?("files")
+    assert_equal 1, JSON.parse(first_res["files"]).count
+    # p JSON.parse(first_res["files"])
+    # => {"monkey.png" => "/pfb/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MSwiZXhwIjoiMjAyNS0wNy0wMlQyMToyMDoxNS4xNzBaIiwicHVyIjoiYmxvYl9pZCJ9fQ==--6e3f646b9f57ea24e0753fd3e1af4240c6442ec3/monkey.png"}
+    assert_equal true, JSON.parse(first_res["files"]).key?("monkey.png")
+    assert_match(/\/pfb\/blobs\/redirect\/.*\/monkey.png/, JSON.parse(first_res["files"])["monkey.png"])
+    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "name", "note", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal first_res.except("url_token", "created_at", "updated_at", "expired_on", "files"), {
+      "expire_after_days" => 7,
+      "expire_after_views" => 5,
+      "expired" => false,
+      "deleted" => false,
+      "deletable_by_viewer" => true,
+      "retrieval_step" => false,
+      "name" => "Test File Push",
+      "note" => "This is a test file push",
+      "days_remaining" => 7,
+      "views_remaining" => 5
+    }
+
+    # These should be default values since we didn't specify them in the params
+    assert_equal Settings.pw.deletable_pushes_default, first_res["deletable_by_viewer"]
+    assert first_res.key?("days_remaining")
+    assert_equal Settings.pw.expire_after_days_default, first_res["days_remaining"]
+    assert first_res.key?("views_remaining")
+    assert_equal Settings.pw.expire_after_views_default, first_res["views_remaining"]
+    assert first_res.key?("expire_after_days")
+    assert_equal Settings.pw.expire_after_days_default, first_res["expire_after_days"]
+    assert first_res.key?("expire_after_views")
+    assert_equal Settings.pw.expire_after_views_default, first_res["expire_after_views"]
+  end
+end

--- a/test/integration/file_push/file_push_json_active_test.rb
+++ b/test/integration/file_push/file_push_json_active_test.rb
@@ -48,24 +48,27 @@ class FilePushJsonActiveTest < ActionDispatch::IntegrationTest
     assert first_res.key?("deletable_by_viewer")
     assert_equal true, first_res["deletable_by_viewer"]
     assert first_res.key?("files")
-    assert_equal 1, JSON.parse(first_res["files"]).count
-    # p JSON.parse(first_res["files"])
-    # => {"monkey.png" => "/pfb/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MSwiZXhwIjoiMjAyNS0wNy0wMlQyMToyMDoxNS4xNzBaIiwicHVyIjoiYmxvYl9pZCJ9fQ==--6e3f646b9f57ea24e0753fd3e1af4240c6442ec3/monkey.png"}
-    assert_equal true, JSON.parse(first_res["files"]).key?("monkey.png")
-    assert_match(/\/pfb\/blobs\/redirect\/.*\/monkey.png/, JSON.parse(first_res["files"])["monkey.png"])
-    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "name", "note", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
-    assert_equal first_res.except("url_token", "created_at", "updated_at", "expired_on", "files"), {
-      "expire_after_days" => 7,
-      "expire_after_views" => 5,
+    assert_equal 1, first_res["files"].count
+    # p first_res["files"]
+    # => [{"filename" => "monkey.png", "content_type" => "image/png", "url" => "http://www.example.com/pfb/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MSwiZXhwIjoiMjAyNS0wNy0wMlQyMToyODoyNi43MzhaIiwicHVyIjoiYmxvYl9pZCJ9fQ==--98a8c59aa58c4c6a943c4eb27cec92c2c04434fd/monkey.png"}]
+    assert_equal true, first_res["files"].first.key?("filename")
+    assert_equal "monkey.png", first_res["files"].first["filename"]
+    assert_equal true, first_res["files"].first.key?("content_type")
+    assert_equal "image/png", first_res["files"].first["content_type"]
+    assert_equal true, first_res["files"].first.key?("url")
+    assert_match(/\/pfb\/blobs\/redirect\/.*\/monkey.png/, first_res["files"].first["url"])
+    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal first_res.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on", "files"), {"expire_after_views" => 5,
       "expired" => false,
-      "deleted" => false,
       "deletable_by_viewer" => true,
       "retrieval_step" => false,
-      "name" => "Test File Push",
-      "note" => "This is a test file push",
+      "passphrase" => "",
+      "expire_after_days" => 7,
       "days_remaining" => 7,
-      "views_remaining" => 5
-    }
+      "views_remaining" => 5,
+      "deleted" => false,
+      "note" => "This is a test file push",
+      "name" => "Test File Push"}
 
     # These should be default values since we didn't specify them in the params
     assert_equal Settings.pw.deletable_pushes_default, first_res["deletable_by_viewer"]

--- a/test/integration/file_push/file_push_json_active_test.rb
+++ b/test/integration/file_push/file_push_json_active_test.rb
@@ -58,7 +58,8 @@ class FilePushJsonActiveTest < ActionDispatch::IntegrationTest
     assert_equal true, first_res["files"].first.key?("url")
     assert_match(/\/pfb\/blobs\/redirect\/.*\/monkey.png/, first_res["files"].first["url"])
     assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
-    assert_equal first_res.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on", "files"), {"expire_after_views" => 5,
+    assert_equal first_res.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on", "files"), {
+      "expire_after_views" => 5,
       "expired" => false,
       "deletable_by_viewer" => true,
       "retrieval_step" => false,
@@ -68,7 +69,8 @@ class FilePushJsonActiveTest < ActionDispatch::IntegrationTest
       "views_remaining" => 5,
       "deleted" => false,
       "note" => "This is a test file push",
-      "name" => "Test File Push"}
+      "name" => "Test File Push"
+    }
 
     # These should be default values since we didn't specify them in the params
     assert_equal Settings.pw.deletable_pushes_default, first_res["deletable_by_viewer"]

--- a/test/integration/file_push/file_push_json_active_test.rb
+++ b/test/integration/file_push/file_push_json_active_test.rb
@@ -69,16 +69,5 @@ class FilePushJsonActiveTest < ActionDispatch::IntegrationTest
       "note" => "This is a test file push",
       "name" => "Test File Push"
     }
-
-    # These should be default values since we didn't specify them in the params
-    assert_equal Settings.pw.deletable_pushes_default, push["deletable_by_viewer"]
-    assert push.key?("days_remaining")
-    assert_equal Settings.pw.expire_after_days_default, push["days_remaining"]
-    assert push.key?("views_remaining")
-    assert_equal Settings.pw.expire_after_views_default, push["views_remaining"]
-    assert push.key?("expire_after_days")
-    assert_equal Settings.pw.expire_after_days_default, push["expire_after_days"]
-    assert push.key?("expire_after_views")
-    assert_equal Settings.pw.expire_after_views_default, push["expire_after_views"]
   end
 end

--- a/test/integration/file_push/file_push_json_active_test.rb
+++ b/test/integration/file_push/file_push_json_active_test.rb
@@ -33,32 +33,30 @@ class FilePushJsonActiveTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     res = JSON.parse(@response.body)
-    first_res = res.first
-    assert_not first_res.key?("payload")
-    assert first_res.key?("url_token")
-    assert first_res.key?("name")
-    assert_equal "Test File Push", first_res["name"]
-    assert first_res.key?("note")
-    assert_equal "This is a test file push", first_res["note"]
-    assert first_res.key?("expired")
-    assert_equal false, first_res["expired"]
-    assert first_res.key?("expired_on")
-    assert first_res.key?("deleted")
-    assert_equal false, first_res["deleted"]
-    assert first_res.key?("deletable_by_viewer")
-    assert_equal true, first_res["deletable_by_viewer"]
-    assert first_res.key?("files")
-    assert_equal 1, first_res["files"].count
-    # p first_res["files"]
-    # => [{"filename" => "monkey.png", "content_type" => "image/png", "url" => "http://www.example.com/pfb/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MSwiZXhwIjoiMjAyNS0wNy0wMlQyMToyODoyNi43MzhaIiwicHVyIjoiYmxvYl9pZCJ9fQ==--98a8c59aa58c4c6a943c4eb27cec92c2c04434fd/monkey.png"}]
-    assert_equal true, first_res["files"].first.key?("filename")
-    assert_equal "monkey.png", first_res["files"].first["filename"]
-    assert_equal true, first_res["files"].first.key?("content_type")
-    assert_equal "image/png", first_res["files"].first["content_type"]
-    assert_equal true, first_res["files"].first.key?("url")
-    assert_match(/\/pfb\/blobs\/redirect\/.*\/monkey.png/, first_res["files"].first["url"])
-    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
-    assert_equal first_res.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on", "files"), {
+    push = res.first
+    assert_not push.key?("payload")
+    assert push.key?("url_token")
+    assert push.key?("name")
+    assert_equal "Test File Push", push["name"]
+    assert push.key?("note")
+    assert_equal "This is a test file push", push["note"]
+    assert push.key?("expired")
+    assert_equal false, push["expired"]
+    assert push.key?("expired_on")
+    assert push.key?("deleted")
+    assert_equal false, push["deleted"]
+    assert push.key?("deletable_by_viewer")
+    assert_equal true, push["deletable_by_viewer"]
+    assert push.key?("files")
+    assert_equal 1, push["files"].count
+    assert_equal true, push["files"].first.key?("filename")
+    assert_equal "monkey.png", push["files"].first["filename"]
+    assert_equal true, push["files"].first.key?("content_type")
+    assert_equal "image/png", push["files"].first["content_type"]
+    assert_equal true, push["files"].first.key?("url")
+    assert_match(/\/pfb\/blobs\/redirect\/.*\/monkey.png/, push["files"].first["url"])
+    assert_equal push.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal push.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on", "files"), {
       "expire_after_views" => 5,
       "expired" => false,
       "deletable_by_viewer" => true,
@@ -73,14 +71,14 @@ class FilePushJsonActiveTest < ActionDispatch::IntegrationTest
     }
 
     # These should be default values since we didn't specify them in the params
-    assert_equal Settings.pw.deletable_pushes_default, first_res["deletable_by_viewer"]
-    assert first_res.key?("days_remaining")
-    assert_equal Settings.pw.expire_after_days_default, first_res["days_remaining"]
-    assert first_res.key?("views_remaining")
-    assert_equal Settings.pw.expire_after_views_default, first_res["views_remaining"]
-    assert first_res.key?("expire_after_days")
-    assert_equal Settings.pw.expire_after_days_default, first_res["expire_after_days"]
-    assert first_res.key?("expire_after_views")
-    assert_equal Settings.pw.expire_after_views_default, first_res["expire_after_views"]
+    assert_equal Settings.pw.deletable_pushes_default, push["deletable_by_viewer"]
+    assert push.key?("days_remaining")
+    assert_equal Settings.pw.expire_after_days_default, push["days_remaining"]
+    assert push.key?("views_remaining")
+    assert_equal Settings.pw.expire_after_views_default, push["views_remaining"]
+    assert push.key?("expire_after_days")
+    assert_equal Settings.pw.expire_after_days_default, push["expire_after_days"]
+    assert push.key?("expire_after_views")
+    assert_equal Settings.pw.expire_after_views_default, push["expire_after_views"]
   end
 end

--- a/test/integration/file_push/file_push_json_active_test.rb
+++ b/test/integration/file_push/file_push_json_active_test.rb
@@ -47,16 +47,8 @@ class FilePushJsonActiveTest < ActionDispatch::IntegrationTest
     assert_equal false, push["deleted"]
     assert push.key?("deletable_by_viewer")
     assert_equal true, push["deletable_by_viewer"]
-    assert push.key?("files")
-    assert_equal 1, push["files"].count
-    assert_equal true, push["files"].first.key?("filename")
-    assert_equal "monkey.png", push["files"].first["filename"]
-    assert_equal true, push["files"].first.key?("content_type")
-    assert_equal "image/png", push["files"].first["content_type"]
-    assert_equal true, push["files"].first.key?("url")
-    assert_match(/\/pfb\/blobs\/redirect\/.*\/monkey.png/, push["files"].first["url"])
-    assert_equal push.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
-    assert_equal push.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on", "files"), {
+    assert_equal push.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal push.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on"), {
       "expire_after_views" => 5,
       "expired" => false,
       "deletable_by_viewer" => true,

--- a/test/integration/file_push/file_push_json_expired_test.rb
+++ b/test/integration/file_push/file_push_json_expired_test.rb
@@ -66,16 +66,5 @@ class FilePushJsonExpiredTest < ActionDispatch::IntegrationTest
       "name" => "Test File Push",
       "files" => []
     }
-
-    # These should be default values since we didn't specify them in the params
-    assert_equal Settings.pw.deletable_pushes_default, push["deletable_by_viewer"]
-    assert push.key?("days_remaining")
-    assert_equal Settings.pw.expire_after_days_default, push["days_remaining"]
-    assert push.key?("views_remaining")
-    assert_equal Settings.pw.expire_after_views_default, push["views_remaining"]
-    assert push.key?("expire_after_days")
-    assert_equal Settings.pw.expire_after_days_default, push["expire_after_days"]
-    assert push.key?("expire_after_views")
-    assert_equal Settings.pw.expire_after_views_default, push["expire_after_views"]
   end
 end

--- a/test/integration/file_push/file_push_json_expired_test.rb
+++ b/test/integration/file_push/file_push_json_expired_test.rb
@@ -38,7 +38,7 @@ class FilePushJsonExpiredTest < ActionDispatch::IntegrationTest
 
     res = JSON.parse(@response.body)
     push = res.first
-    assert push.key?("payload") == false # No payload on create response
+    assert_not push.key?("payload")
     assert push.key?("url_token")
     assert push.key?("name")
     assert_equal "Test File Push", push["name"]

--- a/test/integration/file_push/file_push_json_expired_test.rb
+++ b/test/integration/file_push/file_push_json_expired_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FilePushJsonExpiredTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Settings.enable_file_pushes = true
+    Rails.application.reload_routes!
+
+    @luca = users(:luca)
+    @luca.confirm
+  end
+
+  def test_basic_json_expired
+    post file_pushes_path(format: :json),
+      params: {
+        file_push: {
+          payload: "Message",
+          name: "Test File Push",
+          note: "This is a test file push",
+          files: [
+            fixture_file_upload("monkey.png", "image/jpeg")
+          ]
+        }
+      },
+      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    delete "/f/#{res["url_token"]}.json"
+    assert_response :success
+
+    get expired_file_pushes_path(format: :json), headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    first_res = res.first
+    assert first_res.key?("payload") == false # No payload on create response
+    assert first_res.key?("url_token")
+    assert first_res.key?("name")
+    assert_equal "Test File Push", first_res["name"]
+    assert first_res.key?("note")
+    assert_equal "This is a test file push", first_res["note"]
+    assert first_res.key?("expired")
+    assert_equal true, first_res["expired"]
+    assert first_res.key?("expired_on")
+    assert first_res.key?("deleted")
+    assert_equal true, first_res["deleted"]
+    assert first_res.key?("deletable_by_viewer")
+    assert_equal true, first_res["deletable_by_viewer"]
+    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "name", "note", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal first_res.except("url_token", "created_at", "updated_at", "expired_on"), {
+      "expire_after_days" => 7,
+      "expire_after_views" => 5,
+      "expired" => true,
+      "deleted" => true,
+      "deletable_by_viewer" => true,
+      "retrieval_step" => false,
+      "name" => "Test File Push",
+      "note" => "This is a test file push",
+      "days_remaining" => 7,
+      "views_remaining" => 5,
+      "files" => "{}"
+    }
+
+    # These should be default values since we didn't specify them in the params
+    assert_equal Settings.pw.deletable_pushes_default, first_res["deletable_by_viewer"]
+    assert first_res.key?("days_remaining")
+    assert_equal Settings.pw.expire_after_days_default, first_res["days_remaining"]
+    assert first_res.key?("views_remaining")
+    assert_equal Settings.pw.expire_after_views_default, first_res["views_remaining"]
+    assert first_res.key?("expire_after_days")
+    assert_equal Settings.pw.expire_after_days_default, first_res["expire_after_days"]
+    assert first_res.key?("expire_after_views")
+    assert_equal Settings.pw.expire_after_views_default, first_res["expire_after_views"]
+  end
+end

--- a/test/integration/file_push/file_push_json_expired_test.rb
+++ b/test/integration/file_push/file_push_json_expired_test.rb
@@ -51,7 +51,7 @@ class FilePushJsonExpiredTest < ActionDispatch::IntegrationTest
     assert_equal true, push["deleted"]
     assert push.key?("deletable_by_viewer")
     assert_equal true, push["deletable_by_viewer"]
-    assert_equal push.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal push.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
     assert_equal push.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on"), {
       "expire_after_views" => 5,
       "expired" => true,
@@ -63,8 +63,7 @@ class FilePushJsonExpiredTest < ActionDispatch::IntegrationTest
       "views_remaining" => 5,
       "deleted" => true,
       "note" => "This is a test file push",
-      "name" => "Test File Push",
-      "files" => []
+      "name" => "Test File Push"
     }
   end
 end

--- a/test/integration/file_push/file_push_json_expired_test.rb
+++ b/test/integration/file_push/file_push_json_expired_test.rb
@@ -51,19 +51,20 @@ class FilePushJsonExpiredTest < ActionDispatch::IntegrationTest
     assert_equal true, first_res["deleted"]
     assert first_res.key?("deletable_by_viewer")
     assert_equal true, first_res["deletable_by_viewer"]
-    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "name", "note", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
-    assert_equal first_res.except("url_token", "created_at", "updated_at", "expired_on"), {
-      "expire_after_days" => 7,
+    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal first_res.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on"), {
       "expire_after_views" => 5,
       "expired" => true,
-      "deleted" => true,
       "deletable_by_viewer" => true,
       "retrieval_step" => false,
-      "name" => "Test File Push",
-      "note" => "This is a test file push",
+      "passphrase" => nil,
+      "expire_after_days" => 7,
       "days_remaining" => 7,
       "views_remaining" => 5,
-      "files" => "{}"
+      "deleted" => true,
+      "note" => "This is a test file push",
+      "name" => "Test File Push",
+      "files" => []
     }
 
     # These should be default values since we didn't specify them in the params

--- a/test/integration/file_push/file_push_json_expired_test.rb
+++ b/test/integration/file_push/file_push_json_expired_test.rb
@@ -37,22 +37,22 @@ class FilePushJsonExpiredTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     res = JSON.parse(@response.body)
-    first_res = res.first
-    assert first_res.key?("payload") == false # No payload on create response
-    assert first_res.key?("url_token")
-    assert first_res.key?("name")
-    assert_equal "Test File Push", first_res["name"]
-    assert first_res.key?("note")
-    assert_equal "This is a test file push", first_res["note"]
-    assert first_res.key?("expired")
-    assert_equal true, first_res["expired"]
-    assert first_res.key?("expired_on")
-    assert first_res.key?("deleted")
-    assert_equal true, first_res["deleted"]
-    assert first_res.key?("deletable_by_viewer")
-    assert_equal true, first_res["deletable_by_viewer"]
-    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
-    assert_equal first_res.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on"), {
+    push = res.first
+    assert push.key?("payload") == false # No payload on create response
+    assert push.key?("url_token")
+    assert push.key?("name")
+    assert_equal "Test File Push", push["name"]
+    assert push.key?("note")
+    assert_equal "This is a test file push", push["note"]
+    assert push.key?("expired")
+    assert_equal true, push["expired"]
+    assert push.key?("expired_on")
+    assert push.key?("deleted")
+    assert_equal true, push["deleted"]
+    assert push.key?("deletable_by_viewer")
+    assert_equal true, push["deletable_by_viewer"]
+    assert_equal push.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "files", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal push.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on"), {
       "expire_after_views" => 5,
       "expired" => true,
       "deletable_by_viewer" => true,
@@ -68,14 +68,14 @@ class FilePushJsonExpiredTest < ActionDispatch::IntegrationTest
     }
 
     # These should be default values since we didn't specify them in the params
-    assert_equal Settings.pw.deletable_pushes_default, first_res["deletable_by_viewer"]
-    assert first_res.key?("days_remaining")
-    assert_equal Settings.pw.expire_after_days_default, first_res["days_remaining"]
-    assert first_res.key?("views_remaining")
-    assert_equal Settings.pw.expire_after_views_default, first_res["views_remaining"]
-    assert first_res.key?("expire_after_days")
-    assert_equal Settings.pw.expire_after_days_default, first_res["expire_after_days"]
-    assert first_res.key?("expire_after_views")
-    assert_equal Settings.pw.expire_after_views_default, first_res["expire_after_views"]
+    assert_equal Settings.pw.deletable_pushes_default, push["deletable_by_viewer"]
+    assert push.key?("days_remaining")
+    assert_equal Settings.pw.expire_after_days_default, push["days_remaining"]
+    assert push.key?("views_remaining")
+    assert_equal Settings.pw.expire_after_views_default, push["views_remaining"]
+    assert push.key?("expire_after_days")
+    assert_equal Settings.pw.expire_after_days_default, push["expire_after_days"]
+    assert push.key?("expire_after_views")
+    assert_equal Settings.pw.expire_after_views_default, push["expire_after_views"]
   end
 end

--- a/test/integration/password/password_json_active_test.rb
+++ b/test/integration/password/password_json_active_test.rb
@@ -50,16 +50,5 @@ class PasswordJsonExpiredTest < ActionDispatch::IntegrationTest
       "note" => "This is a test password",
       "name" => "Test Password"
     }
-
-    # These should be default values since we didn't specify them in the params
-    assert_equal Settings.pw.deletable_pushes_default, first_res["deletable_by_viewer"]
-    assert first_res.key?("days_remaining")
-    assert_equal Settings.pw.expire_after_days_default, first_res["days_remaining"]
-    assert first_res.key?("views_remaining")
-    assert_equal Settings.pw.expire_after_views_default, first_res["views_remaining"]
-    assert first_res.key?("expire_after_days")
-    assert_equal Settings.pw.expire_after_days_default, first_res["expire_after_days"]
-    assert first_res.key?("expire_after_views")
-    assert_equal Settings.pw.expire_after_views_default, first_res["expire_after_views"]
   end
 end

--- a/test/integration/password/password_json_active_test.rb
+++ b/test/integration/password/password_json_active_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PasswordJsonExpiredTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Rails.application.reload_routes!
+
+    @luca = users(:luca)
+    @luca.confirm
+  end
+
+  def test_basic_json_expired
+    post passwords_path(format: :json),
+      params: {password: {payload: "testpw", name: "Test Password", note: "This is a test password"}},
+      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+
+    get active_passwords_path(format: :json), headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    first_res = res.first
+    assert_not first_res.key?("payload")
+    assert first_res.key?("url_token")
+    assert first_res.key?("name")
+    assert_equal "Test Password", first_res["name"]
+    assert first_res.key?("note")
+    assert_equal "This is a test password", first_res["note"]
+    assert first_res.key?("expired")
+    assert_equal false, first_res["expired"]
+    assert first_res.key?("expired_on")
+    assert first_res.key?("deleted")
+    assert_equal false, first_res["deleted"]
+    assert first_res.key?("deletable_by_viewer")
+    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "name", "note", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal first_res.except("url_token", "created_at", "updated_at", "expired_on"), {"expire_after_views" => 5,
+      "expired" => false,
+      "deletable_by_viewer" => true,
+      "retrieval_step" => false,
+      "expire_after_days" => 7,
+      "days_remaining" => 7,
+      "views_remaining" => 5,
+      "deleted" => false,
+      "note" => "This is a test password",
+      "name" => "Test Password"}
+
+    # These should be default values since we didn't specify them in the params
+    assert_equal Settings.pw.deletable_pushes_default, first_res["deletable_by_viewer"]
+    assert first_res.key?("days_remaining")
+    assert_equal Settings.pw.expire_after_days_default, first_res["days_remaining"]
+    assert first_res.key?("views_remaining")
+    assert_equal Settings.pw.expire_after_views_default, first_res["views_remaining"]
+    assert first_res.key?("expire_after_days")
+    assert_equal Settings.pw.expire_after_days_default, first_res["expire_after_days"]
+    assert first_res.key?("expire_after_views")
+    assert_equal Settings.pw.expire_after_views_default, first_res["expire_after_views"]
+  end
+end

--- a/test/integration/password/password_json_active_test.rb
+++ b/test/integration/password/password_json_active_test.rb
@@ -37,7 +37,8 @@ class PasswordJsonExpiredTest < ActionDispatch::IntegrationTest
     assert_equal false, first_res["deleted"]
     assert first_res.key?("deletable_by_viewer")
     assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
-    assert_equal first_res.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on"), {"expire_after_views" => 5,
+    assert_equal first_res.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on"), {
+      "expire_after_views" => 5,
       "expired" => false,
       "deletable_by_viewer" => true,
       "retrieval_step" => false,
@@ -47,7 +48,8 @@ class PasswordJsonExpiredTest < ActionDispatch::IntegrationTest
       "views_remaining" => 5,
       "deleted" => false,
       "note" => "This is a test password",
-      "name" => "Test Password"}
+      "name" => "Test Password"
+    }
 
     # These should be default values since we didn't specify them in the params
     assert_equal Settings.pw.deletable_pushes_default, first_res["deletable_by_viewer"]

--- a/test/integration/password/password_json_active_test.rb
+++ b/test/integration/password/password_json_active_test.rb
@@ -36,11 +36,12 @@ class PasswordJsonExpiredTest < ActionDispatch::IntegrationTest
     assert first_res.key?("deleted")
     assert_equal false, first_res["deleted"]
     assert first_res.key?("deletable_by_viewer")
-    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "name", "note", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
-    assert_equal first_res.except("url_token", "created_at", "updated_at", "expired_on"), {"expire_after_views" => 5,
+    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal first_res.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on"), {"expire_after_views" => 5,
       "expired" => false,
       "deletable_by_viewer" => true,
       "retrieval_step" => false,
+      "passphrase" => "",
       "expire_after_days" => 7,
       "days_remaining" => 7,
       "views_remaining" => 5,

--- a/test/integration/password/password_json_expired_test.rb
+++ b/test/integration/password/password_json_expired_test.rb
@@ -20,6 +20,7 @@ class PasswordJsonExpiredTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     res = JSON.parse(@response.body)
+    # Delete the new password via json e.g. /p/<url_token>.json
     delete "/p/#{res["url_token"]}.json"
     assert_response :success
 
@@ -40,12 +41,13 @@ class PasswordJsonExpiredTest < ActionDispatch::IntegrationTest
     assert first_res.key?("deleted")
     assert_equal true, first_res["deleted"]
     assert first_res.key?("deletable_by_viewer")
-    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "name", "note", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
-    assert_equal first_res.except("url_token", "created_at", "updated_at", "expired_on"), {
+    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "html_url", "json_url", "name", "note", "passphrase", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal first_res.except("url_token", "created_at", "updated_at", "html_url", "json_url", "expired_on"), {
       "expire_after_views" => 5,
       "expired" => true,
       "deletable_by_viewer" => true,
       "retrieval_step" => false,
+      "passphrase" => nil,
       "expire_after_days" => 7,
       "days_remaining" => 7,
       "views_remaining" => 5,

--- a/test/integration/password/password_json_expired_test.rb
+++ b/test/integration/password/password_json_expired_test.rb
@@ -55,16 +55,5 @@ class PasswordJsonExpiredTest < ActionDispatch::IntegrationTest
       "note" => "This is a test password",
       "name" => "Test Password"
     }
-
-    # These should be default values since we didn't specify them in the params
-    assert_equal Settings.pw.deletable_pushes_default, first_res["deletable_by_viewer"]
-    assert first_res.key?("days_remaining")
-    assert_equal Settings.pw.expire_after_days_default, first_res["days_remaining"]
-    assert first_res.key?("views_remaining")
-    assert_equal Settings.pw.expire_after_views_default, first_res["views_remaining"]
-    assert first_res.key?("expire_after_days")
-    assert_equal Settings.pw.expire_after_days_default, first_res["expire_after_days"]
-    assert first_res.key?("expire_after_views")
-    assert_equal Settings.pw.expire_after_views_default, first_res["expire_after_views"]
   end
 end

--- a/test/integration/password/password_json_expired_test.rb
+++ b/test/integration/password/password_json_expired_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PasswordJsonExpiredTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Settings.enable_logins = true
+    Rails.application.reload_routes!
+
+    @luca = users(:luca)
+    @luca.confirm
+  end
+
+  def test_basic_json_expired
+    post passwords_path(format: :json),
+      params: {password: {payload: "testpw", name: "Test Password", note: "This is a test password"}},
+      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    delete "/p/#{res["url_token"]}.json"
+    assert_response :success
+
+    get expired_passwords_path(format: :json), headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    first_res = res.first
+    assert_not first_res.key?("payload")
+    assert first_res.key?("url_token")
+    assert first_res.key?("name")
+    assert_equal "Test Password", first_res["name"]
+    assert first_res.key?("note")
+    assert_equal "This is a test password", first_res["note"]
+    assert first_res.key?("expired")
+    assert_equal true, first_res["expired"]
+    assert first_res.key?("expired_on")
+    assert first_res.key?("deleted")
+    assert_equal true, first_res["deleted"]
+    assert first_res.key?("deletable_by_viewer")
+    assert_equal first_res.keys.sort, ["created_at", "days_remaining", "deletable_by_viewer", "deleted", "expire_after_days", "expire_after_views", "expired", "expired_on", "name", "note", "retrieval_step", "updated_at", "url_token", "views_remaining"].sort
+    assert_equal first_res.except("url_token", "created_at", "updated_at", "expired_on"), {
+      "expire_after_views" => 5,
+      "expired" => true,
+      "deletable_by_viewer" => true,
+      "retrieval_step" => false,
+      "expire_after_days" => 7,
+      "days_remaining" => 7,
+      "views_remaining" => 5,
+      "deleted" => true,
+      "note" => "This is a test password",
+      "name" => "Test Password"
+    }
+
+    # These should be default values since we didn't specify them in the params
+    assert_equal Settings.pw.deletable_pushes_default, first_res["deletable_by_viewer"]
+    assert first_res.key?("days_remaining")
+    assert_equal Settings.pw.expire_after_days_default, first_res["days_remaining"]
+    assert first_res.key?("views_remaining")
+    assert_equal Settings.pw.expire_after_views_default, first_res["views_remaining"]
+    assert first_res.key?("expire_after_days")
+    assert_equal Settings.pw.expire_after_days_default, first_res["expire_after_days"]
+    assert first_res.key?("expire_after_views")
+    assert_equal Settings.pw.expire_after_views_default, first_res["expire_after_views"]
+  end
+end


### PR DESCRIPTION
## Description

#3395 API responses are updated. But, `note` and `name` fields are removed from API responses of `active` and `expired` pushes mistakenly. So, it is updated to return these fields in these responses.

## Related Issue

#3508

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
 -- No need to document