### PR TITLE
Enable Permissions-Policy security headers

### DIFF
--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,15 +1,61 @@
 # frozen_string_literal: true
 
 # Be sure to restart your server when you modify this file.
+#
+# Password Pusher is a form-based app: copy-to-clipboard is the main browser
+# capability we rely on. Everything else is denied by default.
+#
+# Rails emits Feature-Policy (legacy). Scanners expect Permissions-Policy
+# (modern syntax), so both are configured here.
 
-# Define an application-wide HTTP permissions policy. For further
-# information see: https://developers.google.com/web/updates/2018/06/feature-policy
+Rails.application.configure do
+  config.permissions_policy do |policy|
+    policy.accelerometer      :none
+    policy.ambient_light_sensor :none
+    policy.autoplay           :none
+    policy.camera             :none
+    policy.display_capture    :none
+    policy.encrypted_media    :none
+    policy.fullscreen         :none
+    policy.geolocation        :none
+    policy.gyroscope          :none
+    policy.hid                :none
+    policy.idle_detection     :none
+    policy.magnetometer       :none
+    policy.microphone         :none
+    policy.midi               :none
+    policy.payment            :none
+    policy.picture_in_picture :none
+    policy.screen_wake_lock   :none
+    policy.serial             :none
+    policy.sync_xhr           :none
+    policy.usb                :none
+    policy.web_share          :none
+  end
 
-# Rails.application.config.permissions_policy do |policy|
-#   policy.camera      :none
-#   policy.gyroscope   :none
-#   policy.microphone  :none
-#   policy.usb         :none
-#   policy.fullscreen  :self
-#   policy.payment     :self, "https://secure.example.com"
-# end
+  config.action_dispatch.default_headers["Permissions-Policy"] = [
+    "accelerometer=()",
+    "autoplay=()",
+    "camera=()",
+    "clipboard-write=(self)",
+    "display-capture=()",
+    "encrypted-media=()",
+    "fullscreen=()",
+    "geolocation=()",
+    "gyroscope=()",
+    "hid=()",
+    "idle-detection=()",
+    "magnetometer=()",
+    "microphone=()",
+    "midi=()",
+    "payment=()",
+    "picture-in-picture=()",
+    "publickey-credentials-get=()",
+    "screen-wake-lock=()",
+    "serial=()",
+    "sync-xhr=()",
+    "usb=()",
+    "web-share=()",
+    "xr-spatial-tracking=()"
+  ].join(", ")
+end

--- a/test/integration/permissions_policy_test.rb
+++ b/test/integration/permissions_policy_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PermissionsPolicyTest < ActionDispatch::IntegrationTest
+  test "responses include permissions policy headers" do
+    get root_path
+
+    assert_response :success
+    assert response.headers["Permissions-Policy"].present?
+    assert_includes response.headers["Permissions-Policy"], "camera=()"
+    assert_includes response.headers["Permissions-Policy"], "clipboard-write=(self)"
+    assert_includes response.headers["Feature-Policy"], "camera 'none'"
+  end
+end


### PR DESCRIPTION
## Summary
- Enable Rails permissions policy to emit `Feature-Policy`, denying browser features Password Pusher does not use (camera, microphone, geolocation, payment, USB, etc.)
- Add modern `Permissions-Policy` response header for security scanner compliance
- Explicitly allow `clipboard-write=(self)` so copy-to-clipboard continues to work
- Add integration test verifying both headers are present on responses

## Test plan
- [x] `bin/rails test test/integration/permissions_policy_test.rb`
- [ ] Verify copy-to-clipboard still works on a push preview page
- [ ] Confirm security scanner passes Permissions-Policy check on a deployed instance


Missing security header reported by @uggytech