### PR TITLE
Translate push validation error title

### DIFF
--- a/app/views/pushes/_error.html.erb
+++ b/app/views/pushes/_error.html.erb
@@ -1,6 +1,6 @@
 <% if push.errors.any? %>
     <div class="alert alert-danger">
-        <div><%= pluralize(push.errors.count, "error") %> prohibited this push from being saved:</div>
+        <div><%= n_("%{count} error prohibited this push from being saved:", "%{count} errors prohibited this push from being saved:", push.errors.count) % { count: push.errors.count } %></div>
 
         <ul>
         <% push.errors.full_messages.each do |error| %>


### PR DESCRIPTION
## Summary

- Wraps the push validation error title in gettext `n_()` so the full sentence can be translated (including plural forms)
- Fixes #4447 where French (and other locales) showed an untranslated "1 error prohibited this push from being saved:" while the error details were already translated

Fixes #4447 

## Test plan

- [ ] Visit `/p/new?tab=url&locale=fr` and submit an invalid URL
- [ ] Confirm the validation detail message still appears
- [ ] After translation sync, confirm the error title translates (English remains: "1 error prohibited this push from being saved:")
- [ ] `bin/ci` passes