### PR TITLE
Fix secret_url FORCE_SSL rewrite corrupting https URLs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,7 @@ module ApplicationHelper
     end
 
     # Support forced https links with FORCE_SSL env var
-    raw_url.gsub!(/http/i, "https") if ENV.key?("FORCE_SSL") && !request.ssl?
+    raw_url = raw_url.sub(%r{\Ahttp://}i, "https://") if ENV.key?("FORCE_SSL") && !request.ssl?
     raw_url
   end
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -138,6 +138,40 @@ class ApplicationHelperTest < ActionView::TestCase
     assert url.start_with?("https://custom.example.com")
   end
 
+  test "secret_url does not corrupt https URLs when FORCE_SSL is set" do
+    Settings.override_base_url = "https://custom.example.com"
+    @request.env["HTTPS"] = "off"
+
+    ENV.stub(:key?, ->(key) { key == "FORCE_SSL" }) do
+      url = secret_url(@push)
+
+      assert url.start_with?("https://custom.example.com/p/#{@push.url_token}")
+      assert_not_includes url, "httpss"
+    end
+  end
+
+  test "secret_url upgrades http to https when FORCE_SSL is set and request is not ssl" do
+    Settings.override_base_url = "http://custom.example.com"
+    @request.env["HTTPS"] = "off"
+
+    ENV.stub(:key?, ->(key) { key == "FORCE_SSL" }) do
+      url = secret_url(@push)
+
+      assert url.start_with?("https://custom.example.com/p/#{@push.url_token}")
+    end
+  end
+
+  test "secret_url leaves https URLs unchanged when FORCE_SSL is set and request is ssl" do
+    Settings.override_base_url = "https://custom.example.com"
+    @request.env["HTTPS"] = "on"
+
+    ENV.stub(:key?, ->(key) { key == "FORCE_SSL" }) do
+      url = secret_url(@push)
+
+      assert_equal "https://custom.example.com/p/#{@push.url_token}", url
+    end
+  end
+
   # Test qr_code method
   test "qr_code generates SVG QR code" do
     test_url = "https://example.com/test"


### PR DESCRIPTION
## Summary
- Replaces broad `gsub(/http/i, "https")` in `secret_url` with anchored `sub(%r{\Ahttp://}i, "https://")` so existing `https://` base URLs are not corrupted to `httpss://`.
- Addresses security review finding L1 when `FORCE_SSL` is set, the request is not SSL, and `override_base_url` is already HTTPS.

## Test plan
- [x] `bin/ci`
- [x] `secret_url does not corrupt https URLs when FORCE_SSL is set`
- [x] `secret_url upgrades http to https when FORCE_SSL is set and request is not ssl`


Made with [Cursor](https://cursor.com)