### PR TITLE
Harden push ownership checks against nil comparisons

### DIFF
--- a/app/controllers/api/v1/pushes_controller.rb
+++ b/app/controllers/api/v1/pushes_controller.rb
@@ -262,7 +262,7 @@ class Api::V1::PushesController < Api::BaseController
     https://docs.pwpush.com/docs/json-api/
   EOS
   def audit
-    if @push.user != current_user
+    unless @push.owned_by?(current_user)
       render json: {error: I18n._("That push doesn't belong to you.")}, status: :forbidden
       return
     end

--- a/app/controllers/api/v2/pushes_controller.rb
+++ b/app/controllers/api/v2/pushes_controller.rb
@@ -54,7 +54,7 @@ class Api::V2::PushesController < Api::V1::PushesController
   def audit
     authenticate_user!
 
-    if @push.user != current_user
+    unless @push.owned_by?(current_user)
       render json: {error: I18n._("That push doesn't belong to you.")}, status: :forbidden
       return
     end
@@ -74,7 +74,7 @@ class Api::V2::PushesController < Api::V1::PushesController
   def notify_emails
     authenticate_user!
 
-    if @push.user != current_user
+    unless @push.owned_by?(current_user)
       render json: {error: I18n._("That push doesn't belong to you.")}, status: :forbidden
       return
     end

--- a/app/controllers/concerns/log_events.rb
+++ b/app/controllers/concerns/log_events.rb
@@ -11,7 +11,7 @@ module LogEvents
     elsif user_signed_in? && current_user.admin?
       # Admin views take precedence over owner views
       log_event(push, :admin_view)
-    elsif user_signed_in? && push.user_id == current_user.id
+    elsif push.owned_by?(current_user)
       log_event(push, :owner_view)
     else
       log_event(push, :view)

--- a/app/controllers/pushes_controller.rb
+++ b/app/controllers/pushes_controller.rb
@@ -130,7 +130,7 @@ class PushesController < BaseController
   # GET /p/:url_token/edit
   def edit
     # Verify the push belongs to the current user
-    if @push.user_id != current_user.id
+    unless @push.owned_by?(current_user)
       redirect_to :root, notice: I18n._("That push doesn't belong to you.")
       return
     end
@@ -172,7 +172,7 @@ class PushesController < BaseController
   # PATCH/PUT /p/:url_token
   def update
     # Verify the push belongs to the current user
-    if @push.user_id != current_user.id
+    unless @push.owned_by?(current_user)
       redirect_to :root, notice: I18n._("That push doesn't belong to you.")
       return
     end
@@ -266,7 +266,7 @@ class PushesController < BaseController
   def notify_emails
     authenticate_user!
 
-    if @push.user_id != current_user.id
+    unless @push.owned_by?(current_user)
       redirect_to :root, notice: I18n._("That push doesn't belong to you.")
       return
     end
@@ -322,7 +322,7 @@ class PushesController < BaseController
       end
       return
     end
-    if @push.user_id != current_user.id
+    unless @push.owned_by?(current_user)
       redirect_to :root, notice: I18n._("That push doesn't belong to you.")
       return
     end
@@ -352,7 +352,7 @@ class PushesController < BaseController
 
   def delete_file
     # Verify the push belongs to the current user
-    if @push.user_id != current_user.id
+    unless @push.owned_by?(current_user)
       redirect_to :root, notice: I18n._("That push doesn't belong to you.")
       return
     end

--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -193,11 +193,16 @@ class Push < ApplicationRecord
     save!
   end
 
+  # True when +user+ is the authenticated owner of this push.
+  # Anonymous pushes have a nil owner; comparing two nils must not count as ownership.
+  def owned_by?(user)
+    user.present? && user_id == user.id
+  end
+
   # True when +user+ is the authenticated owner, or when viewer deletion is
-  # explicitly enabled. Anonymous pushes have a nil owner; comparing two nils
-  # must not count as ownership.
+  # explicitly enabled.
   def deletable_by?(user)
-    (user.present? && user_id == user.id) || deletable_by_viewer == true
+    owned_by?(user) || deletable_by_viewer == true
   end
 
   def settings_for_kind

--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -194,9 +194,10 @@ class Push < ApplicationRecord
   end
 
   # True when +user+ is the authenticated owner of this push.
-  # Anonymous pushes have a nil owner; comparing two nils must not count as ownership.
+  # Require a real owner id on both sides so nil == nil (anonymous push /
+  # non-persisted User.new) never counts as ownership.
   def owned_by?(user)
-    user.present? && user_id == user.id
+    user_id.present? && user.present? && user_id == user.id
   end
 
   # True when +user+ is the authenticated owner, or when viewer deletion is

--- a/test/models/push_edit_test.rb
+++ b/test/models/push_edit_test.rb
@@ -401,11 +401,13 @@ class PushEditTest < ActiveSupport::TestCase
     assert owned.owned_by?(owner)
     assert_not owned.owned_by?(other)
     assert_not owned.owned_by?(nil)
+    assert_not owned.owned_by?(User.new)
 
     anonymous = Push.create!(kind: "text", payload: "anon")
     assert_nil anonymous.user_id
     assert_not anonymous.owned_by?(nil)
     assert_not anonymous.owned_by?(other)
+    assert_not anonymous.owned_by?(User.new)
   end
 
   test "deletable_by? requires authenticated owner or explicit viewer deletion" do

--- a/test/models/push_edit_test.rb
+++ b/test/models/push_edit_test.rb
@@ -393,6 +393,21 @@ class PushEditTest < ActiveSupport::TestCase
     assert_includes push.errors[:files], "You can only attach up to #{max_files} files per push."
   end
 
+  test "owned_by? requires an authenticated matching owner" do
+    owner = users(:luca)
+    other = users(:one)
+
+    owned = Push.create!(kind: "text", payload: "owned", user: owner)
+    assert owned.owned_by?(owner)
+    assert_not owned.owned_by?(other)
+    assert_not owned.owned_by?(nil)
+
+    anonymous = Push.create!(kind: "text", payload: "anon")
+    assert_nil anonymous.user_id
+    assert_not anonymous.owned_by?(nil)
+    assert_not anonymous.owned_by?(other)
+  end
+
   test "deletable_by? requires authenticated owner or explicit viewer deletion" do
     owner = users(:luca)
     other = users(:one)


### PR DESCRIPTION
## Summary

Follow-up hardening after [#4703](https://github.com/pglombardo/PasswordPusher/pull/4703).

Adds `Push#owned_by?` so ownership checks require a present authenticated user and matching `user_id`. Remaining audit/edit/update/notify paths no longer compare optional user associations directly (`@push.user ==/!= current_user`), which can treat two `nil`s as a match.

This is defense in depth — those endpoints were already gated by authentication middleware — but it makes ownership checks consistent and safer everywhere.

Related report by [@theopaid](https://github.com/theopaid). A CVE and GitHub Security Advisory will be published soon for the original delete authorization issue fixed in #4703.

### Changes
- Add `Push#owned_by?`; reuse it from `deletable_by?`
- Use `owned_by?` in HTML and API ownership gates
- Use `owned_by?` for owner-view audit logging
- Add unit coverage for anonymous/`nil` ownership

## Test plan
- [x] Owner can still access audit/edit for their pushes
- [x] Non-owner and anonymous access remain denied
- [x] `owned_by?(nil)` is false for anonymous and owned pushes
- [ ] `bin/ci` passes and signs off the commit