### PR TITLE
Drop arm64 platform for containers

### DIFF
--- a/.github/workflows/docker-containers.yml
+++ b/.github/workflows/docker-containers.yml
@@ -117,7 +117,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./containers/docker/Dockerfile.public-gateway
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -171,7 +171,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./containers/docker/Dockerfile.worker
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -181,4 +181,3 @@ jobs:
           cache-to: |
             type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-worker:buildcache,mode=max,ignore-error=${{env.DOCKER_PUSH == 'false'}}
             type=gha,mode=max
-


### PR DESCRIPTION
## Description

If this affects you, please let us know.  Removing the `arm64` platform from containers as it increases container build time up to an hour.


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
