### PR TITLE
Better log filtering, error tracking and fix GHSA-59w3-h5v2-c4xw

### DIFF
--- a/app/controllers/api/v1/pushes_controller.rb
+++ b/app/controllers/api/v1/pushes_controller.rb
@@ -6,6 +6,12 @@ class Api::V1::PushesController < Api::BaseController
 
   before_action :set_push, only: %i[show preview audit destroy]
 
+  rate_limit to: 5, within: 1.minute, only: :show,
+    if: -> { params[:passphrase].present? },
+    by: -> { params[:id] },
+    scope: :passphrase_attempts, name: "per-push",
+    with: -> { render json: {error: I18n._("Too many passphrase attempts. Please try again in a minute.")}, status: :too_many_requests }
+
   resource_description do
     name "Pushes"
     short "Interact directly with pushes."

--- a/app/controllers/pushes_controller.rb
+++ b/app/controllers/pushes_controller.rb
@@ -12,6 +12,17 @@ class PushesController < BaseController
     by: -> { current_user&.id },
     with: -> { redirect_to preview_push_path(@push), alert: I18n._("Too many email notification requests. Please try again in a minute.") }
 
+  rate_limit to: 5, within: 1.minute, only: :access,
+    by: -> { params[:id] },
+    scope: :passphrase_attempts, name: "per-push",
+    with: -> { redirect_to passphrase_push_path(@push), alert: I18n._("Too many passphrase attempts. Please try again in a minute.") }
+
+  rate_limit to: 5, within: 1.minute, only: :show,
+    if: -> { params[:passphrase].present? },
+    by: -> { params[:id] },
+    scope: :passphrase_attempts, name: "per-push",
+    with: -> { redirect_to passphrase_push_path(@push), alert: I18n._("Too many passphrase attempts. Please try again in a minute.") }
+
   def show
     # This push may have expired since the last view.  Validate the push
     # expiration before doing anything.

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,5 +6,5 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[
-  password note passw secret token _key crypt salt certificate otp ssn
+  password note passw passphrase payload secret token _key crypt salt certificate otp ssn
 ]

--- a/test/controllers/pushes_controller_test.rb
+++ b/test/controllers/pushes_controller_test.rb
@@ -277,6 +277,23 @@ class PushesControllerTest < ActionDispatch::IntegrationTest
     assert_nil flash[:notice]
   end
 
+  test "access is rate limited after five attempts per push" do
+    Rails.cache.clear
+
+    @push.update!(passphrase: "secret")
+
+    5.times do |i|
+      post access_push_path(@push), params: {passphrase: "wrong#{i}"}
+      assert_response :redirect
+    end
+
+    post access_push_path(@push), params: {passphrase: "wrong5"}
+
+    assert_response :redirect
+    assert_redirected_to passphrase_push_path(@push)
+    assert_match(/Too many passphrase attempts/, flash[:alert])
+  end
+
   test "notify_by_email is rate limited after five bursts per user" do
     Rails.cache.clear
 

--- a/test/controllers/pushes_controller_test.rb
+++ b/test/controllers/pushes_controller_test.rb
@@ -278,7 +278,6 @@ class PushesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "access is rate limited after five attempts per push" do
-    Rails.cache.clear
 
     @push.update!(passphrase: "secret")
 

--- a/test/integration/api/api_v2_pushes_test.rb
+++ b/test/integration/api/api_v2_pushes_test.rb
@@ -107,6 +107,29 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  def test_show_passphrase_is_rate_limited_after_five_attempts_per_push
+    Rails.cache.clear
+
+    push = pushes(:test_push)
+    push.update!(passphrase: "super-secret")
+
+    5.times do
+      get "/api/v2/pushes/#{push.url_token}",
+        params: {passphrase: "wrong-passphrase"},
+        as: :json
+
+      assert_response :unauthorized
+    end
+
+    get "/api/v2/pushes/#{push.url_token}",
+      params: {passphrase: "wrong-passphrase"},
+      as: :json
+
+    assert_response :too_many_requests
+    body = response.parsed_body
+    assert_match(/Too many passphrase attempts/, body["error"])
+  end
+
   def test_active_requires_authentication
     get "/api/v2/pushes/active", as: :json
     assert_response :unauthorized

--- a/test/integration/api/api_v2_pushes_test.rb
+++ b/test/integration/api/api_v2_pushes_test.rb
@@ -108,7 +108,6 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
   end
 
   def test_show_passphrase_is_rate_limited_after_five_attempts_per_push
-    Rails.cache.clear
 
     push = pushes(:test_push)
     push.update!(passphrase: "super-secret")


### PR DESCRIPTION
## Summary
- This PR also fixes: https://github.com/pglombardo/PasswordPusher/security/advisories/GHSA-59w3-h5v2-c4xw by using rate limiting on passphrase attempts.
- Adds `payload` and `passphrase` to `filter_parameters` so plaintext secrets are not logged or sent to Rollbar when exceptions occur during push create/access.
- Addresses security review finding M1: `passw` does not match `passphrase`, and nothing matched `payload`.

## Test plan
- [x] `bin/ci`
- [ ] Verify `Rails.application.config.filter_parameters` includes `:payload` and `:passphrase` after boot


Made with [Cursor](https://cursor.com)