### PR TITLE
(helm) allow persistent volumes and usage of k8s secret

### DIFF
--- a/containers/helm/Chart.yaml
+++ b/containers/helm/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.68.0"
+appVersion: "2.0.1"
 
 maintainers:
   - name: pglombardo

--- a/containers/helm/templates/deployment.yaml
+++ b/containers/helm/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -37,6 +38,10 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
           {{- end }}
+          envFrom:
+            - secretRef:
+                name:  {{ .Values.encKeys.existingSecret }}
+                optional: true
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -47,3 +52,11 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/containers/helm/values.yaml
+++ b/containers/helm/values.yaml
@@ -13,11 +13,14 @@ labels:
 podLabels:
   app: "pwpush"
 
+encKeys:
+  existingSecret: "pwpush-keys"                # Secret containing PWPUSH_MASTER_KEY and SECRET_KEY_BASE (optional)
+
 env: {}
 # Optional env map for the pod (2.0). See repo docker-compose.yml and:
 # https://docs.pwpush.com/docs/self-hosted-configuration/
 # Common examples:
-#   PWPUSH_MASTER_KEY: ""                      # production: set via Secret; generate at /pages/generate_key
+#   PWPUSH_MASTER_KEY: ""                      # production: use Secret above; generate at /pages/generate_key
 #   SECRET_KEY_BASE: ""                        # persist sessions across restarts
 #   PWP__ALLOW_ANONYMOUS: "true"
 #   PWP__DISABLE_SIGNUPS: "false"
@@ -26,7 +29,7 @@ env: {}
 #   PWP__ENABLE_URL_PUSHES: "true"
 #   PWP__ENABLE_FILE_PUSHES: "true"
 #   PWP__ENABLE_QR_PUSHES: "true"
-#   PWP__FILES__STORAGE: "local"                # or s3 / gcs / azure per docs
+#   PWP__FILES__STORAGE: "local"               # or s3 / gcs / azure per docs
 #   PWP__LOG_TO_STDOUT: "true"
 
 livenessProbe:
@@ -66,3 +69,10 @@ ingress:
   #  - secretName: pwpush-tls
   #    hosts:
   #      - pwpush.example.com
+volumeMounts: []
+  # - name: pwpush-storage
+  #   mountPath: /opt/PasswordPusher/storage
+volumes: []
+  # - name: pwpush-storage
+  #   persistentVolumeClaim:
+  #     claimName: pwpush-storage


### PR DESCRIPTION
## Description

Secrets:
this change allows use of a kubernetes secret for Master and Secret Key. Doesn't do anything if the secret doesn't exist.

Persistent Volume:
use CSI driver for a persistent deployment, PVC should be created by hand (for now).
also doesn't do anything if not explicitly configured.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📦 Dependency & security updates
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / documentation / tutorials

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [x] I've added documentation as necessary so users can easily use and understand this feature/fix.
