### PR TITLE
Fix CSS build for production deploys & remove unused assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem "solid_cable"
 gem "bootsnap", require: false
 gem "kamal", require: false
 gem "thruster", require: false
-gem "sass-embedded"
 gem "cssbundling-rails"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,30 +255,6 @@ GEM
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
     google-logging-utils (0.2.0)
-    google-protobuf (4.34.1)
-      bigdecimal
-      rake (~> 13.3)
-    google-protobuf (4.34.1-aarch64-linux-gnu)
-      bigdecimal
-      rake (~> 13.3)
-    google-protobuf (4.34.1-aarch64-linux-musl)
-      bigdecimal
-      rake (~> 13.3)
-    google-protobuf (4.34.1-arm64-darwin)
-      bigdecimal
-      rake (~> 13.3)
-    google-protobuf (4.34.1-x86-linux-gnu)
-      bigdecimal
-      rake (~> 13.3)
-    google-protobuf (4.34.1-x86-linux-musl)
-      bigdecimal
-      rake (~> 13.3)
-    google-protobuf (4.34.1-x86_64-linux-gnu)
-      bigdecimal
-      rake (~> 13.3)
-    google-protobuf (4.34.1-x86_64-linux-musl)
-      bigdecimal
-      rake (~> 13.3)
     googleauth (1.16.2)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.2)
@@ -618,35 +594,6 @@ GEM
       rake (>= 0.8.1)
     ruby-progressbar (1.13.0)
     rubyzip (3.2.2)
-    sass-embedded (1.99.0)
-      google-protobuf (~> 4.31)
-      rake (>= 13)
-    sass-embedded (1.99.0-aarch64-linux-android)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-aarch64-linux-gnu)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-aarch64-linux-musl)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-arm-linux-androideabi)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-arm-linux-gnueabihf)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-arm-linux-musleabihf)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-arm64-darwin)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-riscv64-linux-android)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-riscv64-linux-gnu)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-riscv64-linux-musl)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-x86_64-linux-android)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-x86_64-linux-gnu)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-x86_64-linux-musl)
-      google-protobuf (~> 4.31)
     securerandom (0.4.1)
     selenium-webdriver (4.43.0)
       base64 (~> 0.2)
@@ -832,7 +779,6 @@ DEPENDENCIES
   rqrcode (~> 3.2)
   rubocop-rails-omakase
   ruby-debug-ide
-  sass-embedded
   selenium-webdriver (>= 4.20.1)
   solid_cable
   solid_cache
@@ -937,14 +883,6 @@ CHECKSUMS
   google-cloud-errors (1.6.0) sha256=1da8476dd706ad04b9d32e3c4b90d07d3463b37d6407cb56d41342ea7647d0a1
   google-cloud-storage (1.59.0) sha256=b8c9a5661d775d65ccb279bb1d6be07fd8152576eb0146c2026bd023c4b186b9
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
-  google-protobuf (4.34.1) sha256=347181542b8d659c60f028fa3791c9cccce651a91ad27782dbc5c5e374796cdc
-  google-protobuf (4.34.1-aarch64-linux-gnu) sha256=f9c07607dc139c895f2792a7740fcd01cd94d4d7b0e0a939045b50d7999f0b1d
-  google-protobuf (4.34.1-aarch64-linux-musl) sha256=db58e5a4a492b43c6614486aea31b7fb86955b175d1d48f28ebf388f058d78a9
-  google-protobuf (4.34.1-arm64-darwin) sha256=2745061f973119e6e7f3c81a0c77025d291a3caa6585a2cd24a25bbc7bedb267
-  google-protobuf (4.34.1-x86-linux-gnu) sha256=b6da7891fe96b13038e5435d8ac8b8a84d78a468147a48a377fe8da40aba1c88
-  google-protobuf (4.34.1-x86-linux-musl) sha256=ea0f453e78f4c30d0d9dbaa8cf9b33d2a1ea04ab2cad2c2a07e479411c05f1a9
-  google-protobuf (4.34.1-x86_64-linux-gnu) sha256=87088c9fd8e47b5b40ca498fc1195add6149e941ff7e81c532a5b0b8876d4cc9
-  google-protobuf (4.34.1-x86_64-linux-musl) sha256=8c0e91436fbe504ffc64f0bd621f2e69adbcce8ed2c58439d7a21117069cfdd7
   googleauth (1.16.2) sha256=15009502e2e38af71948cda918f230e27d327f6882a1e47967a5a4664930a638
   high_voltage (5.0.0) sha256=fbdd1a861af30d51d6a9f710b37709ab489211402685972945cd5eac6a4c0b23
   highline (3.1.2) sha256=67cbd34d19f6ef11a7ee1d82ffab5d36dfd5b3be861f450fc1716c7125f4bb4a
