### PR TITLE
Docker: Use separated arm64 builds

### DIFF
--- a/.github/workflows/docker-containers.yml
+++ b/.github/workflows/docker-containers.yml
@@ -24,8 +24,9 @@ on:
 
 env:
   DOCKER_PUSH: true
+
 jobs:
-  pwpush-container:
+  pwpush-container-amd64:
     if: github.event.label && github.event.label.name == 'docker' || github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
@@ -38,6 +39,110 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Populate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/pwpush
+          tags: |
+            type=ref,event=pr,format=pr-{{ref}}-docker-amd64
+            type=match,pattern=stable,format=stable-amd64
+            type=schedule,pattern=nightly,format=nightly-amd64
+            type=semver,pattern={{version}},format={{version}}-amd64
+            type=semver,pattern={{major}}.{{minor}},format={{major}}.{{minor}}-amd64
+            type=semver,pattern={{major}},format={{major}}-amd64
+            type=raw,value=latest-amd64,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image (amd64)
+        uses: docker/build-push-action@v6
+        with:
+          file: ./containers/docker/Dockerfile
+          platforms: linux/amd64
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: |
+            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush:buildcache-amd64
+            type=gha
+          cache-to: |
+            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush:buildcache-amd64,mode=max,ignore-error=${{env.DOCKER_PUSH == 'false'}}
+            type=gha,mode=max
+
+      - name: Post job failure details to Campfire
+        if: failure() && github.ref == 'refs/heads/master'
+        continue-on-error: true
+        uses: shane-lamb/campfire-notify-action@v1.1.6
+        with:
+          messages_url: ${{ secrets.CAMPFIRE_MESSAGES_URL }}
+          template: job_failed
+
+  pwpush-container-arm64:
+    if: github.event.label && github.event.label.name == 'docker' || github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Populate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/pwpush
+          tags: |
+            type=ref,event=pr,format=pr-{{ref}}-docker-arm64
+            type=match,pattern=stable,format=stable-arm64
+            type=schedule,pattern=nightly,format=nightly-arm64
+            type=semver,pattern={{version}},format={{version}}-arm64
+            type=semver,pattern={{major}}.{{minor}},format={{major}}.{{minor}}-arm64
+            type=semver,pattern={{major}},format={{major}}-arm64
+            type=raw,value=latest-arm64,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          file: ./containers/docker/Dockerfile
+          platforms: linux/arm64
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: |
+            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush:buildcache-arm64
+            type=gha
+          cache-to: |
+            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush:buildcache-arm64,mode=max,ignore-error=${{env.DOCKER_PUSH == 'false'}}
+            type=gha,mode=max
+
+      - name: Post job failure details to Campfire
+        if: failure() && github.ref == 'refs/heads/master'
+        continue-on-error: true
+        uses: shane-lamb/campfire-notify-action@v1.1.6
+        with:
+          messages_url: ${{ secrets.CAMPFIRE_MESSAGES_URL }}
+          template: job_failed
+
+  pwpush-manifest:
+    if: github.event.label && github.event.label.name == 'docker' || github.event_name != 'pull_request_target'
+    needs: [pwpush-container-amd64, pwpush-container-arm64]
+    runs-on: ubuntu-latest
+    steps:
       - name: Populate Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -58,19 +163,68 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push Docker image
+      - name: Create and push manifest
+        run: |
+          # Create manifests for all tags (excluding architecture-specific ones)
+          echo "${{ steps.meta.outputs.tags }}" | grep -vE '-(amd64|arm64)$' | while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              echo "Creating manifest for $tag"
+              # Remove existing manifest if it exists, then create new one
+              docker manifest rm "$tag" 2>/dev/null || true
+              docker manifest create "$tag" \
+                --amend "${tag}-amd64" \
+                --amend "${tag}-arm64"
+              docker manifest push "$tag"
+            fi
+          done
+
+  public-gateway-container-amd64:
+    if: github.event.label && github.event.label.name == 'docker' || github.event_name != 'pull_request_target'
+    needs: pwpush-container-amd64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Populate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/pwpush-public-gateway
+          tags: |
+            type=ref,event=pr,format=pr-{{ref}}-docker-amd64
+            type=match,pattern=stable,format=stable-amd64
+            type=schedule,pattern=nightly,format=nightly-amd64
+            type=semver,pattern={{version}},format={{version}}-amd64
+            type=semver,pattern={{major}}.{{minor}},format={{major}}.{{minor}}-amd64
+            type=semver,pattern={{major}},format={{major}}-amd64
+            type=raw,value=latest-amd64,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image (amd64)
         uses: docker/build-push-action@v6
         with:
