### PR TITLE
Restrict URL push payloads to http and https schemes

### DIFF
--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -224,7 +224,8 @@ class Push < ApplicationRecord
   end
 
   def valid_url?(url)
-    !Addressable::URI.parse(url).scheme.nil?
+    scheme = Addressable::URI.parse(url)&.scheme&.downcase
+    %w[http https].include?(scheme)
   rescue Addressable::URI::InvalidURIError
     false
   end

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -57,4 +57,52 @@ class UrlTest < ActiveSupport::TestCase
     json = JSON.parse(url.to_json({}))
     assert_not json.key?("name")
   end
+
+  test "should reject data uri payloads" do
+    url = Push.new(
+      kind: "url",
+      payload: "data:text/html,<script>alert(1)</script>"
+    )
+
+    assert_not url.valid?
+    assert_includes url.errors[:payload], I18n._("must be a valid HTTP or HTTPS URL.")
+  end
+
+  test "should reject javascript uri payloads" do
+    url = Push.new(
+      kind: "url",
+      payload: "javascript:alert(1)"
+    )
+
+    assert_not url.valid?
+    assert_includes url.errors[:payload], I18n._("must be a valid HTTP or HTTPS URL.")
+  end
+
+  test "should reject ftp uri payloads" do
+    url = Push.new(
+      kind: "url",
+      payload: "ftp://example.com"
+    )
+
+    assert_not url.valid?
+    assert_includes url.errors[:payload], I18n._("must be a valid HTTP or HTTPS URL.")
+  end
+
+  test "should accept http uri payloads" do
+    url = Push.new(
+      kind: "url",
+      payload: "http://example.com"
+    )
+
+    assert url.valid?
+  end
+
+  test "should accept https uri payloads" do
+    url = Push.new(
+      kind: "url",
+      payload: "https://example.com"
+    )
+
+    assert url.valid?
+  end
 end


### PR DESCRIPTION
## Summary

Fixes redirect-based XSS via URL pushes that accepted non-http(s) URI schemes such as `data:` and `javascript:` (GHSA-76c2-66pg-fj2f).

### Changes
- Restrict `Push#valid_url?` to allow only `http` and `https` schemes
- Add model tests rejecting `data:`, `javascript:`, and `ftp:` payloads

### Impact
- URL pushes with non-http(s) schemes are rejected at validation time
- Prevents 303 redirects to attacker-controlled HTML/JS under trusted push links