### PR TITLE
Make SECRET_KEY_BASE dynamic at boot with instructions

### DIFF
--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -55,30 +55,25 @@ COPY ./ ${APP_ROOT}/
 # Build assets - this layer will be rebuilt when source code changes
 RUN yarn build
 
-# Set default secret_key_base
-# For those self-hosting this app, you should
-# generate your own secret_key_base and set it
-# in your environment.
-# 1. Generate a secret_key_base value with:
+# SECRET_KEY_BASE must be set at runtime via environment variable
+# Do NOT hardcode secrets in Docker images for security reasons.
+# Users should generate their own secret_key_base:
 #    bundle exec rails secret
-# 2. Set the secret_key_base in your environment:
-#    SECRET_KEY_BASE=<value>
-ENV SECRET_KEY_BASE=783ff1544b9612d8bceb8e26a0bab0cf22543eec658a498e7ef9e1d617976f960092005c8a54cb588759dc6dd8fd054bc4eca4a94dd7b96c6efda4a14a01bfbd
+# Then set it when running the container:
+#    docker run -e SECRET_KEY_BASE=<your-secret> ...
 
 # Precompile bootsnap cache only for amd64 architecture
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-      bundle exec bootsnap precompile --gemfile && \
-      bundle exec bootsnap precompile app/ lib/ ; \
+      SECRET_KEY_BASE_DUMMY=1 bundle exec bootsnap precompile --gemfile && \
+      SECRET_KEY_BASE_DUMMY=1 bundle exec bootsnap precompile app/ lib/ ; \
     else \
       echo "Skipping bootsnap precompilation for $TARGETARCH" ; \
     fi
 
 # Precompile Rails assets - this layer will be rebuilt when assets change
-RUN bundle exec rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile
 
-# Setup database and cleanup - combine operations for efficiency
-RUN bundle exec rake db:setup && \
-    rm -rf tmp/cache tmp/pids tmp/sockets app/assets/images/features
+RUN rm -rf tmp/cache tmp/pids tmp/sockets app/assets/images/features
 
 ################## Build done ##################
 
@@ -118,15 +113,8 @@ WORKDIR ${APP_ROOT}
 RUN addgroup -g "${GID}" pwpusher \
   && adduser -D -u "${UID}" -G pwpusher pwpusher
 
-# Set a default secret_key_base
-# For those self-hosting this app, you should
-# generate your own secret_key_base and set it
-# in your environment.
-# 1. Generate a secret_key_base value with:
-#    bundle exec rails secret
-# 2. Set the secret_key_base in your environment:
-#    SECRET_KEY_BASE=<value>
-ENV SECRET_KEY_BASE=783ff1544b9612d8bceb8e26a0bab0cf22543eeca58a498e7ef9e1d617976f960092005c8a54cb588759dc6dd8fd054bc4eca4a94dd7b96c6efda4a14a01bfbd
+# SECRET_KEY_BASE must be set at runtime via environment variable
+# The entrypoint script will validate or generate one if missing
 
 # Copy application from build stage
 COPY --from=build-env --chown=pwpusher:pwpusher ${APP_ROOT} ${APP_ROOT}


### PR DESCRIPTION
## Description

`SECRET_KEY_BASE` is an environment variable that is used to sign login session cookies.  This is part of the login security and session management.

Every installation should have their own custom `SECRET_KEY_BASE` value.

With this PR, on container boot, if the `SECRET_KEY_BASE` isn't set, a new valuel be automatically generated.  This works nicely but if you restart the container, all users currently logged in will be logged out and will have to log in again.

This is acceptable to some but if you want to maintain user login sessions across container restarts (or upgrades), set the `SECRET_KEY_BASE` in your environment.

If `SECRET_KEY_BASE` isn't set in the environment, it now outputs a message with instructions on how to generate a valid value for this environment variable:

<img width="1026" height="278" alt="Screenshot 2025-11-28 at 16 55 26" src="https://github.com/user-attachments/assets/6e373193-e90d-403b-92c0-6dda753e9acc" />


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
