### PR TITLE
Add notify_by_email.enabled setting to disable Auto-Dispatch

### DIFF
--- a/app/views/pages/api.html.erb
+++ b/app/views/pages/api.html.erb
@@ -54,7 +54,7 @@
     },
     "pushes": {
       "enabled": true,
-      "email_auto_dispatch": false,
+      "email_auto_dispatch": <%= Settings.notify_by_email_available? %>,
       "file_attachments": {
         "enabled": <%= Settings.enable_file_pushes %>,
         "requires_authentication": true
@@ -78,6 +78,7 @@
               <li><strong>api_token_authentication</strong> - <%= _("Bearer token authentication support") %></li>
               <li><strong>accounts.enabled</strong> - <%= _("Accounts API availability (not available in OSS)") %></li>
               <li><strong>pushes.enabled</strong> - <%= _("Push creation and management via API") %></li>
+              <li><strong>pushes.email_auto_dispatch</strong> - <%= _("Auto-Dispatch email notifications (Settings.notify_by_email.enabled, requires SMTP and logins)") %></li>
               <li><strong>pushes.file_attachments.enabled</strong> - <%= _("File attachments on pushes (Settings.enable_file_pushes)") %></li>
               <li><strong>pushes.url_pushes.enabled</strong> - <%= _("URL push type (Settings.enable_url_pushes)") %></li>
               <li><strong>pushes.qr_code_pushes.enabled</strong> - <%= _("QR code push type (Settings.enable_qr_pushes)") %></li>

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -1175,11 +1175,19 @@ throttling:
 # See https://docs.pwpush.com/docs/notify-by-email/
 #
 notify_by_email:
+  # Set to false to disable Auto-Dispatch entirely (hides UI, blocks API).
+  #
+  # Default: true
+  #
+  # Environment Variable Override: PWP__NOTIFY_BY_EMAIL__ENABLED='false'
+  enabled: true
+
   # Per-user daily cap on the number of notification emails that may be
   # dispatched. Applies across all pushes owned by the user.
   #
-  # Set to 0 to disable the feature entirely.
+  # Set to 0 to block all sends (UI still visible with a limit message).
   # Set to null (or leave unset) for no cap.
+  # To fully disable the feature, use enabled: false above.
   #
   # Default: 500
   #

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -38,7 +38,9 @@ load_legacy_environment_variables
 
 module SettingsExtensions
   def notify_by_email_available?
-    !disable_logins && mail&.smtp_address.present?
+    notify_by_email&.enabled != false &&
+      !disable_logins &&
+      mail&.smtp_address.present?
   end
 end
 

--- a/config/routes/pushes.rb
+++ b/config/routes/pushes.rb
@@ -18,6 +18,6 @@ constraints(format: :html) do
     delete "expire", on: :member
     get "audit", on: :member
     delete "delete_file", on: :member
-    post "notify_by_email", on: :member
+    post "notify_by_email", on: :member if Settings.notify_by_email.enabled != false
   end
 end

--- a/config/routes/pwp_api.rb
+++ b/config/routes/pwp_api.rb
@@ -8,7 +8,7 @@ constraints(format: :json) do
         get "audit", on: :member
         get "active", on: :collection
         get "expired", on: :collection
-        post "notify_by_email", on: :member
+        post "notify_by_email", on: :member if Settings.notify_by_email.enabled != false
       end
     end
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1175,11 +1175,19 @@ throttling:
 # See https://docs.pwpush.com/docs/notify-by-email/
 #
 notify_by_email:
+  # Set to false to disable Auto-Dispatch entirely (hides UI, blocks API).
+  #
+  # Default: true
+  #
+  # Environment Variable Override: PWP__NOTIFY_BY_EMAIL__ENABLED='false'
+  enabled: true
+
   # Per-user daily cap on the number of notification emails that may be
   # dispatched. Applies across all pushes owned by the user.
   #
-  # Set to 0 to disable the feature entirely.
+  # Set to 0 to block all sends (UI still visible with a limit message).
   # Set to null (or leave unset) for no cap.
+  # To fully disable the feature, use enabled: false above.
   #
   # Default: 500
   #

--- a/test/controllers/pushes_controller_test.rb
+++ b/test/controllers/pushes_controller_test.rb
@@ -16,9 +16,20 @@ class PushesControllerTest < ActionDispatch::IntegrationTest
 
   teardown do
     Settings.reload!
+    Rails.application.reload_routes!
   end
 
   # new
+  test "notify_by_email_recipients field is not shown when feature is disabled" do
+    Settings.notify_by_email.enabled = false
+    Rails.application.reload_routes!
+
+    get new_push_path
+
+    assert_response :success
+    assert_select "input[name=?]", "push[notify_by_email_recipients]", count: 0
+  end
+
   test "notify_by_email_recipients field is shown when mail service is configured and user is signed in" do
     get new_push_path
 
@@ -86,6 +97,25 @@ class PushesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "create doesn't enqueue SendNotifyByEmailJob when feature is disabled" do
+    Settings.notify_by_email.enabled = false
+    Rails.application.reload_routes!
+
+    assert_no_enqueued_jobs(only: SendNotifyByEmailJob) do
+      post pushes_path, params: {
+        push: {
+          kind: "text",
+          payload: "secret",
+          notify_by_email_recipients: "someone@example.com",
+          notify_by_email_locale: "fr"
+        }
+      }
+
+      assert_response :unprocessable_content
+      assert_includes response.body, "Notifying by email is not available"
+    end
+  end
+
   test "create doesn't enqueue SendNotifyByEmailJob when email service is not configured" do
     Settings.mail.smtp_address = nil
 
@@ -137,6 +167,16 @@ class PushesControllerTest < ActionDispatch::IntegrationTest
   end
 
   # preview
+  test "preview does not show notify_by_email when feature is disabled" do
+    Settings.notify_by_email.enabled = false
+    Rails.application.reload_routes!
+
+    get preview_push_path(@push)
+
+    assert_select "input[name=?]", "push[notify_by_email_recipients]", count: 0
+    assert_select "div.collapse#notifyByEmailCollapse", count: 0
+  end
+
   test "preview shows notify_by_email_recipients field when user is signed in and email service is configured" do
     get preview_push_path(@push)
 
@@ -145,6 +185,20 @@ class PushesControllerTest < ActionDispatch::IntegrationTest
   end
 
   # notify_by_email
+  test "notify_by_email returns not found when feature is disabled" do
+    Settings.notify_by_email.enabled = false
+    Rails.application.reload_routes!
+
+    post "/p/#{@push.url_token}/notify_by_email", params: {
+      push: {
+        notify_by_email_recipients: "recipient@example.com",
+        notify_by_email_locale: "en"
+      }
+    }
+
+    assert_response :not_found
+  end
+
   test "notify_by_email enqueues SendNotifyByEmailJob when user is signed in and params present" do
     assert_enqueued_with(job: SendNotifyByEmailJob) do
       post notify_by_email_push_path(@push), params: {

--- a/test/integration/api/api_v2_pushes_test.rb
+++ b/test/integration/api/api_v2_pushes_test.rb
@@ -397,6 +397,30 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
     assert_equal "en", body["notify_by_email"]["locale"]
   end
 
+  def test_create_with_notify_by_email_params_fails_when_feature_is_disabled
+    Settings.mail.smtp_address = "smtp.example.com"
+    Settings.notify_by_email.enabled = false
+    Rails.application.reload_routes!
+    user = users(:one)
+
+    post "/api/v2/pushes",
+      params: {
+        push: {
+          payload: "some-secret",
+          notify_by_email: {
+            recipients: "recipient@example.com",
+            locale: "en"
+          }
+        }
+      },
+      headers: bearer_headers(user),
+      as: :json
+
+    assert_response :unprocessable_entity
+    body = JSON.parse(response.body)
+    assert_equal "Notifying by email is not available", body["base"][0]
+  end
+
   def test_create_with_notify_by_email_params_fails_when_email_service_is_not_configured
     user = users(:one)
 
@@ -462,6 +486,24 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
     assert_equal "recipient@example.com", notify_by_email.recipients
     assert_equal "en", notify_by_email.locale
     assert_equal push, notify_by_email.push
+  end
+
+  def test_notify_by_email_returns_not_found_when_feature_is_disabled
+    Settings.mail.smtp_address = "smtp.example.com"
+    Settings.notify_by_email.enabled = false
+    Rails.application.reload_routes!
+    push = pushes(:test_push)
+    owner = push.user
+
+    post "/api/v2/pushes/#{push.url_token}/notify_by_email",
+      params: {
+        recipients: "recipient@example.com",
+        locale: "en"
+      },
+      headers: bearer_headers(owner),
+      as: :json
+
+    assert_response :not_found
   end
 
   def test_notify_by_email_with_valid_params_returns_error_when_email_service_is_not_configured

--- a/test/integration/api/api_v2_version_test.rb
+++ b/test/integration/api/api_v2_version_test.rb
@@ -3,6 +3,10 @@
 require "test_helper"
 
 class ApiV2VersionTest < ActionDispatch::IntegrationTest
+  teardown do
+    Settings.reload!
+  end
+
   def test_anonymous_version_endpoint
     get "/api/v2/version"
     assert_response :success
@@ -32,6 +36,28 @@ class ApiV2VersionTest < ActionDispatch::IntegrationTest
     assert_equal expected_features, json["features"]
   end
 
+  def test_email_auto_dispatch_is_true_when_feature_is_enabled_and_smtp_configured
+    Settings.mail.smtp_address = "smtp.example.com"
+    Settings.notify_by_email.enabled = true
+
+    get "/api/v2/version"
+    assert_response :success
+
+    json = JSON.parse(@response.body)
+    assert_equal true, json["features"]["pushes"]["email_auto_dispatch"]
+  end
+
+  def test_email_auto_dispatch_is_false_when_feature_is_disabled
+    Settings.mail.smtp_address = "smtp.example.com"
+    Settings.notify_by_email.enabled = false
+
+    get "/api/v2/version"
+    assert_response :success
+
+    json = JSON.parse(@response.body)
+    assert_equal false, json["features"]["pushes"]["email_auto_dispatch"]
+  end
+
   private
 
   def expected_features
@@ -43,7 +69,7 @@ class ApiV2VersionTest < ActionDispatch::IntegrationTest
       },
       "pushes" => {
         "enabled" => true,
-        "email_auto_dispatch" => false,
+        "email_auto_dispatch" => Settings.notify_by_email_available?,
         "file_attachments" => {
           "enabled" => Settings.enable_file_pushes,
           "requires_authentication" => true


### PR DESCRIPTION
## Summary
- Adds `notify_by_email.enabled` (default `true`) so self-hosters can fully disable Auto-Dispatch without removing SMTP configuration
- When disabled, the UI is hidden, dedicated notify-by-email routes return 404, and API create requests with `notify_by_email` params are rejected
- Updates API docs and version endpoint to reflect availability via `Settings.notify_by_email_available?`

## Configuration
```yaml
notify_by_email:
  enabled: false
```
Or: `PWP__NOTIFY_BY_EMAIL__ENABLED='false'`

## Test plan
- [x] `bin/ci` passes locally (RuboCop, ERB lint, i18n, Brakeman, importmap audit, Rails tests, system tests, seeds)
- [x] UI hidden when `enabled: false` with SMTP configured
- [x] API create with `notify_by_email` params returns 422 when disabled
- [x] `POST /api/v2/pushes/:id/notify_by_email` returns 404 when disabled
- [x] Version endpoint reports `email_auto_dispatch: false` when disabled


Made with [Cursor](https://cursor.com)