### PR TITLE
Auto re-blur revealed payloads after 20 seconds

### DIFF
--- a/app/helpers/pushes_helper.rb
+++ b/app/helpers/pushes_helper.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module PushesHelper
+  PUSH_PAYLOAD_AUTO_REBLUR_SECONDS = 20
+
+  def push_payload_auto_reblur_seconds
+    PUSH_PAYLOAD_AUTO_REBLUR_SECONDS
+  end
+
   def filesize(size)
     units = %w[B KiB MiB GiB TiB Pib EiB ZiB]
 

--- a/app/javascript/spoiler_alert.js
+++ b/app/javascript/spoiler_alert.js
@@ -41,6 +41,7 @@ export function spoilerAlert(selector, opts) {
   const processElement = function(index) {
     const el = elements[index];
     el.setAttribute('data-spoiler-state', 'shrouded');
+    let reblurTimeoutId = null;
 
     el.style.webkitTransition = '-webkit-filter 250ms';
     el.style.transition = 'filter 250ms';
@@ -48,6 +49,38 @@ export function spoilerAlert(selector, opts) {
     const applyBlur = function(radius) {
       el.style.filter = 'blur('+radius+'px)';
       el.style.webkitFilter = 'blur('+radius+'px)';
+    }
+
+    const clearReblurTimer = function() {
+      if (reblurTimeoutId !== null) {
+        window.clearTimeout(reblurTimeoutId);
+        reblurTimeoutId = null;
+      }
+    }
+
+    const shroudElement = function() {
+      el.setAttribute('data-spoiler-state', 'shrouded');
+      el.title = hintText;
+      el.style.cursor = 'pointer';
+      applyBlur(maxBlur);
+      clearReblurTimer();
+    }
+
+    const parseSeconds = function(value) {
+      if (value === undefined || value === null || value === '') return null;
+      const seconds = Number(value);
+      if (!Number.isFinite(seconds) || seconds <= 0) return null;
+      return Math.round(seconds * 1000);
+    }
+
+    const resolveAutoReblurMs = function() {
+      const dataAttrMs = parseSeconds(el.getAttribute('data-spoiler-auto-reblur-seconds'));
+      if (dataAttrMs !== null) return dataAttrMs;
+
+      if (opts.autoReblurMs === undefined || opts.autoReblurMs === null) return null;
+      const optionMs = Number(opts.autoReblurMs);
+      if (!Number.isFinite(optionMs) || optionMs <= 0) return null;
+      return Math.round(optionMs);
     }
 
     applyBlur(maxBlur);
@@ -70,12 +103,18 @@ export function spoilerAlert(selector, opts) {
           el.title = '';
           el.style.cursor = 'auto';
           applyBlur(0);
+          clearReblurTimer();
+          const autoReblurMs = resolveAutoReblurMs();
+          if (autoReblurMs !== null) {
+            reblurTimeoutId = window.setTimeout(function() {
+              if (el.getAttribute('data-spoiler-state') === 'revealed') {
+                shroudElement();
+              }
+            }, autoReblurMs);
+          }
           break;
         default:
-          el.setAttribute('data-spoiler-state', 'shrouded');
-          el.title = hintText;
-          el.style.cursor = 'pointer';
-          applyBlur(maxBlur);
+          shroudElement();
       }
     })
   }

--- a/app/javascript/spoiler_alert.js
+++ b/app/javascript/spoiler_alert.js
@@ -66,7 +66,7 @@ export function spoilerAlert(selector, opts) {
       clearReblurTimer();
     }
 
