### PR TITLE
Fix User Account menu by importing Stimulus controllers via importmap

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,6 @@
 import "@hotwired/turbo-rails"
 import "@rails/activestorage"
-import "./controllers"
+import "controllers"
 import "bootstrap"
 
 import LocalTime from "local-time"


### PR DESCRIPTION
## Summary
- Switch the application controller import from a relative path (`./controllers`) to the importmap alias (`controllers`).
- Ensure browsers load the digested controllers asset path in production/importmap builds.
- Restore User Account menu interactivity in Docker deployments affected by `/assets/controllers` 404 errors.

Fixes #4406

## Test plan
- [x] Run `bundle exec rails assets:precompile` and confirm it succeeds.
- [x] Verify importmap resolves `controllers` to `/assets/controllers/index-<digest>.js`.
- [ ] In Docker image, open app, click **User Account**, and confirm menu opens.