### PR TITLE
Polish notify-by-email validation error copy

### DIFF
--- a/app/models/concerns/pwpush/notifiable_by_email.rb
+++ b/app/models/concerns/pwpush/notifiable_by_email.rb
@@ -5,6 +5,11 @@ module Pwpush
     extend ActiveSupport::Concern
     MAX_NOTIFY_BY_EMAILS = 5
 
+    NOTIFY_BY_EMAIL_HUMAN_ATTRIBUTE_NAMES = {
+      notify_emails_to: "Recipient emails",
+      notify_emails_to_locale: "Notification language"
+    }.freeze
+
     included do
       attr_accessor :notify_emails_to, :notify_emails_to_locale, :notify_emails_to_required, :notify_by_email_creator, :notify_by_email_skip_limit_validation, :notify_by_email_recipients, :notify_by_email_locale
 
@@ -27,6 +32,13 @@ module Pwpush
       end
     end
 
+    class_methods do
+      def human_attribute_name(attribute, options = {})
+        name = NOTIFY_BY_EMAIL_HUMAN_ATTRIBUTE_NAMES[attribute.to_sym]
+        name ? _(name) : super
+      end
+    end
+
     private
 
     def validate_notify_by_email
@@ -45,7 +57,7 @@ module Pwpush
 
     def validate_notify_by_email_availability
       unless notify_by_email_available?
-        errors.add(:notify_emails_to, _("is not available")) if notify_emails_to.present?
+        errors.add(:notify_emails_to, _("are not available")) if notify_emails_to.present?
         errors.add(:notify_emails_to_locale, _("is not available")) if notify_emails_to_locale.present?
         errors.add(:base, _("Notify by email feature is not enabled"))
 
@@ -55,22 +67,21 @@ module Pwpush
       notify_by_email_custom_validations
 
       unless notify_by_email_creator.present?
-        errors.add(:notify_emails_to, _("is not allowed for unknown users")) if notify_emails_to.present?
+        errors.add(:notify_emails_to, _("are not allowed for unknown users")) if notify_emails_to.present?
         errors.add(:notify_emails_to_locale, _("is not allowed for unknown users")) if notify_emails_to_locale.present?
 
         return
       end
 
       unless notify_by_email_creator == user
-        errors.add(:notify_emails_to, _("is allowed for only owners")) if notify_emails_to.present?
+        errors.add(:notify_emails_to, _("are allowed for only owners")) if notify_emails_to.present?
         errors.add(:notify_emails_to_locale, _("is allowed for only owners")) if notify_emails_to_locale.present?
 
         return
       end
 
       if notify_by_email_creator.email_limit_reached?
-        errors.add(:notify_emails_to, _("is not allowed because the maximum number of emails has been reached for today")) if notify_emails_to.present?
-        errors.add(:notify_emails_to_locale, _("is not allowed because the maximum number of emails has been reached for today")) if notify_emails_to_locale.present?
+        errors.add(:base, _("The maximum number of emails has been reached for today"))
       end
     end
 

--- a/app/models/concerns/pwpush/notifiable_by_email.rb
+++ b/app/models/concerns/pwpush/notifiable_by_email.rb
@@ -5,11 +5,6 @@ module Pwpush
     extend ActiveSupport::Concern
     MAX_NOTIFY_BY_EMAILS = 5
 
-    NOTIFY_BY_EMAIL_HUMAN_ATTRIBUTE_NAMES = {
-      notify_emails_to: "Recipient emails",
-      notify_emails_to_locale: "Notification language"
-    }.freeze
-
     included do
       attr_accessor :notify_emails_to, :notify_emails_to_locale, :notify_emails_to_required, :notify_by_email_creator, :notify_by_email_skip_limit_validation, :notify_by_email_recipients, :notify_by_email_locale
 
@@ -34,8 +29,14 @@ module Pwpush
 
     class_methods do
       def human_attribute_name(attribute, options = {})
-        name = NOTIFY_BY_EMAIL_HUMAN_ATTRIBUTE_NAMES[attribute.to_sym]
-        name ? _(name) : super
+        case attribute.to_sym
+        when :notify_emails_to
+          _("Recipient emails")
+        when :notify_emails_to_locale
+          _("Notification language")
+        else
+          super
+        end
       end
     end
 
@@ -74,8 +75,8 @@ module Pwpush
       end
 
       unless notify_by_email_creator == user
