### PR TITLE
Add local_time support to Data Explorer

### DIFF
--- a/app/controllers/madmin/application_controller.rb
+++ b/app/controllers/madmin/application_controller.rb
@@ -1,6 +1,7 @@
 module Madmin
   class ApplicationController < Madmin::BaseController
     include SetLocale
+    helper LocalTimeHelper
 
     before_action :authenticate_user!
     before_action :authenticate_admin_user

--- a/app/views/madmin/fields/date/_index.html.erb
+++ b/app/views/madmin/fields/date/_index.html.erb
@@ -1,1 +1,1 @@
-<%= local_date(field.value(record), :short) %>
+<%= local_date(field.value(record), :short) if field.value(record).present? %>

--- a/app/views/madmin/fields/date/_index.html.erb
+++ b/app/views/madmin/fields/date/_index.html.erb
@@ -1,0 +1,1 @@
+<%= local_date(field.value(record), :short) %>

--- a/app/views/madmin/fields/date/_show.html.erb
+++ b/app/views/madmin/fields/date/_show.html.erb
@@ -1,0 +1,1 @@
+<%= local_date(field.value(record), :long) %>

--- a/app/views/madmin/fields/date/_show.html.erb
+++ b/app/views/madmin/fields/date/_show.html.erb
@@ -1,1 +1,1 @@
-<%= local_date(field.value(record), :long) %>
+<%= local_date(field.value(record), :long) if field.value(record).present? %>

--- a/app/views/madmin/fields/date_time/_index.html.erb
+++ b/app/views/madmin/fields/date_time/_index.html.erb
@@ -1,1 +1,1 @@
-<%= local_time(field.value(record), :short) %>
+<%= local_time(field.value(record), :short) if field.value(record).present? %>

--- a/app/views/madmin/fields/date_time/_index.html.erb
+++ b/app/views/madmin/fields/date_time/_index.html.erb
@@ -1,0 +1,1 @@
+<%= local_time(field.value(record), :short) %>

--- a/app/views/madmin/fields/date_time/_show.html.erb
+++ b/app/views/madmin/fields/date_time/_show.html.erb
@@ -1,1 +1,1 @@
-<%= local_time(field.value(record), :long) %>
+<%= local_time(field.value(record), :long) if field.value(record).present? %>

--- a/app/views/madmin/fields/date_time/_show.html.erb
+++ b/app/views/madmin/fields/date_time/_show.html.erb
@@ -1,0 +1,1 @@
+<%= local_time(field.value(record), :long) %>

--- a/test/system/madmin_local_time_test.rb
+++ b/test/system/madmin_local_time_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class MadminLocalTimeTest < ApplicationSystemTestCase
+  setup do
+    Rails.application.reload_routes!
+
+    @mr_admin = users(:mr_admin)
+    @giuliana = users(:giuliana)
+    @test_push = pushes(:test_push)
+
+    login_as(@mr_admin, scope: :user)
+  end
+
+  teardown do
+    logout(:user)
+    Rails.application.reload_routes!
+  end
+
+  test "madmin users index renders timestamps with local_time helper" do
+    visit madmin_users_path
+
+    # Verify the page loads successfully
+    assert_selector "h1", text: "Users"
+
+    # Find the row with giuliana's email and check that it has a time element
+    # The local_time helper renders a <time> tag with data-local attribute
+    row = find("tr", text: @giuliana.email)
+    within(row) do
+      # local_time renders a <time> tag with data-local="time" or data-local="date"
+      assert_selector "time[data-local]", minimum: 1
+    end
+  end
+
+  test "madmin users show page renders timestamps with local_time helper" do
+    visit madmin_user_path(@giuliana)
+
+    # Verify the page loads successfully
+    assert_selector "h1", text: @giuliana.email
+
+    # On the show page, we should see time elements for datetime fields
+    # local_time helper generates <time> tags with data attributes
+    assert_selector "time[data-local]", minimum: 1
+  end
+
+  test "madmin pushes index renders timestamps with local_time helper" do
+    visit madmin_pushes_path
+
+    # Verify the page loads successfully
+    assert_selector "h1", text: "Pushes"
+
+    # Find the push row and verify it has time elements
+    assert_selector "time[data-local]", minimum: 1
+  end
+
+  test "madmin pushes show page renders timestamps with local_time helper" do
+    visit madmin_push_path(@test_push)
+
+    # Verify the page loads successfully - h1 contains the url_token for pushes
+    assert_selector "h1", text: @test_push.url_token
+
+    # Show page should have time elements for datetime fields
+    assert_selector "time[data-local]", minimum: 1
+  end
+
+  test "madmin audit_logs index renders timestamps with local_time helper" do
+    visit madmin_audit_logs_path
+
+    # Verify the page loads successfully
+    assert_selector "h1", text: "Audit Logs"
+
+    # Audit logs should have time elements for their timestamps
+    assert_selector "time[data-local]", minimum: 1
+  end
+
+  test "local_time renders proper data attributes" do
+    visit madmin_users_path
+
+    # Find giuliana's row
+    row = find("tr", text: @giuliana.email)
+    within(row) do
+      # Look for the first time element (there may be multiple timestamps)
+      time_element = first("time[data-local]")
+
+      # Verify it has the proper data attributes that local_time sets
+      assert time_element["data-local"].present?, "Time element should have data-local attribute"
+      assert time_element["datetime"].present?, "Time element should have datetime attribute"
+
+      # The datetime attribute should be in ISO8601 format
+      datetime_value = time_element["datetime"]
+      assert_match(/\d{4}-\d{2}-\d{2}/, datetime_value, "datetime attribute should contain date in ISO format")
+    end
+  end
+
+  test "local_time handles nil values gracefully" do
+    # Visit users page - some fields may be nil (like last_sign_in_at)
+    visit madmin_users_path
+    assert_selector "h1", text: "Users"
+
+    # Page should load without errors even if some datetime fields are nil
+    # Just verify the page loaded successfully by finding expected content
+    assert_text @giuliana.email
+  end
+end


### PR DESCRIPTION
## Summary

Adds timezone-aware timestamp display to the Data Explorer (madmin) by overriding the gem's default field partials.

### Changes
- Created `madmin/fields/date_time/_index.html.erb` with `local_time :short` format
- Created `madmin/fields/date_time/_show.html.erb` with `local_time :long` format
- Created `madmin/fields/date/_index.html.erb` with `local_date :short` format  
- Created `madmin/fields/date/_show.html.erb` with `local_date :long` format

### Impact
- Timestamps in Data Explorer (created_at, updated_at, last_sign_in_at, etc.) now display in the user's browser-local timezone
- Consistent with other parts of the application that already use `local_time`/`local_date`
- No database migrations or configuration changes required