### PR TITLE
use app name as helm chart name

### DIFF
--- a/containers/helm/Chart.yaml
+++ b/containers/helm/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-name: helm
+name: passwordpusher
 description: A Helm chart for Password Pusher
 
 # A chart can be either an 'application' or a 'library' chart.
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.58.0"
+appVersion: "1.68.0"
 
 maintainers:
   - name: pglombardo


### PR DESCRIPTION
## Description

just a little Change:
per specifications the name field in the chart.yaml should contain the application name (must be lower case).
this way you can run `helm package .` to create a versioned archive, which in turn can be deployed.

This was the only change I needed to push the chart to our container registry for deployment on our kubernetes cluster via argocd.

good job @minebaev 👍

## Related Issue

#3484 

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
