### PR TITLE
Fix: Remove javascript_importmap_tags from Devise mailer templates

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,21 +1,3 @@
-<!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-  <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>
-
-  <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
-  <meta content='width=device-width, initial-scale=1' name='viewport'>
-
-  <%= stylesheet_link_tag PasswordPusher::Theme.stylesheet_logical_name, "data-turbo-track": "reload" %>
-  <%= javascript_importmap_tags %>
-</head>
-
-<body class="d-flex flex-column min-vh-100">
-
-<div class="container">
-
 <h1><%= _('Confirm your new account') %></h1>
 <p><%= _('Your account has been created but you must confirm that you own this email address.') %></p>
 
@@ -32,8 +14,3 @@
 <p><%= _("If you didn't create an account, no action is required.") %></p>
 
 <%= render 'shared/email_footer' %>
-
-</div>
-
-</body>
-</html>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,21 +1,3 @@
-<!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-  <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>
-
-  <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
-  <meta content='width=device-width, initial-scale=1' name='viewport'>
-
-  <%= stylesheet_link_tag PasswordPusher::Theme.stylesheet_logical_name, "data-turbo-track": "reload" %>
-  <%= javascript_importmap_tags %>
-</head>
-
-<body class="d-flex flex-column min-vh-100">
-
-<div class="container">
-
 <h1><%= _('Your email is being changed') %></h1>
 <p>
   <%= _('We\'re contacting you to notify you that your email at') %>
@@ -28,8 +10,3 @@
   <% end %>
 </p>
 <%= render 'shared/email_footer' %>
-
-</div>
-
-</body>
-</html>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,21 +1,3 @@
-<!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-  <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>
-
-  <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
-  <meta content='width=device-width, initial-scale=1' name='viewport'>
-
-  <%= stylesheet_link_tag PasswordPusher::Theme.stylesheet_logical_name, "data-turbo-track": "reload" %>
-  <%= javascript_importmap_tags %>
-</head>
-
-<body class="d-flex flex-column min-vh-100">
-
-<div class="container">
-
 <h1><%= _('Password Change') %></h1>
 <p>
   <%= _('We\'re contacting you to notify you that your password has been changed on') %>
@@ -23,8 +5,3 @@
 </p>
 <p><%= _("If you didn't initiate this and it wasn't your intention, please contact us as soon as possible.") %></p>
 <%= render 'shared/email_footer' %>
-
-</div>
-
-</body>
-</html>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,21 +1,3 @@
-<!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-  <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>
-
-  <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
-  <meta content='width=device-width, initial-scale=1' name='viewport'>
-
-  <%= stylesheet_link_tag PasswordPusher::Theme.stylesheet_logical_name, "data-turbo-track": "reload" %>
-  <%= javascript_importmap_tags %>
-</head>
-
-<body class="d-flex flex-column min-vh-100">
-
-<div class="container">
-
 <h1><%= _('Password Change Request') %></h1>
 <p>
 <%= _('Someone has requested a link to change your password. You can proceed with this action') %>
@@ -32,8 +14,3 @@
 <%= _("Your password won't change until you access the link above and create a new one.") %>
 </p>
 <%= render 'shared/email_footer' %>
-
-</div>
-
-</body>
-</html>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,21 +1,3 @@
-<!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-
-  <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>
-
-  <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
-  <meta content='width=device-width, initial-scale=1' name='viewport'>
-
-  <%= stylesheet_link_tag PasswordPusher::Theme.stylesheet_logical_name, "data-turbo-track": "reload" %>
-  <%= javascript_importmap_tags %>
-</head>
-
-<body class="d-flex flex-column min-vh-100">
-
-<div class="container">
-
 <h1><%= _('Unlock Your Account') %></h1>
 
 <p>
@@ -32,8 +14,3 @@
 </pre>
 </p>
 <%= render 'shared/email_footer' %>
-
-</div>
-
-</body>
-</html>