-          file: ./containers/docker/Dockerfile
+          file: ./containers/docker/Dockerfile.public-gateway
           platforms: linux/amd64
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: |
-            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush:buildcache
+            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-public-gateway:buildcache-amd64
             type=gha
           cache-to: |
-            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush:buildcache,mode=max,ignore-error=${{env.DOCKER_PUSH == 'false'}}
+            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-public-gateway:buildcache-amd64,mode=max,ignore-error=${{env.DOCKER_PUSH == 'false'}}
             type=gha,mode=max
 
       - name: Post job failure details to Campfire
@@ -81,11 +235,10 @@ jobs:
           messages_url: ${{ secrets.CAMPFIRE_MESSAGES_URL }}
           template: job_failed
 
-
-  public-gateway-container:
+  public-gateway-container-arm64:
     if: github.event.label && github.event.label.name == 'docker' || github.event_name != 'pull_request_target'
-    needs: pwpush-container
-    runs-on: ubuntu-latest
+    needs: pwpush-container-arm64
+    runs-on: ubuntu-latest-arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -93,14 +246,57 @@ jobs:
           ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:master
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Populate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/pwpush-public-gateway
+          tags: |
+            type=ref,event=pr,format=pr-{{ref}}-docker-arm64
+            type=match,pattern=stable,format=stable-arm64
+            type=schedule,pattern=nightly,format=nightly-arm64
+            type=semver,pattern={{version}},format={{version}}-arm64
+            type=semver,pattern={{major}}.{{minor}},format={{major}}.{{minor}}-arm64
+            type=semver,pattern={{major}},format={{major}}-arm64
+            type=raw,value=latest-arm64,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          file: ./containers/docker/Dockerfile.public-gateway
+          platforms: linux/arm64
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: |
+            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-public-gateway:buildcache-arm64
+            type=gha
+          cache-to: |
+            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-public-gateway:buildcache-arm64,mode=max,ignore-error=${{env.DOCKER_PUSH == 'false'}}
+            type=gha,mode=max
+
+      - name: Post job failure details to Campfire
+        if: failure() && github.ref == 'refs/heads/master'
+        continue-on-error: true
+        uses: shane-lamb/campfire-notify-action@v1.1.6
+        with:
+          messages_url: ${{ secrets.CAMPFIRE_MESSAGES_URL }}
+          template: job_failed
+
+  public-gateway-manifest:
+    if: github.event.label && github.event.label.name == 'docker' || github.event_name != 'pull_request_target'
+    needs: [public-gateway-container-amd64, public-gateway-container-arm64]
+    runs-on: ubuntu-latest
+    steps:
       - name: Populate Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -121,19 +317,68 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push Docker image
+      - name: Create and push manifest
+        run: |
+          # Create manifests for all tags (excluding architecture-specific ones)
+          echo "${{ steps.meta.outputs.tags }}" | grep -vE '-(amd64|arm64)$' | while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              echo "Creating manifest for $tag"
+              # Remove existing manifest if it exists, then create new one
+              docker manifest rm "$tag" 2>/dev/null || true
+              docker manifest create "$tag" \
+                --amend "${tag}-amd64" \
+                --amend "${tag}-arm64"
+              docker manifest push "$tag"
+            fi
+          done
+
+  worker-container-amd64:
+    if: github.event.label && github.event.label.name == 'docker' || github.event_name != 'pull_request_target'
+    needs: pwpush-container-amd64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Populate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/pwpush-worker
+          tags: |
+            type=ref,event=pr,format=pr-{{ref}}-docker-amd64
+            type=match,pattern=stable,format=stable-amd64
+            type=schedule,pattern=nightly,format=nightly-amd64
+            type=semver,pattern={{version}},format={{version}}-amd64
+            type=semver,pattern={{major}}.{{minor}},format={{major}}.{{minor}}-amd64
+            type=semver,pattern={{major}},format={{major}}-amd64
+            type=raw,value=latest-amd64,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image (amd64)
         uses: docker/build-push-action@v6
         with:
