### PR TITLE
Harden crawler protections for self-hosted deployments

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery unless: -> { request.format.json? }
   add_flash_types :info, :error, :success, :warning
+  before_action :set_robots_header
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   include Pwpush::FirstRun
@@ -10,6 +11,10 @@ class ApplicationController < ActionController::Base
   include EnforceRequiredMfa
 
   private
+
+  def set_robots_header
+    response.headers["X-Robots-Tag"] = "noindex, nofollow" if Settings.noindex
+  end
 
   # To add extra fields to Devise registration, add the attribute names to `extra_keys`
   # See: https://stackoverflow.com/questions/64057147/attributes-not-saving-with-devise-and-accepts-nested-attributes-for

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,6 @@
 
   <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>
 
-  <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
   <meta content='width=device-width, initial-scale=1' name='viewport'>
 
   <%= render partial: "shared/robots_meta" %>

--- a/app/views/layouts/bare.html.erb
+++ b/app/views/layouts/bare.html.erb
@@ -5,7 +5,6 @@
 
   <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>
 
-  <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
   <meta content='width=device-width, initial-scale=1' name='viewport'>
 
   <%= render partial: "shared/robots_meta" %>

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -5,7 +5,6 @@
 
   <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>
 
-  <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
   <meta content='width=device-width, initial-scale=1' name='viewport'>
 
   <%= render partial: "shared/robots_meta" %>

--- a/app/views/layouts/naked.html.erb
+++ b/app/views/layouts/naked.html.erb
@@ -5,7 +5,6 @@
 
   <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>
 
-  <meta content="<%= _('Password Pusher is an application to securely send passwords over the web. Links to passwords expire after a certain number of views and/or time has passed.') %>" name='description'>
   <meta content='width=device-width, initial-scale=1' name='viewport'>
 
   <%= render partial: "shared/robots_meta" %>

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -948,8 +948,8 @@ show_gdpr_consent_banner: false
 # Environment variable override:
 # PWP__NOINDEX=true
 #
-# Default: false
-noindex: false
+# Default: true
+noindex: true
 
 ### Themes
 #

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -948,8 +948,8 @@ show_gdpr_consent_banner: false
 # Environment variable override:
 # PWP__NOINDEX=true
 #
-# Default: false
-noindex: false
+# Default: true
+noindex: true
 
 ### Themes
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,7 @@ x-env: &x-env
     # PWP__BRAND__SHOW_FOOTER_MENU: "true"
     # PWP__SHOW_VERSION: "true"
     # PWP__SHOW_GDPR_CONSENT_BANNER: "false"
-    # PWP__NOINDEX: "false"
+    # PWP__NOINDEX: "true" # Default; set false only for public demos
     # PWP__THEME: "default" # See: https://docs.pwpush.com/docs/rebranding/#themes
     # PWP_PRECOMPILE: "false"  # DEPRECATED. Precompilation now happens automatically when PWP__THEME is set. Keeping for backward compatibility.
 

--- a/lib/tasks/pwpush.rake
+++ b/lib/tasks/pwpush.rake
@@ -64,18 +64,7 @@ end
 
 desc "Generate robots.txt."
 task generate_robots_txt: :environment do
-  include Rails.application.routes.url_helpers
-
-  contents = "User-agent: *\n"
-
-  # Old secret links have `/f/` and `/r/` in them for file pushes and url pushes respectively.
-  contents += "Disallow: /p/\n"
-  contents += "Disallow: /f/\n"
-  contents += "Disallow: /r/\n"
-
-  # New secret links can be generated at `/p/new`.
-  contents += "Allow: /p/new\n"
-  contents += "Allow: /pages/\n"
+  contents = "User-agent: *\nDisallow: /\n"
 
   File.write("./public/robots.txt", contents)
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,2 @@
 User-agent: *
-Disallow: /p/
-Disallow: /f/
-Disallow: /r/
-Allow: /p/new
-Allow: /f/new
-Allow: /r/new
-Allow: /pages/
+Disallow: /

--- a/test/integration/noindex_test.rb
+++ b/test/integration/noindex_test.rb
@@ -12,6 +12,7 @@ class NoindexTest < ActionDispatch::IntegrationTest
 
     get root_path
     assert_response :success
+    assert_nil response.headers["X-Robots-Tag"]
     assert_select "meta[name=robots][content=?]", "noindex, nofollow", count: 0
   end
 
@@ -20,6 +21,21 @@ class NoindexTest < ActionDispatch::IntegrationTest
 
     get root_path
     assert_response :success
+    assert_equal "noindex, nofollow", response.headers["X-Robots-Tag"]
     assert_select "meta[name=robots][content=?]", "noindex, nofollow", count: 1
+  end
+
+  test "robots txt blocks all crawlers" do
+    get "/robots.txt"
+
+    assert_response :success
+    assert_equal "User-agent: *\nDisallow: /\n", response.body
+  end
+
+  test "description meta tag is absent" do
+    get root_path
+
+    assert_response :success
+    assert_select "meta[name=description]", count: 0
   end
 end


### PR DESCRIPTION
## Summary

Strengthens privacy defaults for self-hosted Password Pusher deployments by discouraging search engines and crawlers from indexing private instances.

### Changes
- Ships a block-all `robots.txt` by default
- Adds `X-Robots-Tag: noindex, nofollow` when `PWP__NOINDEX` is enabled
- Removes generic page description metadata from app layouts
- Updates self-hosted configuration examples to reflect private-by-default crawler behavior

### Impact
- Helps prevent accidental indexing of internal or private Password Pusher instances
- Keeps `PWP__NOINDEX=true` as the recommended default for self-hosted deployments
- Public/demo operators can still customize crawler behavior for their environment

## Test plan

- `bin/rails test test/integration/noindex_test.rb`