### PR TITLE
Updates to fix deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,9 +78,11 @@ gem "json", "~> 2.18" # Legacy carry-over
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
-gem "apipie-rails"
+# https://github.com/Apipie/apipie-rails/pull/964
+gem "apipie-rails", github: "Apipie/apipie-rails", branch: "copilot/fix-router-deprecation-warning"
+
 gem "config"
-gem "devise", ">= 4.9.0"
+gem "devise", github: "heartcombo/devise", branch: "main"
 gem "foreman"
 gem "lograge"
 gem "mail_form", ">= 1.9.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,25 @@
 GIT
+  remote: https://github.com/Apipie/apipie-rails.git
+  revision: b7db02124cf0f33e318f5cb799ff974e55a58163
+  branch: copilot/fix-router-deprecation-warning
+  specs:
+    apipie-rails (1.6.0)
+      actionpack (>= 7.0)
+      activesupport (>= 7.0)
+
+GIT
+  remote: https://github.com/heartcombo/devise.git
+  revision: c8a64b549c8b37e494eaca7be2def136a7e1b236
+  branch: main
+  specs:
+    devise (5.0.0.beta)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 6.0.0)
+      responders
+      warden (~> 1.2.3)
+
+GIT
   remote: https://github.com/pglombardo/version.git
   revision: c3121678c8e501f31420d7629dec001e23899eaf
   branch: master
@@ -85,9 +106,6 @@ GEM
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
     ansi (1.5.0)
-    apipie-rails (1.5.0)
-      actionpack (>= 5.0)
-      activesupport (>= 5.0)
     ast (2.4.3)
     aws-eventstream (1.4.0)
     aws-partitions (1.1197.0)
@@ -159,12 +177,6 @@ GEM
       reline (>= 0.3.8)
     declarative (0.0.20)
     deep_merge (1.2.2)
-    devise (4.9.4)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
-      responders
-      warden (~> 1.2.3)
     devise-i18n (1.15.0)
       devise (>= 4.9.0)
       rails-i18n
@@ -763,7 +775,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  apipie-rails
+  apipie-rails!
   aws-sdk-s3
   azure-blob (~> 0.6.0)
   bootsnap
@@ -774,7 +786,7 @@ DEPENDENCIES
   cssbundling-rails
   debase
   debug
-  devise (>= 4.9.0)
+  devise!
   devise-i18n
   dotenv (~> 3.2)
   erb_lint (~> 0.9.0)

--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -5,7 +5,7 @@ class CspReportsController < ApplicationController
   def create
     # Limit request size to prevent DoS attacks
     if request.body.size > 10.kilobytes
-      head :payload_too_large
+      head :content_too_large
       return
     end
 

--- a/test/controllers/csp_reports_controller_test.rb
+++ b/test/controllers/csp_reports_controller_test.rb
@@ -87,8 +87,7 @@ class CspReportsControllerTest < ActionDispatch::IntegrationTest
         "Content-Type" => "application/json"
       }
 
-    # Note: :payload_too_large is deprecated, but controller uses it
-    assert_response :payload_too_large
+    assert_response :content_too_large
   end
 
   test "accepts request exactly 10KB" do
@@ -108,7 +107,7 @@ class CspReportsControllerTest < ActionDispatch::IntegrationTest
       }
 
     # Should process successfully (may be close to limit but should work)
-    assert_not_equal :payload_too_large, response.status
+    assert_not_equal :content_too_large, response.status
   end
 
   test "rejects request slightly over 10KB" do
@@ -126,7 +125,7 @@ class CspReportsControllerTest < ActionDispatch::IntegrationTest
         "Content-Type" => "application/json"
       }
 
-    assert_response :payload_too_large
+    assert_response :content_too_large
   end
 
   # Test field truncation (log injection prevention)


### PR DESCRIPTION
## Description

This PR updates some gems to get rid of the annoying deprecation message:

```
DEPRECATION WARNING: get received a hash argument (:version)/(:resource)/(:method). Please use a keyword instead. Support to hash argument will be removed in Rails 8.2. (called from block in <main> at /Users/pglombardo/Projects/apnotic/pwpush/config/routes.rb:17)
```


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
