### PR TITLE
Fix header text invisible on dark themes

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <header class="d-flex flex-wrap justify-content-center py-3 mb-4 border-bottom">
-    <%= link_to root_path, class: 'd-flex align-items-center mb-3 mb-md-0 me-md-auto text-dark text-decoration-none', hreflang: locale.to_s do %>
+    <%= link_to root_path, class: 'd-flex align-items-center mb-3 mb-md-0 me-md-auto text-body-emphasis text-decoration-none', hreflang: locale.to_s do %>
       <div class='me-2'>
       <picture>
         <% if Settings.brand.nil? || Settings.brand.light_logo.nil? %>


### PR DESCRIPTION
## Summary
Replace `text-dark` with `text-body-emphasis` class on the header brand link.

## Problem
The header link uses Bootstrap's `text-dark` utility class which forces dark/black text color (rgb(33, 37, 41)). This makes the site title and tagline invisible or barely readable on dark themes like darkly, slate, cyborg, superhero, etc.

## Solution
Replace `text-dark` with `text-body-emphasis` which is theme-aware in Bootstrap 5.3+ and provides high-contrast text that adapts to any theme.

## Test plan
- [x] Tested on darkly theme - header text now visible
- [x] Tested on slate theme - header text now visible  
- [x] Tested on cyborg theme - header text now visible
- [x] Light themes still work correctly