### PR TITLE
Upgrade devise to 5.0 stable release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ gem "json", "~> 2.18" # Legacy carry-over
 gem "apipie-rails", github: "Apipie/apipie-rails", branch: "copilot/fix-router-deprecation-warning"
 
 gem "config"
-gem "devise", github: "heartcombo/devise", branch: "main"
+gem "devise", "~> 5.0"
 gem "foreman"
 gem "lograge"
 gem "mail_form", ">= 1.9.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,18 +8,6 @@ GIT
       activesupport (>= 7.0)
 
 GIT
-  remote: https://github.com/heartcombo/devise.git
-  revision: c8a64b549c8b37e494eaca7be2def136a7e1b236
-  branch: main
-  specs:
-    devise (5.0.0.beta)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 6.0.0)
-      responders
-      warden (~> 1.2.3)
-
-GIT
   remote: https://github.com/pglombardo/version.git
   revision: 7e56f1552c19a1e5ce283c7add001c2a2322e385
   branch: master
@@ -179,6 +167,12 @@ GEM
       reline (>= 0.3.8)
     declarative (0.0.20)
     deep_merge (1.2.2)
+    devise (5.0.0)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 7.0)
+      responders
+      warden (~> 1.2.3)
     devise-i18n (1.15.0)
       devise (>= 4.9.0)
       rails-i18n
@@ -792,7 +786,7 @@ DEPENDENCIES
   cssbundling-rails
   debase
   debug
-  devise!
+  devise (~> 5.0)
   devise-i18n
   dotenv (~> 3.2)
   erb_lint (~> 0.9.0)


### PR DESCRIPTION
## Summary
- Upgrades devise from GitHub main branch (5.0.0.beta) to official 5.0.0 stable release
- Now that devise 5.0 is officially released on RubyGems, we can use the standard gem reference

## Test plan
- [ ] Run `bin/ci` to verify all tests pass
- [ ] Verify authentication flows work correctly