### PR TITLE
Fix custom.css overlays with PWP_PRECOMPILE

### DIFF
--- a/containers/docker/entrypoint.sh
+++ b/containers/docker/entrypoint.sh
@@ -72,6 +72,8 @@ echo "Password Pusher: migrating database to latest..."
 bundle exec rake db:migrate
 
 if [ -n "$PWP_PRECOMPILE" ]; then
+    echo "Password Pusher: rebuilding CSS for selected theme (custom overlays)..."
+    BUILD_CSS_SINGLE=1 yarn build:css:single
     echo "Password Pusher: precompiling assets (PWP_PRECOMPILE set)..."
     bundle exec rails assets:precompile
 fi


### PR DESCRIPTION
## Summary
- Rebuild single-theme CSS at container boot when `PWP_PRECOMPILE` is set.
- Ensure mounted `app/assets/stylesheets/custom.css` overlays are included before `assets:precompile` runs.
- Restore expected behavior reported in #4405 after the 2.5.0 CSS build policy change.

Fixes #4405

## Test plan
- [x] Validate shell syntax: `bash -n containers/docker/entrypoint.sh`
- [ ] Run container with `PWP_PRECOMPILE=true` and mounted `custom.css` to verify override renders
- [ ] Confirm startup still completes normally when `PWP_PRECOMPILE` is unset