### PR TITLE
Fix CSP: remove script unsafe-inline, move countdown to Stimulus

### DIFF
--- a/app/javascript/controllers/countdown_controller.js
+++ b/app/javascript/controllers/countdown_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["output"]
+  static values = {
+    durationMinutes: { type: Number, default: 5 },
+    expiredLabel: { type: String, default: "Expired" }
+  }
+
+  connect() {
+    this.endTime = Date.now() + this.durationMinutesValue * 60 * 1000
+    this.intervalId = setInterval(() => this.tick(), 1000)
+    this.tick()
+  }
+
+  disconnect() {
+    if (this.intervalId) clearInterval(this.intervalId)
+  }
+
+  tick() {
+    const now = Date.now()
+    const timeRemaining = this.endTime - now
+
+    if (timeRemaining < 0) {
+      clearInterval(this.intervalId)
+      this.intervalId = null
+      this.outputTarget.textContent = this.expiredLabelValue
+    } else {
+      const minutes = Math.floor((timeRemaining % (1000 * 60 * 60)) / (1000 * 60))
+      const seconds = Math.floor((timeRemaining % (1000 * 60)) / 1000)
+      const padded = seconds.toString().padStart(2, "0")
+      this.outputTarget.textContent = `${minutes}:${padded}`
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,4 +1,5 @@
 import CopyController from "./copy_controller"
+import CountdownController from "./countdown_controller"
 import FormController from "./form_controller"
 import GdprController from "./gdpr_controller"
 import KnobsController from "./knobs_controller"
@@ -10,6 +11,7 @@ import { application } from "./application"
 
 application.register("gdpr", GdprController)
 application.register("copy", CopyController)
+application.register("countdown", CountdownController)
 application.register("pwgen", PWGenController)
 application.register("form", FormController)
 application.register("knobs", KnobsController)

--- a/app/views/application/_push_expiration.html.erb
+++ b/app/views/application/_push_expiration.html.erb
@@ -1,25 +1,8 @@
 <% if push.files.attached? && Rails.application.config.active_storage.try(:service).to_s != "local" %>
-  <div class="text-muted fs-6">
-    <%= _('The file download links above will expire in:') %> <span id="countdown-timer">4:59</span>
+  <div class="text-muted fs-6" data-controller="countdown" data-countdown-expired-label-value="<%= _('Expired') %>">
+    <%= _('The file download links above will expire in:') %> <span id="countdown-timer" data-countdown-target="output">4:59</span>
     <div class="mt-2 mb-4">
       <%= _('You can refresh the page to regenerate new download links if views remain.') %>
     </div>
   </div>
-  <script>
-    var endTime = new Date().getTime() + 5 * 60 * 1000; // 5 minutes in milliseconds
-    var countdown = setInterval(function() {
-      var now = new Date().getTime();
-      var timeRemaining = endTime - now;
-
-      if (timeRemaining < 0) {
-        clearInterval(countdown);
-        document.getElementById("countdown-timer").innerHTML = "<%= _('Expired') %>";
-      } else {
-        var minutes = Math.floor((timeRemaining % (1000 * 60 * 60)) / (1000 * 60));
-        var seconds = Math.floor((timeRemaining % (1000 * 60)) / 1000);
-        seconds = seconds.toString().padStart(2, '0');
-        document.getElementById("countdown-timer").innerHTML = minutes + ":" + seconds;
-      }
-    }, 1000);
-  </script>
 <% end %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,12 +13,12 @@ Rails.application.configure do
     policy.img_src :self, :https, :http, :data, :blob
     policy.media_src :self, :https, :http, :data, :blob
     policy.object_src :none
-    policy.script_src :self, :https, :http, :unsafe_inline
+    policy.script_src :self, :https, :http
     policy.style_src :self, :https, :http, :unsafe_inline
     policy.style_src_attr :unsafe_inline
     policy.connect_src :self, :https, :http, :ws, :wss
     policy.report_uri "/csp-violation-report"
-    policy.script_src_elem :self, :https, :http, :unsafe_inline
+    policy.script_src_elem :self, :https, :http
   end
 end
 


### PR DESCRIPTION
Addresses CSP report from tools like Domsignal that flag `unsafe-inline` for scripts.

- Remove `:unsafe_inline` from `script_src` and `script_src_elem` in Content-Security-Policy
- Add Stimulus `countdown_controller.js` for file download link expiration countdown
- Replace inline script in `_push_expiration` partial with controller (only non-nonced inline script)
- GA partial already uses nonces; Plausible is external script only