### PR TITLE
Fix: Prevent unauthorized deletion of anonymous pushes

### DIFF
--- a/app/controllers/api/v1/pushes_controller.rb
+++ b/app/controllers/api/v1/pushes_controller.rb
@@ -308,7 +308,7 @@ class Api::V1::PushesController < Api::BaseController
     https://docs.pwpush.com/docs/json-api/
   EOS
   def destroy
-    if (@push.user == current_user) || @push.deletable_by_viewer
+    if @push.deletable_by?(current_user)
       unless @push.expired?
         # Deletable by the owner or viewer
         @push.expire!

--- a/app/controllers/pushes_controller.rb
+++ b/app/controllers/pushes_controller.rb
@@ -332,7 +332,7 @@ class PushesController < BaseController
 
   def expire
     # Check if the push is deletable by the viewer or if the user is the owner
-    unless @push.deletable_by_viewer || (@push.user == current_user)
+    unless @push.deletable_by?(current_user)
       redirect_to :root, notice: I18n._("That push is not deletable by viewers and does not belong to you.")
       return
     end

--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -193,6 +193,13 @@ class Push < ApplicationRecord
     save!
   end
 
+  # True when +user+ is the authenticated owner, or when viewer deletion is
+  # explicitly enabled. Anonymous pushes have a nil owner; comparing two nils
+  # must not count as ownership.
+  def deletable_by?(user)
+    (user.present? && user_id == user.id) || deletable_by_viewer == true
+  end
+
   def settings_for_kind
     if text?
       Settings.pw

--- a/test/integration/api/api_v2_pushes_test.rb
+++ b/test/integration/api/api_v2_pushes_test.rb
@@ -268,6 +268,27 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
     assert push.reload.expired?
   end
 
+  def test_destroy_forbidden_for_anonymous_push_when_not_deletable_by_viewer
+    post "/api/v2/pushes",
+      params: {
+        push: {
+          payload: "anonymous-secret",
+          deletable_by_viewer: false
+        }
+      },
+      as: :json
+    assert_response :created
+
+    token = JSON.parse(@response.body)["url_token"]
+    push = Push.find_by!(url_token: token)
+    assert_nil push.user_id
+    assert_equal false, push.deletable_by_viewer
+
+    delete "/api/v2/pushes/#{token}", as: :json
+    assert_response :unauthorized
+    assert_not push.reload.expired?
+  end
+
   def test_create_requires_auth_when_allow_anonymous_disabled
     Settings.allow_anonymous = false
 

--- a/test/integration/password/password_deletion_test.rb
+++ b/test/integration/password/password_deletion_test.rb
@@ -80,4 +80,19 @@ class PasswordDeletionTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert response.body.include?("We apologize but this secret link has expired.")
   end
+
+  def test_anonymous_push_not_deletable_by_viewer_cannot_be_expired
+    post pushes_path, params: {push: {kind: "text", payload: "testpw", deletable_by_viewer: "0"}}
+    assert_response :redirect
+
+    push = Push.order(:created_at).last
+    assert_nil push.user_id
+    assert_equal false, push.deletable_by_viewer
+
+    delete expire_push_path(push)
+    assert_response :redirect
+    follow_redirect!
+    assert_not push.reload.expired?
+    assert_equal "testpw", push.payload
+  end
 end

--- a/test/integration/password/password_json_deletion_test.rb
+++ b/test/integration/password/password_json_deletion_test.rb
@@ -72,4 +72,36 @@ class PasswordJsonDeletionTest < ActionDispatch::IntegrationTest
     assert res.key?("views_remaining")
     assert_equal Settings.pw.expire_after_views_default - 1, res["views_remaining"]
   end
+
+  def test_anonymous_push_not_deletable_by_viewer_cannot_be_deleted_unauthenticated
+    post passwords_path(format: :json), params: {
+      password: {
+        payload: "SUPER-SECRET",
+        passphrase: "s3cr3t",
+        deletable_by_viewer: "false"
+      }
+    }
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    token = res["url_token"]
+    assert_equal false, res["deletable_by_viewer"]
+    push = Push.find_by!(url_token: token)
+    assert_nil push.user_id
+
+    # Passphrase still blocks reading
+    get "/p/#{token}.json"
+    assert_response :unauthorized
+
+    # Unauthenticated DELETE must not destroy the push
+    delete "/p/#{token}.json"
+    assert_response :unauthorized
+    assert_not push.reload.expired?
+    assert_equal "SUPER-SECRET", push.payload
+
+    # Intended recipient can still retrieve with passphrase
+    get "/p/#{token}.json", params: {passphrase: "s3cr3t"}
+    assert_response :success
+    assert_equal "SUPER-SECRET", JSON.parse(@response.body)["payload"]
+  end
 end

--- a/test/models/push_edit_test.rb
+++ b/test/models/push_edit_test.rb
@@ -392,4 +392,27 @@ class PushEditTest < ActiveSupport::TestCase
     assert_not push.valid?
     assert_includes push.errors[:files], "You can only attach up to #{max_files} files per push."
   end
+
+  test "deletable_by? requires authenticated owner or explicit viewer deletion" do
+    owner = users(:luca)
+    other = users(:one)
+
+    owned = Push.create!(kind: "text", payload: "owned", user: owner, deletable_by_viewer: false)
+    assert owned.deletable_by?(owner)
+    assert_not owned.deletable_by?(other)
+    assert_not owned.deletable_by?(nil)
+
+    anonymous = Push.create!(kind: "text", payload: "anon", deletable_by_viewer: false)
+    assert_nil anonymous.user_id
+    assert_not anonymous.deletable_by?(nil)
+    assert_not anonymous.deletable_by?(other)
+
+    anonymous_deletable = Push.create!(kind: "text", payload: "anon-del", deletable_by_viewer: true)
+    assert anonymous_deletable.deletable_by?(nil)
+    assert anonymous_deletable.deletable_by?(other)
+
+    url_push = Push.create!(kind: "url", payload: "https://example.com", deletable_by_viewer: nil)
+    assert_not url_push.deletable_by?(nil)
+    assert_not url_push.deletable_by?(other)
+  end
 end


### PR DESCRIPTION
## Summary

Fixes an authorization bug where anyone with a secret URL could permanently delete an anonymous push, even when the creator disabled “deletable by viewer.”

Anonymous pushes have no owner (`user_id` is `nil`). The old check treated `nil == nil` as ownership, so unauthenticated delete requests were allowed and the `deletable_by_viewer` setting was skipped. A passphrase still blocked reading, but not deletion.

This change requires a real authenticated owner match, or an explicit `deletable_by_viewer: true`, before a push can be expired/deleted.

Reported by [@theopaid](https://github.com/theopaid). A CVE and GitHub Security Advisory will be published soon.

### Changes
- Add `Push#deletable_by?` with a safe ownership check
- Use it in JSON destroy and HTML expire paths
- Add regression tests for anonymous, non-deletable pushes

### Impact
- Affects deployments that allow anonymous pushes (the default)
- Owned pushes were already protected and remain so
- Recommend upgrading when the security release is available

## Test plan
- [x] Anonymous push with `deletable_by_viewer=false` cannot be deleted via JSON DELETE
- [x] Same case cannot be expired via HTML `/expire`
- [x] Anonymous push with `deletable_by_viewer=true` can still be deleted by viewers
- [x] Authenticated owners can still delete their own pushes
- [x] Passphrase-protected payload remains readable with the correct passphrase after a denied delete
- [x] `bin/ci` passes and signs off the commit