-        errors.add(:notify_emails_to, _("are allowed for only owners")) if notify_emails_to.present?
-        errors.add(:notify_emails_to_locale, _("is allowed for only owners")) if notify_emails_to_locale.present?
+        errors.add(:notify_emails_to, _("are allowed only for owners")) if notify_emails_to.present?
+        errors.add(:notify_emails_to_locale, _("is allowed only for owners")) if notify_emails_to_locale.present?
 
         return
       end

--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -240,7 +240,7 @@ class Push < ApplicationRecord
 
   def notify_by_email_custom_validations
     if expired?
-      errors.add(:notify_emails_to, _("is not available for expired pushes")) if notify_emails_to.present?
+      errors.add(:notify_emails_to, _("are not available for expired pushes")) if notify_emails_to.present?
       errors.add(:notify_emails_to_locale, _("is not available for expired pushes")) if notify_emails_to_locale.present?
     end
   end

--- a/test/controllers/pushes_controller_test.rb
+++ b/test/controllers/pushes_controller_test.rb
@@ -93,7 +93,7 @@ class PushesControllerTest < ActionDispatch::IntegrationTest
       }
 
       assert_response :unprocessable_content
-      assert_includes response.body, "Notify emails to is not allowed for unknown users"
+      assert_includes response.body, "Recipient emails are not allowed for unknown users"
     end
   end
 
@@ -112,8 +112,8 @@ class PushesControllerTest < ActionDispatch::IntegrationTest
       }
 
       assert_response :unprocessable_content
-      assert_includes response.body, "Notify emails to is not available"
-      assert_includes response.body, "Notify emails to locale is not available"
+      assert_includes response.body, "Recipient emails are not available"
+      assert_includes response.body, "Notification language is not available"
       assert_includes response.body, "Notify by email feature is not enabled"
     end
   end
@@ -132,8 +132,8 @@ class PushesControllerTest < ActionDispatch::IntegrationTest
       }
 
       assert_response :unprocessable_content
-      assert_includes response.body, "Notify emails to is not available"
-      assert_includes response.body, "Notify emails to locale is not available"
+      assert_includes response.body, "Recipient emails are not available"
+      assert_includes response.body, "Notification language is not available"
     end
   end
 
@@ -263,7 +263,7 @@ class PushesControllerTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :unprocessable_content
-    assert_includes response.body, "Notify emails to is not available"
+    assert_includes response.body, "Recipient emails are not available"
   end
 
   test "notify_emails redirects to preview when push does not belong to user and disable_logins is false" do

--- a/test/integration/api/api_v2_pushes_test.rb
+++ b/test/integration/api/api_v2_pushes_test.rb
@@ -434,7 +434,7 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
     body = JSON.parse(response.body)
-    assert_equal "is not available", body["notify_emails_to"][0]
+    assert_equal "are not available", body["notify_emails_to"][0]
     assert_equal "is not available", body["notify_emails_to_locale"][0]
   end
 
@@ -454,7 +454,7 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
     body = JSON.parse(response.body)
-    assert_equal "is not available", body["notify_emails_to"][0]
+    assert_equal "are not available", body["notify_emails_to"][0]
     assert_equal "is not available", body["notify_emails_to_locale"][0]
   end
 
@@ -473,7 +473,7 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
     body = JSON.parse(response.body)
-    assert_equal "is not allowed for unknown users", body["notify_emails_to"][0]
+    assert_equal "are not allowed for unknown users", body["notify_emails_to"][0]
     assert_equal "is not allowed for unknown users", body["notify_emails_to_locale"][0]
   end
 
@@ -536,7 +536,7 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
 
     body = JSON.parse(response.body)
-    assert_equal "is not available", body["notify_emails_to"][0]
+    assert_equal "are not available", body["notify_emails_to"][0]
     assert_equal "is not available", body["notify_emails_to_locale"][0]
   end
 

--- a/test/models/concerns/pwpush/notifiable_by_email_test.rb
+++ b/test/models/concerns/pwpush/notifiable_by_email_test.rb
@@ -85,8 +85,8 @@ class Pwpush::NotifiableByEmailTest < ActiveSupport::TestCase
 
     assert @other_user != @user
     assert_not @push.valid?
-    assert_includes @push.errors[:notify_emails_to], "are allowed for only owners"
-    assert_includes @push.errors[:notify_emails_to_locale], "is allowed for only owners"
+    assert_includes @push.errors[:notify_emails_to], "are allowed only for owners"
+    assert_includes @push.errors[:notify_emails_to_locale], "is allowed only for owners"
   end
 
   # Test notify_by_email_limit validation

