### PR TITLE
Record audit log IPs using request.remote_ip

### DIFF
--- a/app/controllers/concerns/log_events.rb
+++ b/app/controllers/concerns/log_events.rb
@@ -44,7 +44,7 @@ module LogEvents
   def log_event(push, kind)
     return if audit_log_limit_reached?(push.audit_logs)
 
-    ip = request.env["HTTP_X_FORWARDED_FOR"].blank? ? request.env["REMOTE_ADDR"] : request.env["HTTP_X_FORWARDED_FOR"]
+    ip = request.remote_ip
 
     # Limit retrieved values to 256 characters
     user_agent = request.env["HTTP_USER_AGENT"].to_s[0, 255]

--- a/test/controllers/concerns/log_events_test.rb
+++ b/test/controllers/concerns/log_events_test.rb
@@ -243,14 +243,29 @@ class LogEventsTest < ActionController::TestCase
   end
 
   # Test log_event method - IP address handling
-  test "log_event uses HTTP_X_FORWARDED_FOR when present" do
+  test "log_event ignores spoofed X-Forwarded-For from untrusted clients" do
     @request.env["HTTP_X_FORWARDED_FOR"] = "203.0.113.50, 192.168.1.1"
+    @request.env["REMOTE_ADDR"] = "203.0.113.99"
+
+    @controller.log_view(@push)
+
+    log = AuditLog.last
+    assert_equal "203.0.113.99", log.ip
+  end
+
+  test "log_event uses client IP from X-Forwarded-For when REMOTE_ADDR is a trusted proxy" do
+    original_trusted_proxies = Rails.application.config.action_dispatch.trusted_proxies
+    Rails.application.config.action_dispatch.trusted_proxies = [IPAddr.new("10.0.0.0/8")]
+
+    @request.env["HTTP_X_FORWARDED_FOR"] = "203.0.113.50, 10.0.0.1"
     @request.env["REMOTE_ADDR"] = "10.0.0.1"
 
     @controller.log_view(@push)
 
     log = AuditLog.last
-    assert_equal "203.0.113.50, 192.168.1.1", log.ip
+    assert_equal "203.0.113.50", log.ip
+  ensure
+    Rails.application.config.action_dispatch.trusted_proxies = original_trusted_proxies
   end
 
   test "log_event uses REMOTE_ADDR when HTTP_X_FORWARDED_FOR is nil" do
@@ -269,7 +284,6 @@ class LogEventsTest < ActionController::TestCase
     @controller.log_view(@push)
 
     log = AuditLog.last
-    # Now correctly falls back to REMOTE_ADDR when HTTP_X_FORWARDED_FOR is empty
     assert_equal "10.0.0.3", log.ip
   end
 


### PR DESCRIPTION
## Summary
- Replaces raw `HTTP_X_FORWARDED_FOR` / `REMOTE_ADDR` handling in audit logging with `request.remote_ip`, which honors `config.action_dispatch.trusted_proxies`.
- Addresses security review finding M2: viewers could previously forge the IP recorded in the audit log by sending a spoofed `X-Forwarded-For` header.

## Test plan
- [x] `bin/ci`
- [x] `log_event ignores spoofed X-Forwarded-For from untrusted clients`
- [x] `log_event uses client IP from X-Forwarded-For when REMOTE_ADDR is a trusted proxy`


Made with [Cursor](https://cursor.com)