-    const parseSeconds = function(value) {
+    const parseSecondsToMs = function(value) {
       if (value === undefined || value === null || value === '') return null;
       const seconds = Number(value);
       if (!Number.isFinite(seconds) || seconds <= 0) return null;
@@ -74,9 +74,13 @@ export function spoilerAlert(selector, opts) {
     }
 
     const resolveAutoReblurMs = function() {
-      const dataAttrMs = parseSeconds(el.getAttribute('data-spoiler-auto-reblur-seconds'));
+      const dataAttrMs = parseSecondsToMs(el.getAttribute('data-spoiler-auto-reblur-seconds'));
       if (dataAttrMs !== null) return dataAttrMs;
 
+      const optionSecondsMs = parseSecondsToMs(opts.autoReblurSeconds);
+      if (optionSecondsMs !== null) return optionSecondsMs;
+
+      // Backward compatibility for existing callers using milliseconds.
       if (opts.autoReblurMs === undefined || opts.autoReblurMs === null) return null;
       const optionMs = Number(opts.autoReblurMs);
       if (!Number.isFinite(optionMs) || optionMs <= 0) return null;

--- a/app/views/pushes/_show_payload.html.erb
+++ b/app/views/pushes/_show_payload.html.erb
@@ -7,7 +7,7 @@
 </div>
 
 <% if payload.chomp.match?(/\n/) || payload.length > 100 %>
-    <div class='payload <%= blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white d-flex justify-content-center' id='push_payload' translate='no' data-copy-target="payloadDiv" data-spoiler-auto-reblur-seconds="20"><pre class='text-break my-5'><%= payload %></pre></div>
+    <div class='payload <%= blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white d-flex justify-content-center' id='push_payload' translate='no' data-copy-target="payloadDiv" data-spoiler-auto-reblur-seconds="<%= push_payload_auto_reblur_seconds %>"><pre class='text-break my-5'><%= payload %></pre></div>
 <% else %>
-    <div class='payload <%= blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white fs-2' id='push_payload' translate='no' data-copy-target="payloadDiv" data-spoiler-auto-reblur-seconds="20"><pre class='w-100 text-break text-wrap my-5 text-center'><%= payload %></pre></div>
+    <div class='payload <%= blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white fs-2' id='push_payload' translate='no' data-copy-target="payloadDiv" data-spoiler-auto-reblur-seconds="<%= push_payload_auto_reblur_seconds %>"><pre class='w-100 text-break text-wrap my-5 text-center'><%= payload %></pre></div>
 <% end %>

--- a/app/views/pushes/_show_payload.html.erb
+++ b/app/views/pushes/_show_payload.html.erb
@@ -7,7 +7,7 @@
 </div>
 
 <% if payload.chomp.match?(/\n/) || payload.length > 100 %>
-    <div class='payload <%= blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white d-flex justify-content-center' id='push_payload' translate='no' data-copy-target="payloadDiv"><pre class='text-break my-5'><%= payload %></pre></div>
+    <div class='payload <%= blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white d-flex justify-content-center' id='push_payload' translate='no' data-copy-target="payloadDiv" data-spoiler-auto-reblur-seconds="20"><pre class='text-break my-5'><%= payload %></pre></div>
 <% else %>
-    <div class='payload <%= blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white fs-2' id='push_payload' translate='no' data-copy-target="payloadDiv"><pre class='w-100 text-break text-wrap my-5 text-center'><%= payload %></pre></div>
+    <div class='payload <%= blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white fs-2' id='push_payload' translate='no' data-copy-target="payloadDiv" data-spoiler-auto-reblur-seconds="20"><pre class='w-100 text-break text-wrap my-5 text-center'><%= payload %></pre></div>
 <% end %>

--- a/app/views/pushes/show.html.erb
+++ b/app/views/pushes/show.html.erb
@@ -17,9 +17,9 @@
           </div>
 
           <% if @payload.chomp.match?(/\n/) || @payload.length > 100 %>
-            <div class='payload <%= @blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white d-flex justify-content-center mb-3' id='push_payload' translate='no' data-copy-target="payloadDiv" data-spoiler-auto-reblur-seconds="20"><pre class='text-break my-5'><%= @payload %></pre></div>
+            <div class='payload <%= @blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white d-flex justify-content-center mb-3' id='push_payload' translate='no' data-copy-target="payloadDiv" data-spoiler-auto-reblur-seconds="<%= push_payload_auto_reblur_seconds %>"><pre class='text-break my-5'><%= @payload %></pre></div>
           <% else %>
-            <div class='payload <%= @blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white fs-2 mb-3' id='push_payload' translate='no' data-copy-target="payloadDiv" data-spoiler-auto-reblur-seconds="20"><pre class='w-100 text-break text-wrap my-5 text-center'><%= @payload %></pre></div>
+            <div class='payload <%= @blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white fs-2 mb-3' id='push_payload' translate='no' data-copy-target="payloadDiv" data-spoiler-auto-reblur-seconds="<%= push_payload_auto_reblur_seconds %>"><pre class='w-100 text-break text-wrap my-5 text-center'><%= @payload %></pre></div>
           <% end %>
           <%= render partial: 'shared/copy_button', cached: true %>
       <% end %>

--- a/app/views/pushes/show.html.erb
+++ b/app/views/pushes/show.html.erb
@@ -17,9 +17,9 @@
           </div>
 
           <% if @payload.chomp.match?(/\n/) || @payload.length > 100 %>
-            <div class='payload <%= @blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white d-flex justify-content-center mb-3' id='push_payload' translate='no' data-copy-target="payloadDiv"><pre class='text-break my-5'><%= @payload %></pre></div>
+            <div class='payload <%= @blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white d-flex justify-content-center mb-3' id='push_payload' translate='no' data-copy-target="payloadDiv" data-spoiler-auto-reblur-seconds="20"><pre class='text-break my-5'><%= @payload %></pre></div>
           <% else %>
-            <div class='payload <%= @blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white fs-2 mb-3' id='push_payload' translate='no' data-copy-target="payloadDiv"><pre class='w-100 text-break text-wrap my-5 text-center'><%= @payload %></pre></div>
+            <div class='payload <%= @blur_css_class %> notranslate px-5 border-top border-bottom border-5 w-100 bg-white fs-2 mb-3' id='push_payload' translate='no' data-copy-target="payloadDiv" data-spoiler-auto-reblur-seconds="20"><pre class='w-100 text-break text-wrap my-5 text-center'><%= @payload %></pre></div>
           <% end %>
           <%= render partial: 'shared/copy_button', cached: true %>
       <% end %>

--- a/test/system/push_viewing_workflows_test.rb
+++ b/test/system/push_viewing_workflows_test.rb
@@ -149,8 +149,7 @@ class PushViewingWorkflowsTest < ApplicationSystemTestCase
 
     find("#push_payload").click
     assert_selector "#push_payload[data-spoiler-state='revealed']", wait: 2
-    sleep 1
-    assert_equal "shrouded", page.evaluate_script("document.querySelector('#push_payload').getAttribute('data-spoiler-state')")
+    assert_selector "#push_payload[data-spoiler-state='shrouded']", wait: 3
   ensure
     Settings.pw.enable_blur = original_blur_setting
   end

--- a/test/system/push_viewing_workflows_test.rb
+++ b/test/system/push_viewing_workflows_test.rb
@@ -137,4 +137,21 @@ class PushViewingWorkflowsTest < ApplicationSystemTestCase
     # Should not show delete button for regular users
     assert_no_selector "button", text: /delete/i, wait: 5
   end
+
+  test "payload re-blurs automatically after reveal timeout" do
+    original_blur_setting = Settings.pw.enable_blur
+    Settings.pw.enable_blur = true
+
+    visit push_path(@push)
+
+    assert_selector "#push_payload.spoiler[data-spoiler-state='shrouded']", wait: 5
+    execute_script("document.querySelector('#push_payload').setAttribute('data-spoiler-auto-reblur-seconds', '0.2')")
+
+    find("#push_payload").click
+    assert_selector "#push_payload[data-spoiler-state='revealed']", wait: 2
+    sleep 1
+    assert_equal "shrouded", page.evaluate_script("document.querySelector('#push_payload').getAttribute('data-spoiler-state')")
+  ensure
+    Settings.pw.enable_blur = original_blur_setting
+  end
 end


### PR DESCRIPTION
## Summary
- Adds automatic re-blur support to spoiler payload elements after reveal.
- Applies a 20-second auto re-blur timeout to secret payload displays on push retrieval pages.
- Adds a system test to verify payloads return to the blurred state after timeout.

## Test plan
- [x] `bin/rails test test/system/push_viewing_workflows_test.rb`
- [x] `bin/ci`

Fixes #3229