### PR TITLE
Deprecate PWP_PRECOMPILE; auto-precompile on PWP__THEME

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -957,15 +957,15 @@ show_gdpr_consent_banner: false
 #
 theme: 'default'
 
-### Pre-compilation
+### Pre-compilation (DEPRECATED)
 #
-# Optional: force `rails assets:precompile` on container boot (e.g. after overlaying custom assets).
-# Not required solely to switch among built-in themes.
+# DEPRECATED: Precompilation now happens automatically when PWP__THEME is set.
+# This setting is kept for backward compatibility only.
 #
-# Pre-compilation isn't supported in this yaml file.  It is only supported
-# through the environment variable PWP_PRECOMPILE='true'.
+# Previously: Optional force `rails assets:precompile` on container boot.
+# Now: Assets are precompiled automatically when PWP__THEME is set.
 #
-# Environment Variable: PWP_PRECOMPILE='false'
+# Environment Variable: PWP_PRECOMPILE='true' (deprecated, no longer needed)
 
 # =============================================================================
 # Locale & internationalization

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -957,15 +957,15 @@ show_gdpr_consent_banner: false
 #
 theme: 'default'
 
-### Pre-compilation
+### Pre-compilation (DEPRECATED)
 #
-# Optional: force `rails assets:precompile` on container boot (e.g. after overlaying custom assets).
-# Not required solely to switch among built-in themes.
+# DEPRECATED: Precompilation now happens automatically when PWP__THEME is set.
+# This setting is kept for backward compatibility only.
 #
-# Pre-compilation isn't supported in this yaml file.  It is only supported
-# through the environment variable PWP_PRECOMPILE='true'.
+# Previously: Optional force `rails assets:precompile` on container boot.
+# Now: Assets are precompiled automatically when PWP__THEME is set.
 #
-# Environment Variable: PWP_PRECOMPILE='false'
+# Environment Variable: PWP_PRECOMPILE='true' (deprecated, no longer needed)
 
 # =============================================================================
 # Locale & internationalization

--- a/containers/docker/entrypoint.sh
+++ b/containers/docker/entrypoint.sh
@@ -101,10 +101,10 @@ fi
 echo "Password Pusher: migrating database to latest..."
 bundle exec rake db:migrate
 
-if [ -n "$PWP_PRECOMPILE" ]; then
+if [ -n "$PWP_PRECOMPILE" ] || [ -n "$PWP__THEME" ]; then
     echo "Password Pusher: rebuilding CSS for selected theme (custom overlays)..."
     BUILD_CSS_SINGLE=1 yarn build:css:single
-    echo "Password Pusher: precompiling assets (PWP_PRECOMPILE set)..."
+    echo "Password Pusher: precompiling assets..."
     bundle exec rails assets:precompile
 fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,7 +136,7 @@ x-env: &x-env
     # PWP__SHOW_VERSION: "true"
     # PWP__SHOW_GDPR_CONSENT_BANNER: "false"
     # PWP__THEME: "default" # See: https://docs.pwpush.com/docs/rebranding/#themes
-    # PWP_PRECOMPILE: "false"  # Set "true" to force assets:precompile on boot (e.g. custom overlays). Not needed for built-in themes.
+    # PWP_PRECOMPILE: "false"  # DEPRECATED. Precompilation now happens automatically when PWP__THEME is set. Keeping for backward compatibility.
 
     # --- Locale ---
     # PWP__TIMEZONE: "America/New_York"


### PR DESCRIPTION
## Summary

Deprecates the `PWP_PRECOMPILE` environment variable and automatically precompiles assets when `PWP__THEME` is set.

### Changes
- Assets are now automatically precompiled when `PWP__THEME` is set (no need for manual `PWP_PRECOMPILE`)
- `PWP_PRECOMPILE` is kept for backward compatibility only
- Updated `entrypoint.sh` to check for `PWP__THEME` in addition to `PWP_PRECOMPILE`
- Updated documentation in `settings.yml` and `docker-compose.yml` to reflect deprecation

### Impact
- Users setting custom themes no longer need to set `PWP_PRECOMPILE=true`
- Backward compatible: existing `PWP_PRECOMPILE` usage still works