### PR TITLE
Use Stimulus eager loading for importmap controllers

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,20 +1,4 @@
-import CopyController from "./copy_controller"
-import CountdownController from "./countdown_controller"
-import FormController from "./form_controller"
-import GdprController from "./gdpr_controller"
-import KnobsController from "./knobs_controller"
-import MultiUploadController from "./multi_upload_controller"
-import PWGenController from "./pwgen_controller"
-import PasswordsController from "./passwords_controller"
-import ThemeController from "./theme_controller"
-import { application } from "./application"
+import { application } from "controllers/application"
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
 
-application.register("gdpr", GdprController)
-application.register("copy", CopyController)
-application.register("countdown", CountdownController)
-application.register("pwgen", PWGenController)
-application.register("form", FormController)
-application.register("knobs", KnobsController)
-application.register("passwords", PasswordsController)
-application.register("multi-upload", MultiUploadController)
-application.register("theme", ThemeController)
+eagerLoadControllersFrom("controllers", application)


### PR DESCRIPTION
## Summary
- Replace manual controller imports/registration with `eagerLoadControllersFrom("controllers", application)` in OSS.
- Ensure controller modules resolve through importmap mappings and digested asset URLs in production.
- Prevent undigested `/assets/controllers/*` requests that return 404 in Docker deployments.

Fixes #4406

## Test plan
- [x] Run `bundle exec rails assets:precompile` and verify generated `controllers/index-*.js` uses `@hotwired/stimulus-loading` + `eagerLoadControllersFrom`.
- [x] Confirm digested controller assets are available under `/assets/controllers/*-<digest>.js`.
- [ ] Verify in Docker deployment that `/assets/controllers/*` 404s no longer appear in browser console.