### PR TITLE
Fix a raw SQL for MySQL2

### DIFF
--- a/db/migrate/20250606094103_drop_legacy_models.rb
+++ b/db/migrate/20250606094103_drop_legacy_models.rb
@@ -2,12 +2,12 @@ class DropLegacyModels < ActiveRecord::Migration[7.2]
   def up
     # Check if data migration is complete
     if DataMigrationStatus.find_by(name: "push_model_migration")&.completed? ||
-        ActiveRecord::Base.connection.execute(<<-SQL).first["total_count"]&.to_i == 0
+        ActiveRecord::Base.connection.select_value(<<-SQL) == 0
          SELECT (
            (SELECT COUNT(*) FROM passwords) +
            (SELECT COUNT(*) FROM urls) +
            (SELECT COUNT(*) FROM file_pushes)
-         ) as total_count
+         )
         SQL
       drop_table :passwords, force: :cascade
       drop_table :urls, force: :cascade


### PR DESCRIPTION
## Description

```
ActiveRecord::Base.connection.execute(<<-SQL).first
   SELECT (
     (SELECT COUNT(*) FROM passwords) +
     (SELECT COUNT(*) FROM urls) +
     (SELECT COUNT(*) FROM file_pushes)
   ) as total_count
SQL
```
is returning `[0]` for MySQL2 and  `{"total_count" => 0}` for SQLite3 and PostgreSQL. So, it is causing an error.

It is fixed to return `0`;
```
ActiveRecord::Base.connection.select_value(<<-SQL)
     SELECT (
       (SELECT COUNT(*) FROM passwords) +
       (SELECT COUNT(*) FROM urls) +
       (SELECT COUNT(*) FROM file_pushes)
     )
SQL
```

What is the problem?

[SQLite2 returns result of high-level queries in a hash](https://github.com/brianmario/mysql2/tree/441b104f8f120788e86086702d96963aecec3172?tab=readme-ov-file#array-of-hashes). So, it doesn't cause any issue when working with ActiveRecord. But, the result of lower-level `#execute` method is returned in an array. 

## Related Issue

#3458 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
 -- Tested manually
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
 -- No need to document