@@ -1079,20 +1017,6 @@ CHECKSUMS
   ruby-debug-ide (0.7.5) sha256=5ec9b2d78e9aa106d23e29e4fdfeb9dc687a279bd25de060c6343aa135314488
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
-  sass-embedded (1.99.0) sha256=61942229dc7da4f335688196d43c1d3d5314060667a43ccf48f4b4c41b5578e1
-  sass-embedded (1.99.0-aarch64-linux-android) sha256=3b077c8436424b45eb04edaa46514fc92cc333f17b3fcca45857d124d453cdf1
-  sass-embedded (1.99.0-aarch64-linux-gnu) sha256=a46615b0295ca7bd979b9ce79f6b9f1d26881736400188bd6fd5c4b7c9b46473
-  sass-embedded (1.99.0-aarch64-linux-musl) sha256=eaa6d56968909d1d54073c46e21c13fd5bbcb5af609d7e4fbe6b196426ca8e49
-  sass-embedded (1.99.0-arm-linux-androideabi) sha256=9089a3aca8f16f855a2fc848c0762b09aef23251f91ec9714fea31c28c9094df
-  sass-embedded (1.99.0-arm-linux-gnueabihf) sha256=f5f0748934660cda6948917af6dc974caf4d36ea6121e450982153b7d9c49b55
-  sass-embedded (1.99.0-arm-linux-musleabihf) sha256=29a4056e76bc136025ba5d03e82d86ecdabfb6c07a473a4fdedcd72fb28dbbc4
-  sass-embedded (1.99.0-arm64-darwin) sha256=20773f2fb0e8f4d0194eb1874dab4c0ef60262ff6dafe29361e217beb2208629
-  sass-embedded (1.99.0-riscv64-linux-android) sha256=7ac1145c066670d5918a7afae8445338c45b4d8e34ad2968bda7099665ba8d15
-  sass-embedded (1.99.0-riscv64-linux-gnu) sha256=b8c421eba2e41fa3c94bffc971611d803aae336586a3baf2933c99e1c7548f88
-  sass-embedded (1.99.0-riscv64-linux-musl) sha256=63b924eb97548bd1f31193c36fab89bb100cd1a9bd144789a9a596fc98244a09
-  sass-embedded (1.99.0-x86_64-linux-android) sha256=39c51b80c292fdb5157fee9166793374104c4e6639d77dfefc36c339aa5dce12
-  sass-embedded (1.99.0-x86_64-linux-gnu) sha256=a4e2ae5e9951815cb8b3ab408cee8b800852491988a57de735f18d259c70d7c4
-  sass-embedded (1.99.0-x86_64-linux-musl) sha256=94be72a6f856c610e67b12303dc76a58412e64b24ce97bdf4912199b8145c8dd
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.43.0) sha256=a634377b964b701c6ac0a009ce3a08fa34ec1e1e7fe9a6d57e3088d14529a65c
   signet (0.21.0) sha256=d617e9fbf24928280d39dcfefba9a0372d1c38187ffffd0a9283957a10a8cd5b

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -1,1 +1,0 @@
-// Entry point for your Sass build

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,14 +13,11 @@ Bundler.require(*Rails.groups)
 # cssbundling-rails attaches `css:build` to `test:prepare`, `assets:precompile`, etc. That runs
 # `yarn build:css` → build_themes.js (all Bootswatch themes) unless SKIP_CSS_BUILD is set.
 #
-# Policy: skip the rake CSS build by default so tests and local dev stay fast. Opt in to the full
-# multi-theme build only when PWP_DOCKER_ASSET_BUILD=1 (e.g. Dockerfile RUN assets:precompile).
+# Policy: skip the rake CSS build in test/development so tests stay fast and dev uses the watcher.
+# In production (Docker, Hatchbox, etc.), always build CSS during assets:precompile.
 # CI/test jobs should run `yarn build:css:single` where digested CSS is required.
-# Non-Docker production releases: run `PWP_DOCKER_ASSET_BUILD=1 bundle exec rails assets:precompile`.
 # Local full rebuild of every theme: `yarn build:css` / `yarn build:css:all` manually.
-if ENV["RAILS_ENV"] == "test"
-  ENV["SKIP_CSS_BUILD"] ||= "1"
-elsif ENV["PWP_DOCKER_ASSET_BUILD"] != "1"
+if ENV["RAILS_ENV"] != "production"
   ENV["SKIP_CSS_BUILD"] ||= "1"
 end
 

--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -53,8 +53,8 @@ RUN yarn install --frozen-lockfile
 # Copy source code - this should be done as late as possible
 COPY ./ ${APP_ROOT}/
 
-# Full multi-theme CSS (build_themes.js) runs during assets:precompile only when
-# PWP_DOCKER_ASSET_BUILD=1 (see config/application.rb SKIP_CSS_BUILD policy).
+# Full multi-theme CSS (build_themes.js) runs during assets:precompile.
+# See config/application.rb for the CSS build policy.
 
 # SECRET_KEY_BASE must be set at runtime via environment variable
 # Do NOT hardcode secrets in Docker images for security reasons.
@@ -72,7 +72,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi
 
 # Precompile Rails assets - this layer will be rebuilt when assets change
-RUN PWP_DOCKER_ASSET_BUILD=1 SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile
 
 RUN rm -rf tmp/cache tmp/pids tmp/sockets app/assets/images/features
 


### PR DESCRIPTION
## Summary

Fixes missing `application-default.css` error on production boot (e.g., Hatchbox) by changing CSS build policy to always build in production environments. Also removes unused `sass-embedded` gem and leftover `application.sass.scss` file.

### Changes
- **config/application.rb**: Simplify CSS build policy - builds CSS in all `production` environments (Docker, Hatchbox, etc.) instead of requiring `PWP_DOCKER_ASSET_BUILD=1`
- **Gemfile**: Remove unused `sass-embedded` gem (CSS built via Node.js/yarn)
- **app/assets/stylesheets/application.sass.scss**: Delete unused placeholder file
- **Dockerfile**: Remove redundant `PWP_DOCKER_ASSET_BUILD` env var and update comments

### Impact
- Fixes 500 error on Hatchbox deploys due to missing CSS files
- Docker builds continue to work (no changes needed)
- No migration or config changes required