### PR TITLE
fix: Update German translation for push sharing message

### DIFF
--- a/config/locales/gettext/de/app.po
+++ b/config/locales/gettext/de/app.po
@@ -3285,8 +3285,8 @@ msgstr "Push erstellt"
 #: ../../../app/views/pushes/preview.html.erb:12
 msgid "Copy the link or message below to share this push securely."
 msgstr ""
-"Kopieren Sie den unten stehenden Link oder die Nachricht, um diese Pressemitte"
-"ilung sicher weiterzuleiten."
+"Kopieren Sie den unten stehenden Link oder die Nachricht, um diesen Push"
+" sicher weiterzuleiten."
 
 #: ../../../app/views/pushes/preview.html.erb:28
 msgid "QR code"


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Apparently, this was auto translated. "Pressemitteilung" doesn't make sense here.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📦 Dependency & security updates
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / documentation / tutorials

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [x] I've added documentation as necessary so users can easily use and understand this feature/fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single German gettext string correction with no runtime or security impact.
> 
> **Overview**
> Fixes the **German** string on the push preview page (`preview.html.erb`) for *"Copy the link or message below to share this push securely."*
> 
> The previous translation used **"Pressemitteilung"** (press release), which is a bad auto-translation for Password Pusher’s **push** feature. It now uses **"diesen Push"**, consistent with other German entries in the same locale file (e.g. push created / push ownership strings).
> 
> Only `config/locales/gettext/de/app.po` changes; no application logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b64c792e4b2d57d7326717b19611d4270fa969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->