### PR TITLE
Fix SMTP TLS failures when openssl_verify_mode is set

### DIFF
--- a/app/mailers/test_mailer.rb
+++ b/app/mailers/test_mailer.rb
@@ -1,4 +1,6 @@
 class TestMailer < ApplicationMailer
+  after_deliver :announce_test_email_success, only: :send_test_email
+
   def send_test_email(email)
     puts ""
     puts "--> Configured FROM: address: '#{Settings.mail.mailer_sender}'"
@@ -64,17 +66,21 @@ class TestMailer < ApplicationMailer
 
     puts ""
     puts "--> Attempting to send a test email to #{email}..."
-    mail(to: email,
-      subject: "Test Email from Password Pusher",
-      body: "⭐  If you are reading this, sending email works! ⭐ ")
-
-    puts "--> ✅   It seems that the Email was accepted by the SMTP server!  Check destination inbox for the test email."
     puts ""
-
     puts "--> If you see an error, please paste this output into a GitHub issue for help."
     puts "  --> Make sure that no sensitive data is included."
     puts "  --> https://github.com/pglombardo/PasswordPusher/issues/new/choose"
+    puts ""
 
+    mail(to: email,
+      subject: "Test Email from Password Pusher",
+      body: "⭐  If you are reading this, sending email works! ⭐ ")
+  end
+
+  private
+
+  def announce_test_email_success
+    puts "--> ✅   It seems that the Email was accepted by the SMTP server!  Check destination inbox for the test email."
     puts ""
   end
 end

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -337,7 +337,7 @@ mail:
 
   # When using TLS, you can set how OpenSSL checks the certificate. This is
   # useful if you need to validate a self-signed and/or a wildcard certificate.
-  # This can be one of the OpenSSL verify constants, :none or :peer
+  # Must be a string name of an OpenSSL verify constant: 'none' or 'peer'
   # Environment Variable Override: PWP__MAIL__SMTP_OPENSSL_VERIFY_MODE='none'
   # smtp_openssl_verify_mode: 'peer'
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -163,16 +163,19 @@ Rails.application.configure do
       config.action_mailer.smtp_settings[:password] = Settings.mail.smtp_password
     end
 
+    # Pass a String ("none" / "peer"). The mail gem maps strings to OpenSSL::SSL::VERIFY_*
+    # constants; a Symbol like :none raises TypeError during TLS handshake.
     if !Settings.mail.smtp_openssl_verify_mode.nil?
-      config.action_mailer.smtp_settings[:openssl_verify_mode] = Settings.mail.smtp_openssl_verify_mode.to_sym
+      config.action_mailer.smtp_settings[:openssl_verify_mode] = Settings.mail.smtp_openssl_verify_mode.to_s
     end
 
     if !Settings.mail.smtp_enable_starttls_auto.nil?
       config.action_mailer.smtp_settings[:enable_starttls_auto] = Settings.mail.smtp_enable_starttls_auto
     end
 
-    if !Settings.mail.smtp_enable_starttls.nil?
-      config.action_mailer.smtp_settings[:enable_starttls] = Settings.mail.smtp_enable_starttls
+    # settings.yml / PWP__MAIL__SMTP_STARTTLS maps to smtp_starttls
+    if !Settings.mail.smtp_starttls.nil?
+      config.action_mailer.smtp_settings[:enable_starttls] = Settings.mail.smtp_starttls
     end
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -163,10 +163,12 @@ Rails.application.configure do
       config.action_mailer.smtp_settings[:password] = Settings.mail.smtp_password
     end
 
-    # Pass a String ("none" / "peer"). The mail gem maps strings to OpenSSL::SSL::VERIFY_*
-    # constants; a Symbol like :none raises TypeError during TLS handshake.
+    # The mail gem maps String names ("none" / "peer") to OpenSSL::SSL::VERIFY_* constants.
+    # A Symbol like :none raises TypeError during TLS handshake. Leave Integers alone —
+    # config.env_parse_values can turn PWP__MAIL__SMTP_OPENSSL_VERIFY_MODE=0 into an Integer.
     if !Settings.mail.smtp_openssl_verify_mode.nil?
-      config.action_mailer.smtp_settings[:openssl_verify_mode] = Settings.mail.smtp_openssl_verify_mode.to_s
+      mode = Settings.mail.smtp_openssl_verify_mode
+      config.action_mailer.smtp_settings[:openssl_verify_mode] = mode.is_a?(Symbol) ? mode.to_s : mode
     end
 
     if !Settings.mail.smtp_enable_starttls_auto.nil?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -337,7 +337,7 @@ mail:
 
   # When using TLS, you can set how OpenSSL checks the certificate. This is
   # useful if you need to validate a self-signed and/or a wildcard certificate.
-  # This can be one of the OpenSSL verify constants, :none or :peer
+  # Must be a string name of an OpenSSL verify constant: 'none' or 'peer'
   # Environment Variable Override: PWP__MAIL__SMTP_OPENSSL_VERIFY_MODE='none'
   # smtp_openssl_verify_mode: 'peer'
 


### PR DESCRIPTION
## Summary

Fixes SMTP TLS handshake failures when `PWP__MAIL__SMTP_OPENSSL_VERIFY_MODE` is set (for example to `none` for self-signed certs).

**What was wrong:** Password Pusher converted that setting to a Ruby Symbol (`:none`). The mail gem only maps **strings** like `"none"` to OpenSSL verify constants. A Symbol was passed through unchanged and OpenSSL raised:

```text
no implicit conversion of Symbol into Integer (TypeError)
OpenSSL::SSL::SSLSocket.new socket, context
```

**Also fixed:**
- `PWP__MAIL__SMTP_STARTTLS` was documented but ignored (code looked for a different setting name)
- `TestMailer` printed “email accepted” before delivery actually ran

### Changes
- Pass `openssl_verify_mode` as a String to Action Mailer
- Wire `smtp_starttls` / `PWP__MAIL__SMTP_STARTTLS` to `enable_starttls`
- Report TestMailer success only after successful delivery

Fixes #4005

## Test plan
- [ ] Set `PWP__MAIL__SMTP_OPENSSL_VERIFY_MODE=none` against an SMTP server with a self-signed cert and confirm `TestMailer.send_test_email("you@example.com").deliver_now` succeeds
- [ ] Set `PWP__MAIL__SMTP_STARTTLS=true` and confirm it appears as `enable_starttls: true` in the TestMailer SMTP config dump
- [ ] Confirm a failed delivery no longer prints the success checkmark before the error