### PR TITLE
Add noindex setting to block search engine indexing

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="ROBOTS" content="NOODP">
     <meta name="viewport" content="initial-scale=1">
+    <%= render partial: "shared/robots_meta" %>
     <title>
       <% if content_for? :title %>
         <%= yield(:title) %> -

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,8 @@
   <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
   <meta content='width=device-width, initial-scale=1' name='viewport'>
 
+  <%= render partial: "shared/robots_meta" %>
+
   <%= render partial: "shared/layout_icons", cached: true %>
 
   <%= render partial: "application/ga", cached: true %>

--- a/app/views/layouts/bare.html.erb
+++ b/app/views/layouts/bare.html.erb
@@ -8,6 +8,8 @@
   <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
   <meta content='width=device-width, initial-scale=1' name='viewport'>
 
+  <%= render partial: "shared/robots_meta" %>
+
   <%= render partial: "shared/layout_icons", cached: true %>
 
   <%= render partial: "application/ga", cached: true %>

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -8,6 +8,8 @@
   <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
   <meta content='width=device-width, initial-scale=1' name='viewport'>
 
+  <%= render partial: "shared/robots_meta" %>
+
   <%= render partial: "shared/layout_icons", cached: true %>
 
   <%= render partial: "application/ga", cached: true %>

--- a/app/views/layouts/madmin/application.html.erb
+++ b/app/views/layouts/madmin/application.html.erb
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="ROBOTS" content="NOODP">
     <meta name="viewport" content="initial-scale=1">
+    <%= render partial: "shared/robots_meta" %>
     <%= tag.meta name: 'turbo-drive-enabled', content: ENV.key?('TURBO_DRIVE_ENABLED') ? ENV['TURBO_DRIVE_ENABLED'].to_s.downcase : 'true' %>
     <title>
       <% if content_for? :title %>

--- a/app/views/layouts/naked.html.erb
+++ b/app/views/layouts/naked.html.erb
@@ -8,6 +8,8 @@
   <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
   <meta content='width=device-width, initial-scale=1' name='viewport'>
 
+  <%= render partial: "shared/robots_meta" %>
+
   <%= render partial: "shared/layout_icons", cached: true %>
 
   <%= render partial: "application/ga", cached: true %>

--- a/app/views/shared/_robots_meta.html.erb
+++ b/app/views/shared/_robots_meta.html.erb
@@ -1,0 +1,3 @@
+<% if Settings.noindex %>
+  <meta name="robots" content="noindex, nofollow">
+<% end %>

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -940,6 +940,17 @@ show_version: true
 # Default: true
 show_gdpr_consent_banner: false
 
+### Block search engine indexing
+#
+# When true, adds <meta name="robots" content="noindex, nofollow"> to HTML pages.
+# Use for internal/staging instances that should not appear in search results.
+#
+# Environment variable override:
+# PWP__NOINDEX=true
+#
+# Default: false
+noindex: false
+
 ### Themes
 #
 # Password Pusher uses Bootswatch themes from https://bootswatch.com/

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -940,6 +940,17 @@ show_version: true
 # Default: true
 show_gdpr_consent_banner: false
 
+### Block search engine indexing
+#
+# When true, adds <meta name="robots" content="noindex, nofollow"> to HTML pages.
+# Use for internal/staging instances that should not appear in search results.
+#
+# Environment variable override:
+# PWP__NOINDEX=true
+#
+# Default: false
+noindex: false
+
 ### Themes
 #
 # Password Pusher uses Bootswatch themes from https://bootswatch.com/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,7 @@ x-env: &x-env
     # PWP__BRAND__SHOW_FOOTER_MENU: "true"
     # PWP__SHOW_VERSION: "true"
     # PWP__SHOW_GDPR_CONSENT_BANNER: "false"
+    # PWP__NOINDEX: "false"
     # PWP__THEME: "default" # See: https://docs.pwpush.com/docs/rebranding/#themes
     # PWP_PRECOMPILE: "false"  # DEPRECATED. Precompilation now happens automatically when PWP__THEME is set. Keeping for backward compatibility.
 

--- a/test/integration/noindex_test.rb
+++ b/test/integration/noindex_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class NoindexTest < ActionDispatch::IntegrationTest
+  teardown do
+    Settings.reload!
+  end
+
+  test "robots meta tag is absent when noindex is false" do
+    Settings.noindex = false
+
+    get root_path
+    assert_response :success
+    assert_select "meta[name=robots][content=?]", "noindex, nofollow", count: 0
+  end
+
+  test "robots meta tag is present when noindex is true" do
+    Settings.noindex = true
+
+    get root_path
+    assert_response :success
+    assert_select "meta[name=robots][content=?]", "noindex, nofollow", count: 1
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `noindex` configuration option for self-hosted instances that should not appear in search results.

### Changes
- New `noindex` setting in `settings.yml` (default `false`) with env override `PWP__NOINDEX=true`
- Shared `_robots_meta` partial renders `<meta name="robots" content="noindex, nofollow">` on all HTML layouts when enabled
- Integration tests for meta tag presence/absence
- Commented example in `docker-compose.yml`

### Impact
- No behavior change unless `PWP__NOINDEX=true` or `noindex: true` is set
- Recommended for internal, staging, or private deployments

## Test plan
- [x] `bin/rails test test/unit/settings_test.rb test/integration/noindex_test.rb`
- [ ] Enable `PWP__NOINDEX=true` and verify meta tag in page source
- [ ] Confirm default deployment has no robots meta tag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in HTML meta tag only; no auth, data, or API behavior changes when left at the default `false`.
> 
> **Overview**
> Adds an opt-in **`noindex`** setting (default `false`, override **`PWP__NOINDEX=true`**) so self-hosted instances can tell crawlers not to index HTML pages.
> 
> When enabled, a new **`shared/robots_meta`** partial emits `<meta name="robots" content="noindex, nofollow">`; it is wired into the main HTML layouts (app, login, admin, madmin, bare, naked). Documentation is updated in **`settings.yml`** / defaults and **`docker-compose.yml`**, with integration tests covering tag presence vs absence on the root page.
> 
> **Default deployments are unchanged** until `noindex` is turned on explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c594be6651d366c895c6474e316861cab56d0ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->