### PR TITLE
Fix inconsistent error responses for invalid API v2 push creation requests

### DIFF
--- a/app/controllers/api/v2/pushes_controller.rb
+++ b/app/controllers/api/v2/pushes_controller.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 class Api::V2::PushesController < Api::V1::PushesController
+  before_action :force_json_format
+
   private
+
+  def force_json_format
+    request.format = :json
+  end
 
   def push_params
     permitted = params.require(:push).permit(:name, :kind, :expire_after_days, :expire_after_views,

--- a/test/integration/api/api_v2_pushes_test.rb
+++ b/test/integration/api/api_v2_pushes_test.rb
@@ -219,6 +219,25 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
     assert body.key?("payload")
   end
 
+  def test_create_with_valid_payload_returns_json_created_without_accept_header
+    assert_difference("Push.count", 1) do
+      post "/api/v2/pushes",
+        params: {
+          push: {
+            payload: "valid-secret-without-accept",
+            expire_after_days: 1,
+            expire_after_views: 5
+          }
+        }.to_json,
+        headers: {"Content-Type" => "application/json"}
+    end
+
+    assert_response :created
+    assert_equal "application/json; charset=utf-8", response.content_type
+    body = JSON.parse(response.body)
+    assert body["url_token"].present?
+  end
+
   def test_create_with_null_payload_returns_json_validation_error_without_accept_header
     post "/api/v2/pushes",
       params: {

--- a/test/integration/api/api_v2_pushes_test.rb
+++ b/test/integration/api/api_v2_pushes_test.rb
@@ -202,4 +202,48 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
   ensure
     Settings.allow_anonymous = true
   end
+
+  def test_create_with_missing_payload_returns_json_validation_error_without_accept_header
+    post "/api/v2/pushes",
+      params: {
+        push: {
+          expire_after_days: 1,
+          expire_after_views: 5
+        }
+      }.to_json,
+      headers: {"Content-Type" => "application/json"}
+
+    assert_response :unprocessable_content
+    assert_equal "application/json; charset=utf-8", response.content_type
+    body = JSON.parse(response.body)
+    assert body.key?("payload")
+  end
+
+  def test_create_with_null_payload_returns_json_validation_error_without_accept_header
+    post "/api/v2/pushes",
+      params: {
+        push: {
+          payload: nil,
+          expire_after_days: 1,
+          expire_after_views: 5
+        }
+      }.to_json,
+      headers: {"Content-Type" => "application/json"}
+
+    assert_response :unprocessable_content
+    assert_equal "application/json; charset=utf-8", response.content_type
+    body = JSON.parse(response.body)
+    assert body.key?("payload")
+  end
+
+  def test_create_with_missing_push_param_returns_json_bad_request_without_accept_header
+    post "/api/v2/pushes",
+      params: {}.to_json,
+      headers: {"Content-Type" => "application/json"}
+
+    assert_response :bad_request
+    assert_equal "application/json; charset=utf-8", response.content_type
+    body = JSON.parse(response.body)
+    assert body["error"].present?
+  end
 end


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

Fixes #4377

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📦 Dependency & security updates
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / documentation / tutorials

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
