### PR TITLE
Fix: use expiration_count variable

### DIFF
--- a/app/jobs/expire_pushes_job.rb
+++ b/app/jobs/expire_pushes_job.rb
@@ -22,7 +22,7 @@ class ExpirePushesJob < ApplicationJob
     logger.info("  -> Finished validating #{counter} unexpired pushes.  #{expiration_count} total pushes expired...")
 
     # Log results
-    logger.info("  -> #{self.class.name}: #{counter} anonymous and expired pushes have been deleted.")
+    logger.info("  -> #{self.class.name}: #{expiration_count} anonymous and expired pushes have been deleted.")
 
     # Log completion
     logger.info("  -> #{self.class.name}: Finished.")


### PR DESCRIPTION
## Description

Fixed log message of ExpirePushesJob Job regarding the number of deleted pushes.

## Related Issue

Fixes https://github.com/pglombardo/PasswordPusher/issues/3644

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