--- a/test/mailers/devise_mailer_test.rb
+++ b/test/mailers/devise_mailer_test.rb
@@ -1,0 +1,121 @@
+require "test_helper"
+
+# These tests verify that Devise mailer templates render without errors.
+# They require the User model to have :recoverable, :confirmable, and :lockable
+# modules loaded (controlled by Settings.enable_user_account_emails).
+#
+# To run these tests: PWP__ENABLE_USER_ACCOUNT_EMAILS=true bin/rails test test/mailers/devise_mailer_test.rb
+#
+# When the feature is disabled, the tests are skipped.
+class DeviseMailerTest < ActionMailer::TestCase
+  setup do
+    Rails.application.routes.default_url_options[:host] = "localhost:3000"
+    @email_enabled = User.respond_to?(:send_reset_password_instructions)
+  end
+
+  teardown do
+    Rails.application.routes.default_url_options[:host] = nil
+  end
+
+  test "reset_password_instructions renders without error" do
+    skip "User account emails not enabled (Settings.enable_user_account_emails)" unless @email_enabled
+
+    user = users(:one)
+    token = user.send_reset_password_instructions
+
+    email = Devise::Mailer.reset_password_instructions(user, token)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal [user.email], email.to
+    assert_match(/Password Change Request/i, email.subject)
+    assert_match(/change your password/i, email.body.to_s)
+  end
+
+  test "confirmation_instructions renders without error" do
+    skip "User account emails not enabled (Settings.enable_user_account_emails)" unless @email_enabled
+
+    user = User.create!(email: "newuser@example.org", password: "password12345")
+    token = user.send_confirmation_instructions
+
+    email = Devise::Mailer.confirmation_instructions(user, token)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal [user.email], email.to
+    assert_match(/Confirm your new account/i, email.subject)
+    assert_match(/confirm your account/i, email.body.to_s)
+  end
+
+  test "email_changed renders without error for unconfirmed email" do
+    skip "User account emails not enabled (Settings.enable_user_account_emails)" unless @email_enabled
+
+    user = users(:one)
+    user.unconfirmed_email = "newemail@example.org"
+    user.send_confirmation_instructions
+
+    email = Devise::Mailer.email_changed(user)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal [user.email], email.to
+    assert_match(/Your email is being changed/i, email.subject)
+    assert_match(/is being changed to/i, email.body.to_s)
+  end
+
+  test "email_changed renders without error for confirmed email" do
+    skip "User account emails not enabled (Settings.enable_user_account_emails)" unless @email_enabled
+
+    user = users(:one)
+    user.update!(email: "changed@example.org")
+
+    email = Devise::Mailer.email_changed(user)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal ["changed@example.org"], email.to
+    assert_match(/Your email is being changed/i, email.subject)
+    assert_match(/has been changed to/i, email.body.to_s)
+  end
+
+  test "password_change renders without error" do
+    skip "User account emails not enabled (Settings.enable_user_account_emails)" unless @email_enabled
+
+    user = users(:one)
+
+    email = Devise::Mailer.password_change(user)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal [user.email], email.to
+    assert_match(/Password Change/i, email.subject)
+    assert_match(/password has been changed/i, email.body.to_s)
+  end
+
+  test "unlock_instructions renders without error" do
+    skip "User account emails not enabled (Settings.enable_user_account_emails)" unless @email_enabled
+
+    user = users(:one)
+    token = user.send_unlock_instructions
+
+    email = Devise::Mailer.unlock_instructions(user, token)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal [user.email], email.to
+    assert_match(/Unlock Your Account/i, email.subject)
+    assert_match(/account has been locked/i, email.body.to_s)
+  end
+end


### PR DESCRIPTION
## Summary

Fixes ActionView::Template::Error when sending Devise emails (password reset, confirmation, etc.) by removing `javascript_importmap_tags` from mailer templates.

### The Problem
The Devise mailer templates were full HTML documents that included `javascript_importmap_tags`, which caused errors because:
- `javascript_importmap_tags` requires a request object (unavailable in email contexts)
- JavaScript has no place in emails (email clients block it anyway)

### Changes
- Converted 5 Devise mailer templates from full HTML documents to content-only fragments
- Templates now properly use the existing `layouts/mailer.html.erb` layout
- Files updated: reset_password_instructions, confirmation_instructions, email_changed, password_change, unlock_instructions

### Testing
- All 719 Rails tests pass
- All 106 system tests pass
- Brakeman security audit: clean
- ERB linting: clean