### PR TITLE
Add Dependabot updates for Node.js packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,13 @@ updates:
     commit-message:
       prefix: ":arrow_up:"
     open-pull-requests-limit: 20
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: ":arrow_up:"
+    open-pull-requests-limit: 20


### PR DESCRIPTION
## Summary
- Enable Dependabot `npm` ecosystem checks for the root `package.json` / `yarn.lock`
- Match existing daily schedule and commit message style used by other ecosystems

## Test plan
- [ ] Confirm Dependabot config validates in GitHub repo settings / Dependabot UI
- [ ] Verify Dependabot opens PRs for outdated Node dependencies