-          file: ./containers/docker/Dockerfile.public-gateway
+          file: ./containers/docker/Dockerfile.worker
           platforms: linux/amd64
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: |
-            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-public-gateway:buildcache
+            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-worker:buildcache-amd64
             type=gha
           cache-to: |
-            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-public-gateway:buildcache,mode=max,ignore-error=${{env.DOCKER_PUSH == 'false'}}
+            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-worker:buildcache-amd64,mode=max,ignore-error=${{env.DOCKER_PUSH == 'false'}}
             type=gha,mode=max
 
       - name: Post job failure details to Campfire
@@ -144,10 +389,10 @@ jobs:
           messages_url: ${{ secrets.CAMPFIRE_MESSAGES_URL }}
           template: job_failed
 
-  worker-container:
+  worker-container-arm64:
     if: github.event.label && github.event.label.name == 'docker' || github.event_name != 'pull_request_target'
-    needs: pwpush-container
-    runs-on: ubuntu-latest
+    needs: pwpush-container-arm64
+    runs-on: ubuntu-latest-arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -155,14 +400,57 @@ jobs:
           ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:master
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Populate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/pwpush-worker
+          tags: |
+            type=ref,event=pr,format=pr-{{ref}}-docker-arm64
+            type=match,pattern=stable,format=stable-arm64
+            type=schedule,pattern=nightly,format=nightly-arm64
+            type=semver,pattern={{version}},format={{version}}-arm64
+            type=semver,pattern={{major}}.{{minor}},format={{major}}.{{minor}}-arm64
+            type=semver,pattern={{major}},format={{major}}-arm64
+            type=raw,value=latest-arm64,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          file: ./containers/docker/Dockerfile.worker
+          platforms: linux/arm64
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: |
+            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-worker:buildcache-arm64
+            type=gha
+          cache-to: |
+            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-worker:buildcache-arm64,mode=max,ignore-error=${{env.DOCKER_PUSH == 'false'}}
+            type=gha,mode=max
+
+      - name: Post job failure details to Campfire
+        if: failure() && github.ref == 'refs/heads/master'
+        continue-on-error: true
+        uses: shane-lamb/campfire-notify-action@v1.1.6
+        with:
+          messages_url: ${{ secrets.CAMPFIRE_MESSAGES_URL }}
+          template: job_failed
+
+  worker-manifest:
+    if: github.event.label && github.event.label.name == 'docker' || github.event_name != 'pull_request_target'
+    needs: [worker-container-amd64, worker-container-arm64]
+    runs-on: ubuntu-latest
+    steps:
       - name: Populate Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -183,25 +471,17 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          file: ./containers/docker/Dockerfile.worker
-          platforms: linux/amd64
-          push: true
-          labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{ steps.meta.outputs.tags }}
-          cache-from: |
-            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-worker:buildcache
-            type=gha
-          cache-to: |
-            type=registry,ref=${{ secrets.DOCKER_USERNAME }}/pwpush-worker:buildcache,mode=max,ignore-error=${{env.DOCKER_PUSH == 'false'}}
-            type=gha,mode=max
-
-      - name: Post job failure details to Campfire
-        if: failure() && github.ref == 'refs/heads/master'
-        continue-on-error: true
-        uses: shane-lamb/campfire-notify-action@v1.1.6
-        with:
-          messages_url: ${{ secrets.CAMPFIRE_MESSAGES_URL }}
-          template: job_failed
+      - name: Create and push manifest
+        run: |
+          # Create manifests for all tags (excluding architecture-specific ones)
+          echo "${{ steps.meta.outputs.tags }}" | grep -vE '-(amd64|arm64)$' | while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              echo "Creating manifest for $tag"
+              # Remove existing manifest if it exists, then create new one
+              docker manifest rm "$tag" 2>/dev/null || true
+              docker manifest create "$tag" \
+                --amend "${tag}-amd64" \
+                --amend "${tag}-arm64"
+              docker manifest push "$tag"
+            fi
+          done


### PR DESCRIPTION
## Description

This PR restores the arm64 builds by instead running and building directly on arm64 architecture.

This avoids the need for QEMU and simplifes multi-arch container builds.

## Related Issue

#3877

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [X] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
