### PR TITLE
Clarify share message expiration copy

### DIFF
--- a/app/helpers/share_message_helper.rb
+++ b/app/helpers/share_message_helper.rb
@@ -11,7 +11,7 @@ module ShareMessageHelper
       notes = [
         share_message_expiration_note(push),
         (passphrase_share_note if push.passphrase.present?),
-        I18n._("Once retrieved, the link and content will be deleted upon expiration.")
+        I18n._("The link and content will be deleted upon expiration.")
       ].compact
 
       [

--- a/test/helpers/share_message_helper_test.rb
+++ b/test/helpers/share_message_helper_test.rb
@@ -18,6 +18,8 @@ class ShareMessageHelperTest < ActionView::TestCase
     assert_includes message, "IMPORTANT NOTES:"
     assert_includes message, @push.views_remaining.to_s
     assert_includes message, @push.days_remaining.to_s
+    assert_includes message, "The link and content will be deleted upon expiration."
+    assert_not_includes message, "Once retrieved"
   end
 
   test "push_share_message_text includes passphrase note when passphrase set" do


### PR DESCRIPTION
## Summary

- Removes misleading "Once retrieved" from the share message expiration note
- Content is deleted on expiration whether or not the link was retrieved
- Aligns OSS wording with Pro
- Fixes #4485

## Test plan

- [ ] Create a push and open the preview/share message
- [ ] Confirm the note reads: "The link and content will be deleted upon expiration."
- [ ] Confirm it no longer says "Once retrieved"
- [ ] `bin/ci` passes