--- a/test/models/concerns/pwpush/notifiable_by_email_test.rb
+++ b/test/models/concerns/pwpush/notifiable_by_email_test.rb
@@ -67,7 +67,7 @@ class Pwpush::NotifiableByEmailTest < ActiveSupport::TestCase
     Settings.mail.smtp_address = nil
 
     assert_not @push.valid?
-    assert_includes @push.errors[:notify_emails_to], "is not available"
+    assert_includes @push.errors[:notify_emails_to], "are not available"
     assert_includes @push.errors[:notify_emails_to_locale], "is not available"
     assert_includes @push.errors[:base], "Notify by email feature is not enabled"
   end
@@ -76,7 +76,7 @@ class Pwpush::NotifiableByEmailTest < ActiveSupport::TestCase
     @push.notify_by_email_creator = nil
 
     assert_not @push.valid?
-    assert_includes @push.errors[:notify_emails_to], "is not allowed for unknown users"
+    assert_includes @push.errors[:notify_emails_to], "are not allowed for unknown users"
     assert_includes @push.errors[:notify_emails_to_locale], "is not allowed for unknown users"
   end
 
@@ -85,7 +85,7 @@ class Pwpush::NotifiableByEmailTest < ActiveSupport::TestCase
 
     assert @other_user != @user
     assert_not @push.valid?
-    assert_includes @push.errors[:notify_emails_to], "is allowed for only owners"
+    assert_includes @push.errors[:notify_emails_to], "are allowed for only owners"
     assert_includes @push.errors[:notify_emails_to_locale], "is allowed for only owners"
   end
 
@@ -143,7 +143,7 @@ class Pwpush::NotifiableByEmailTest < ActiveSupport::TestCase
     @push.notify_emails_to_locale = "en"
 
     assert_not @push.valid?
-    assert_includes @push.errors[:notify_emails_to], "is not available for expired pushes"
+    assert_includes @push.errors[:notify_emails_to], "are not available for expired pushes"
     assert_includes @push.errors[:notify_emails_to_locale], "is not available for expired pushes"
   end
 

--- a/test/system/notify_by_email_test.rb
+++ b/test/system/notify_by_email_test.rb
@@ -39,7 +39,7 @@ class NotifyByEmailTest < ApplicationSystemTestCase
     fill_in "push[notify_emails_to]", with: "test@example.com, invalid-email"
     click_on "Send Emails"
 
-    assert_text "Notify emails to contains invalid email(s)"
+    assert_text "Recipient emails contains invalid email(s)"
   end
 
   test "notify_by_email creation and sending emails" do

--- a/test/unit/send_notify_by_email_job_test.rb
+++ b/test/unit/send_notify_by_email_job_test.rb
@@ -62,7 +62,7 @@ class SendNotifyByEmailJobTest < ActiveJob::TestCase
     @notify_by_email.reload
     assert_equal "failed", @notify_by_email.status
     assert @notify_by_email.successful_sends.blank?
-    assert_equal "Notify emails to can't be blank.", @notify_by_email.error_message
+    assert_equal "Recipient emails can't be blank.", @notify_by_email.error_message
   end
 
   test "perform does not send mail when notifying by email is not available" do
@@ -72,7 +72,7 @@ class SendNotifyByEmailJobTest < ActiveJob::TestCase
 
     @notify_by_email.reload
     assert_equal "failed", @notify_by_email.status, "Status should be failed"
-    assert_equal "Notify emails to is not available. Notify emails to locale is not available. Notify by email feature is not enabled.", @notify_by_email.error_message
+    assert_equal "Recipient emails are not available. Notification language is not available. Notify by email feature is not enabled.", @notify_by_email.error_message
   end
 
   test "perform logs error and does not send mail if notify_by_email is not found" do


### PR DESCRIPTION
## Summary
- Add humanized attribute names for notify-by-email fields (`Recipient emails`, `Notification language`) so `full_messages` read naturally in the UI and job error output.
- Fix grammatically awkward validation suffixes (e.g. "are not available" vs "is not available") and consolidate the daily email limit message to a single base-level error.
- Update API, controller, model, system, and job tests to match the improved copy.

## Test plan
- [x] `bin/ci` passes locally (RuboCop, ERB lint, i18n health, Brakeman, importmap audit, Rails tests, system tests, seeds)
- [x] Notify-by-email model, API v2, controller, job, and system tests updated and passing


Made with [Cursor](https://cursor.com)