### PR TITLE
Improves translations and standardizes terms in Brazilian Portuguese.

### DIFF
--- a/config/locales/gettext/pt_BR/app.po
+++ b/config/locales/gettext/pt_BR/app.po
@@ -34,7 +34,7 @@ msgstr "Você não pode excluir sua própria conta."
 #: ../../../app/controllers/pushes_controller.rb:19
 #: ../../../app/controllers/pushes_controller.rb:25
 msgid "Too many passphrase attempts. Please try again in a minute."
-msgstr "Muitas tentativas de senha foram feitas. Tente novamente em alguns instantes."
+msgstr "Muitas tentativas de frase secreta. Tente novamente em um minuto."
 
 #: ../../../app/controllers/api/v1/pushes_controller.rb:266
 #: ../../../app/controllers/api/v2/pushes_controller.rb:58
@@ -54,15 +54,13 @@ msgstr "Esse envio não pode ser excluído pelos visualizadores."
 #: ../../../app/controllers/api/v2/pushes_controller.rb:12
 #: ../../../app/controllers/pushes_controller.rb:14
 msgid "Too many email notification requests. Please try again in a minute."
-msgstr ""
-"Muitas solicitações de notificação por e-mail. Tente novamente em alguns insta"
-"ntes."
+msgstr "Muitas solicitações de notificação por e-mail. Tente novamente em um minuto."
 
 #: ../../../app/controllers/api/v2/pushes_controller.rb:87
 #: ../../../app/controllers/pushes_controller.rb:279
 #: ../../../app/views/pages/api.html.erb:245
 msgid "Recipient(s) are added to the queue to be sent."
-msgstr "Os destinatários são adicionados à fila para envio."
+msgstr "Os destinatários foram adicionados à fila de envio."
 
 #: ../../../app/controllers/concerns/enforce_required_mfa.rb:19
 #: ../../../test/controllers/api/base_controller_test.rb:50
@@ -70,22 +68,18 @@ msgstr "Os destinatários são adicionados à fila para envio."
 #: ../../../test/integration/require_mfa_test.rb:58
 #: ../../../test/integration/require_mfa_test.rb:74
 msgid "Two-factor authentication is required. Please set it up to continue."
-msgstr ""
-"É necessária a autenticação de dois fatores. Por favor, configure-a para conti"
-"nuar."
+msgstr "A autenticação de dois fatores é obrigatória. Configure-a para continuar."
 
 #: ../../../app/controllers/pushes_controller.rb:114
 msgid ""
 "That passphrase is incorrect.  Please try again or contact the person or organ"
 "ization that sent you this link."
-msgstr ""
-"Essa senha está incorreta. Tente novamente ou entre em contato com a pessoa ou"
-" organização que lhe enviou este link."
+msgstr "Essa frase secreta está incorreta. Tente novamente ou entre em contato com a pessoa ou organização que enviou este link."
 
 #: ../../../app/controllers/pushes_controller.rb:139
 #: ../../../app/controllers/pushes_controller.rb:182
 msgid "That push has already expired and cannot be edited."
-msgstr "Essa notificação já expirou e não pode ser editada."
+msgstr "Esse envio já expirou e não pode ser editado."
 
 #: ../../../app/controllers/pushes_controller.rb:207
 msgid "must be at least %{count} (days already elapsed + 1)."
@@ -98,11 +92,11 @@ msgstr "deve ser pelo menos %{count} (visualizações já consumidas + 1)."
 #: ../../../app/controllers/pushes_controller.rb:241
 #: ../../../app/models/push.rb:116
 msgid "You can only attach up to %{count} files per push."
-msgstr "Você só pode anexar até %{count} arquivos por push."
+msgstr "Você só pode anexar até %{count} arquivos por envio."
 
 #: ../../../app/controllers/pushes_controller.rb:254
 msgid "Push was successfully updated."
-msgstr "O push foi atualizado com sucesso."
+msgstr "O envio foi atualizado com sucesso."
 
 #: ../../../app/controllers/pushes_controller.rb:319
 #: ../../../app/controllers/pushes_controller.rb:503
@@ -116,23 +110,21 @@ msgstr "Você precisa estar conectado para visualizar o registro de auditoria."
 
 #: ../../../app/controllers/pushes_controller.rb:336
 msgid "That push is not deletable by viewers and does not belong to you."
-msgstr ""
-"Essa publicação não pode ser excluída pelos espectadores e não pertence a você"
-"."
+msgstr "Esse envio não pode ser excluído pelos visualizadores e não pertence a você."
 
 #: ../../../app/controllers/pushes_controller.rb:341
 #: ../../../app/controllers/pushes_controller.rb:362
 msgid "That push has already expired."
-msgstr "Esse impulso já expirou."
+msgstr "Esse envio já expirou."
 
 #: ../../../app/controllers/pushes_controller.rb:349
 #: ../../../app/views/pushes/audit.html.erb:96
 msgid "The push content has been deleted and the secret URL expired."
-msgstr "O conteúdo do push foi deletado e a URL secreta expirou."
+msgstr "O conteúdo do envio foi excluído e a URL secreta expirou."
 
 #: ../../../app/controllers/pushes_controller.rb:368
 msgid "You cannot delete the last file from a file push."
-msgstr "Não é possível excluir o último arquivo de um push de arquivos."
+msgstr "Você não pode excluir o último arquivo de um envio de arquivos."
 
 #: ../../../app/controllers/pushes_controller.rb:377
 msgid "File was successfully deleted."
@@ -145,28 +137,24 @@ msgstr "Arquivo não encontrado."
 #: ../../../app/controllers/pushes_controller.rb:495
 #: ../../../test/integration/disable_logins_test.rb:144
 msgid "The push dashboard is not available while logins are disabled."
-msgstr ""
-"O painel de controle de notificações push não está disponível enquanto os logi"
-"ns estiverem desativados."
+msgstr "O painel de envios não está disponível enquanto os logins estiverem desativados."
 
 #: ../../../app/controllers/pushes_controller.rb:528
 #: ../../../test/integration/disable_logins_test.rb:135
 msgid "File pushes are unavailable while logins are disabled."
-msgstr ""
-"O envio de arquivos não está disponível enquanto os logins estiverem desativad"
-"os."
+msgstr "Os envios de arquivos não estão disponíveis enquanto os logins estiverem desativados."
 
 #: ../../../app/controllers/pushes_controller.rb:536
 #: ../../../app/models/push.rb:210
 msgid "File pushes are disabled."
-msgstr "Os envios de arquivos estão desabilitados."
+msgstr "Os envios de arquivos estão desativados."
 
 #: ../../../app/controllers/pushes_controller.rb:541
 #: ../../../app/models/push.rb:214
 #: ../../../test/controllers/urls_controller_test.rb:110
 #: ../../../test/controllers/urls_controller_test.rb:127
 msgid "URL pushes are disabled."
-msgstr "Os envios de URL estão desabilitados."
+msgstr "Os envios de URLs estão desativados."
 
 #: ../../../app/controllers/pushes_controller.rb:553
 #: ../../../app/models/push.rb:218
@@ -189,7 +177,7 @@ msgstr ""
 
 #: ../../../app/controllers/users/sessions_controller.rb:55
 msgid "Session expired. Please sign in again."
-msgstr "Sessão expirada. Por favor, faça login novamente."
+msgstr "A sessão expirou. Entre novamente."
 
 #: ../../../app/controllers/users/sessions_controller.rb:67
 #: ../../../app/controllers/users/two_factor_controller.rb:25
@@ -198,7 +186,7 @@ msgstr "Código de verificação incorreto."
 
 #: ../../../app/controllers/users/two_factor_controller.rb:23
 msgid "Two-factor authentication is now enabled."
-msgstr "A autenticação de dois fatores agora está ativada."
+msgstr "A autenticação de dois fatores foi ativada."
 
 #: ../../../app/controllers/users/two_factor_controller.rb:34
 #: ../../../test/integration/require_mfa_test.rb:105
@@ -227,7 +215,7 @@ msgstr[1] "dias"
 
 #: ../../../app/helpers/share_message_helper.rb:14
 msgid "Once retrieved, the link and content will be deleted upon expiration."
-msgstr "Uma vez recuperado, o link e o conteúdo serão excluídos após a expiração."
+msgstr "Após a recuperação, o link e o conteúdo serão excluídos quando expirarem."
 
 #: ../../../app/helpers/share_message_helper.rb:18
 msgid "A secure link has been shared with you."
@@ -236,9 +224,7 @@ msgstr "Um link seguro foi compartilhado com você."
 #: ../../../app/helpers/share_message_helper.rb:20
 #: ../../../app/views/push_created_mailer/notify.html.erb:6
 msgid "Please find the secret link below to access the sensitive information."
-msgstr ""
-"Por favor, encontre o link secreto abaixo para acessar as informações sensívei"
-"s."
+msgstr "Use o link secreto abaixo para acessar as informações confidenciais."
 
 #: ../../../app/helpers/share_message_helper.rb:22
 #: ../../../app/views/pushes/preview.html.erb:18
@@ -288,11 +274,11 @@ msgstr "Alguém"
 
 #: ../../../app/mailers/push_created_mailer.rb:15
 msgid "You have received a push"
-msgstr "Você recebeu um empurrão"
+msgstr "Você recebeu um envio"
 
 #: ../../../app/models/concerns/pwpush/notifiable_by_email.rb:34
 msgid "Recipient emails"
-msgstr "E-mails do destinatário"
+msgstr "E-mails dos destinatários"
 
 #: ../../../app/models/concerns/pwpush/notifiable_by_email.rb:36
 msgid "Notification language"
@@ -312,23 +298,23 @@ msgstr "A funcionalidade de notificação por e-mail não está ativada."
 
 #: ../../../app/models/concerns/pwpush/notifiable_by_email.rb:71
 msgid "are not allowed for unknown users"
-msgstr "Não são permitidos para usuários desconhecidos."
+msgstr "não são permitidos para usuários desconhecidos"
 
 #: ../../../app/models/concerns/pwpush/notifiable_by_email.rb:72
 msgid "is not allowed for unknown users"
-msgstr "Não é permitido para usuários desconhecidos."
+msgstr "não é permitido para usuários desconhecidos"
 
 #: ../../../app/models/concerns/pwpush/notifiable_by_email.rb:78
 msgid "are allowed only for owners"
-msgstr "são permitidos apenas para proprietários"
+msgstr "são permitidos apenas para os proprietários"
 
 #: ../../../app/models/concerns/pwpush/notifiable_by_email.rb:79
 msgid "is allowed only for owners"
-msgstr "É permitido apenas para proprietários."
+msgstr "é permitido apenas para o proprietário"
 
 #: ../../../app/models/concerns/pwpush/notifiable_by_email.rb:85
 msgid "The maximum number of emails has been reached for today"
-msgstr "O número máximo de emails enviados por hoje foi atingido."
+msgstr "O número máximo de e-mails de hoje foi atingido."
 
 #: ../../../app/models/concerns/pwpush/notifiable_by_email.rb:99
 msgid ""
@@ -341,11 +327,11 @@ msgstr ""
 #: ../../../app/models/push.rb:125 ../../../app/models/push.rb:143
 #: ../../../app/models/push.rb:157
 msgid "Payload is required."
-msgstr "É necessária carga útil."
+msgstr "O conteúdo é obrigatório."
 
 #: ../../../app/models/push.rb:130
 msgid "The payload is too large.  You can only push up to %{count} bytes."
-msgstr "A carga útil é muito grande. Você só pode enviar até %{count} bytes."
+msgstr "O conteúdo é muito grande. Você só pode enviar até %{count} bytes."
 
 #: ../../../app/models/push.rb:140 ../../../test/models/url_test.rb:68
 #: ../../../test/models/url_test.rb:78 ../../../test/models/url_test.rb:88
@@ -354,41 +340,41 @@ msgstr "deve ser uma URL HTTP ou HTTPS válida."
 
 #: ../../../app/models/push.rb:154
 msgid "The QR code payload is too large.  You can only push up to %{count} bytes."
-msgstr "O payload do código QR é muito grande. Você só pode enviar até %{count} bytes."
+msgstr "O conteúdo do código QR é muito grande. Você só pode enviar até %{count} bytes."
 
 #: ../../../app/models/push.rb:243
 msgid "are not available for expired pushes"
-msgstr "não estão disponíveis para notificações expiradas"
+msgstr "não estão disponíveis para envios expirados"
 
 #: ../../../app/models/push.rb:244
 msgid "is not available for expired pushes"
-msgstr "Não está disponível para notificações expiradas."
+msgstr "não está disponível para envios expirados"
 
 #: ../../../app/validators/multiple_emails_validator.rb:20
 msgid "has commas used in the wrong way"
-msgstr "tem vírgulas usadas de forma errada"
+msgstr "contém vírgulas usadas incorretamente"
 
 #: ../../../app/validators/multiple_emails_validator.rb:25
 msgid "contains duplicate emails"
-msgstr "contém e-mails duplicados"
+msgstr "contém endereços de e-mail duplicados"
 
 #: ../../../app/validators/multiple_emails_validator.rb:29
 msgid "contains more than %{count} email(s)"
-msgstr "Contém mais de %{count} e-mail(s)"
+msgstr "contém mais de %{count} endereço(s) de e-mail"
 
 #: ../../../app/validators/multiple_emails_validator.rb:33
 msgid "contains invalid email(s)"
-msgstr "contém e-mail(s) inválido(s)"
+msgstr "contém endereço(s) de e-mail inválido(s)"
 
 #: ../../../app/views/admin/_navigation.html.erb:9
 msgid "Password Pusher"
-msgstr "Enviador de senha"
+msgstr "Password Pusher"
 
 #: ../../../app/views/admin/_navigation.html.erb:12
 #: ../../../app/views/admin/index.html.erb:11
 #: ../../../app/views/shared/_header.html.erb:40
 msgid "Administration Center"
-msgstr "Administração"
+msgstr "Central de administração"
 
 #: ../../../app/views/admin/_navigation.html.erb:17
 msgid "BETA"
@@ -396,28 +382,28 @@ msgstr "BETA"
 
 #: ../../../app/views/admin/_navigation.html.erb:31
 msgid "Administration Home"
-msgstr "Página inicial da administração"
+msgstr "Início da administração"
 
 #: ../../../app/views/admin/_navigation.html.erb:37
 #: ../../../app/views/admin/index.html.erb:121
 msgid "System Administration"
-msgstr "Administração de Sistemas"
+msgstr "Administração do sistema"
 
 #: ../../../app/views/admin/_navigation.html.erb:43
 msgid "Admin Users"
-msgstr "Usuários administradores"
+msgstr "Administradores"
 
 #: ../../../app/views/admin/_navigation.html.erb:50
 #: ../../../app/views/admin/index.html.erb:161
 #: ../../../app/views/madmin/dashboard/show.html.erb:1
 msgid "Data Explorer"
-msgstr "Explorador de Dados"
+msgstr "Explorador de dados"
 
 #: ../../../app/views/admin/_navigation.html.erb:57
 #: ../../../app/views/admin/index.html.erb:146
 #: ../../../app/views/layouts/mission_control/jobs/_application_selection.html.erb:34
 msgid "Background Jobs"
-msgstr "Trabalhos de fundo"
+msgstr "Tarefas em segundo plano"
 
 #: ../../../app/views/admin/_navigation.html.erb:64
 #: ../../../app/views/admin/custom_css/edit.html.erb:1
@@ -435,7 +421,7 @@ msgstr ""
 
 #: ../../../app/views/admin/custom_css/edit.html.erb:16
 msgid "Use Caution"
-msgstr "Tenha cuidado."
+msgstr "Cuidado"
 
 #: ../../../app/views/admin/custom_css/edit.html.erb:17
 msgid ""
@@ -462,7 +448,7 @@ msgstr ""
 
 #: ../../../app/views/admin/custom_css/edit.html.erb:31
 msgid "View the Theme Gallery"
-msgstr "Veja a Galeria de Temas"
+msgstr "Ver a galeria de temas"
 
 #: ../../../app/views/admin/custom_css/edit.html.erb:41
 msgid "Custom Stylesheet"
@@ -475,7 +461,7 @@ msgid ""
 "body {\n"
 "  background-color: #f5f5f5;\n"
 "}"
-msgstr "/* Adicione seu CSS personalizado aqui */ body { background-color: #f5f5f5; }"
+msgstr "/* Adicione seu CSS personalizado aqui */\n\nbody {\n  background-color: #f5f5f5;\n}"
 
 #: ../../../app/views/admin/custom_css/edit.html.erb:51
 msgid ""
@@ -503,7 +489,7 @@ msgstr "Aumente o tamanho da área de texto da senha e use uma fonte monoespaça
 
 #: ../../../app/views/admin/custom_css/edit.html.erb:82
 msgid "Style the Generate Password button with gradient"
-msgstr "Personalize o botão \"Gerar Senha\" com um gradiente."
+msgstr "Personalize o botão \"Gerar senha\" com um gradiente"
 
 #: ../../../app/views/admin/custom_css/edit.html.erb:92
 msgid "Customize slider appearance"
@@ -511,15 +497,15 @@ msgstr "Personalize a aparência do controle deslizante."
 
 #: ../../../app/views/admin/custom_css/edit.html.erb:104
 msgid "Style the Push It button"
-msgstr "Personalize o botão \"Aperte-o\""
+msgstr "Personalize o botão \"Enviar\""
 
 #: ../../../app/views/admin/custom_css/edit.html.erb:116
 msgid "Highlight the passphrase field when focused"
-msgstr "O campo da senha fica destacado quando selecionado."
+msgstr "Destaque o campo da frase secreta quando ele estiver selecionado"
 
 #: ../../../app/views/admin/custom_css/edit.html.erb:125
 msgid "Add card-style borders to form sections"
-msgstr "Adicione bordas no estilo de cartões para formar seções."
+msgstr "Adicione bordas em estilo de cartão às seções do formulário"
 
 #: ../../../app/views/admin/index.html.erb:1
 #: ../../../app/views/layouts/admin.html.erb:39
@@ -548,7 +534,7 @@ msgstr "Total de usuários"
 
 #: ../../../app/views/admin/index.html.erb:60
 msgid "Total Pushes"
-msgstr "Empurrões totais"
+msgstr "Total de envios"
 
 #: ../../../app/views/admin/index.html.erb:80
 msgid "Active Pushes"
@@ -597,15 +583,15 @@ msgstr ""
 
 #: ../../../app/views/admin/index.html.erb:192
 msgid "Advanced Database Access"
-msgstr "Acesso avançado a bancos de dados"
+msgstr "Acesso avançado ao banco de dados"
 
 #: ../../../app/views/admin/index.html.erb:193
 msgid "Direct record manipulation and management"
-msgstr "Manipulação e gestão direta de registros"
+msgstr "Manipulação e gerenciamento direto de registros"
 
 #: ../../../app/views/admin/index.html.erb:196
 msgid "Open Data Explorer"
-msgstr "Explorador de Dados Abertos"
+msgstr "Abrir o Explorador de Dados"
 
 #: ../../../app/views/admin/index.html.erb:218
 msgid "Resources & Support"
@@ -646,7 +632,7 @@ msgstr "Guias completos de instalação e utilização"
 
 #: ../../../app/views/admin/index.html.erb:278
 msgid "Support"
-msgstr "Apoiar"
+msgstr "Suporte"
 
 #: ../../../app/views/admin/index.html.erb:279
 msgid "Get help and report issues"
@@ -654,7 +640,7 @@ msgstr "Obtenha ajuda e relate problemas"
 
 #: ../../../app/views/admin/index.html.erb:299
 msgid "Getting Started"
-msgstr "Começando"
+msgstr "Primeiros passos"
 
 #: ../../../app/views/admin/index.html.erb:302
 msgid ""
@@ -678,9 +664,7 @@ msgstr "📊 Monitorar trabalhos em segundo plano:"
 
 #: ../../../app/views/admin/index.html.erb:305
 msgid "Track email notifications, push cleanup, and system processing tasks"
-msgstr ""
-"Rastrear notificações de e-mail, limpeza de notificações push e tarefas de pro"
-"cessamento do sistema."
+msgstr "Acompanhe notificações por e-mail, a limpeza de envios e as tarefas de processamento do sistema."
 
 #: ../../../app/views/admin/index.html.erb:306
 msgid "🗄️ Explore Database:"
@@ -688,9 +672,7 @@ msgstr "🗄️ Explorar Banco de Dados:"
 
 #: ../../../app/views/admin/index.html.erb:306
 msgid "Direct access to users, pushes, audit logs, and file storage records"
-msgstr ""
-"Acesso direto a usuários, notificações push, registros de auditoria e arquivos"
-" armazenados."
+msgstr "Acesso direto a usuários, envios, registros de auditoria e registros de armazenamento de arquivos."
 
 #: ../../../app/views/admin/index.html.erb:307
 msgid "📈 View System Stats:"
@@ -698,9 +680,7 @@ msgstr "📈 Ver estatísticas do sistema:"
 
 #: ../../../app/views/admin/index.html.erb:307
 msgid "Monitor user activity, push counts, and audit log entries"
-msgstr ""
-"Monitore a atividade do usuário, a contagem de notificações push e as entradas"
-" de log de auditoria."
+msgstr "Monitore a atividade dos usuários, a quantidade de envios e as entradas do registro de auditoria."
 
 #: ../../../app/views/admin/index.html.erb:308
 msgid "🔍 Track Activity:"
@@ -788,7 +768,7 @@ msgstr "No momento, não há contas de administrador no sistema."
 
 #: ../../../app/views/admin/users/index.html.erb:129
 msgid "Regular Users"
-msgstr "Usuários regulares"
+msgstr "Usuários comuns"
 
 #: ../../../app/views/admin/users/index.html.erb:133
 msgid "%{count} Regular Users"
@@ -912,7 +892,7 @@ msgstr "Referenciador:"
 
 #: ../../../app/views/audit_logs/_log_creation.html.erb:3
 msgid "Created on %{date} by %{user}"
-msgstr "Push criado em %{date} por %{user}"
+msgstr "Criado em %{date} por %{user}"
 
 #: ../../../app/views/audit_logs/_log_creation_email_send.html.erb:22
 msgid "Email notification(s) queued on %{date}"
@@ -936,7 +916,7 @@ msgstr "Erro:"
 
 #: ../../../app/views/audit_logs/_log_creation_email_send.html.erb:49
 msgid "Proceed At:"
-msgstr "Prossiga em:"
+msgstr "Processar em:"
 
 #: ../../../app/views/audit_logs/_log_creation_email_send.html.erb:49
 msgid "Not yet"
@@ -948,11 +928,11 @@ msgstr "Editado em %{date} por %{user}"
 
 #: ../../../app/views/audit_logs/_log_expire.html.erb:3
 msgid "Manually expired on %{date} by %{user}"
-msgstr "Push expirou manualmente em %{date} por %{user}"
+msgstr "Expirado manualmente em %{date} por %{user}"
 
 #: ../../../app/views/audit_logs/_log_failed_passphrase.html.erb:3
 msgid "Failed passphrase attempt on %{date} by %{user}"
-msgstr "Falha na tentativa de senha em %{date} por %{user}"
+msgstr "Tentativa malsucedida de frase secreta em %{date} por %{user}"
 
 #: ../../../app/views/audit_logs/_log_failed_view.html.erb:3
 msgid "Failed view attempt on %{date} by %{user}"
@@ -1018,7 +998,7 @@ msgstr "foi alterado para %s"
 
 #: ../../../app/views/devise/mailer/password_change.html.erb:1
 msgid "Password Change"
-msgstr "Mudança de senha"
+msgstr "Alteração de senha"
 
 #: ../../../app/views/devise/mailer/password_change.html.erb:3
 msgid "We're contacting you to notify you that your password has been changed on"
@@ -1078,11 +1058,11 @@ msgstr ""
 
 #: ../../../app/views/devise/passwords/edit.html.erb:9
 msgid "New password"
-msgstr "Nova Senha"
+msgstr "Nova senha"
 
 #: ../../../app/views/devise/passwords/edit.html.erb:14
 msgid "Confirm new password"
-msgstr "Confirme a nova senha"
+msgstr "Confirmar nova senha"
 
 #: ../../../app/views/devise/passwords/edit.html.erb:19
 msgid "A minimum of %d characters is required but the more the better."
@@ -1116,7 +1096,7 @@ msgstr "Tem certeza?"
 
 #: ../../../app/views/devise/registrations/edit.html.erb:73
 msgid "Set up two-factor authentication"
-msgstr "Configure a autenticação de dois fatores."
+msgstr "Configurar autenticação de dois fatores"
 
 #: ../../../app/views/devise/registrations/token.html.erb:1
 #: ../../../app/views/devise/registrations/token.html.erb:6
@@ -1155,7 +1135,7 @@ msgstr "Seu token de API está desfocado. Clique abaixo para revelá-lo."
 #: ../../../app/views/devise/registrations/token.html.erb:35
 #: ../../../app/views/devise/registrations/token.html.erb:41
 msgid "Regenerate Token"
-msgstr "Regenerar token"
+msgstr "Gerar novo token"
 
 #: ../../../app/views/devise/registrations/token.html.erb:37
 msgid "To delete this token and regenerate a new one, use the button below."
@@ -1196,13 +1176,13 @@ msgstr "Cancelar"
 
 #: ../../../app/views/devise/registrations/token.html.erb:63
 msgid "Delete & Regenerate"
-msgstr "Excluir e regenerar"
+msgstr "Excluir e gerar novamente"
 
 #: ../../../app/views/devise/registrations/token.html.erb:63
 #: ../../../app/views/pushes/audit.html.erb:221
 #: ../../../app/views/pushes/show.html.erb:119
 msgid "Processing..."
-msgstr "Em processamento..."
+msgstr "Processando..."
 
 #: ../../../app/views/devise/sessions/new.html.erb:12
 #: ../../../app/views/users/first_runs/new.html.erb:79
@@ -1212,11 +1192,11 @@ msgstr "Senha"
 
 #: ../../../app/views/layouts/admin.html.erb:12
 msgid "Administration - Password Pusher"
-msgstr "Administração - Empurrador de Senhas"
+msgstr "Administração — Password Pusher"
 
 #: ../../../app/views/layouts/admin.html.erb:53
 msgid "System Active"
-msgstr "Sistema Ativo"
+msgstr "Sistema ativo"
 
 #: ../../../app/views/layouts/admin.html.erb:61
 msgid "Back to App"
@@ -1229,15 +1209,15 @@ msgstr "Voltar ao aplicativo"
 #: ../../../app/views/shared/_header.html.erb:13
 #: ../../../app/views/users/first_runs/new.html.erb:11
 msgid "Password Pusher Logo"
-msgstr "Logotipo do enviardor de senha"
+msgstr "Logotipo do Password Pusher"
 
 #: ../../../app/views/layouts/madmin/application.html.erb:13
 msgid "Data Explorer - Administration - Password Pusher"
-msgstr "Explorador de Dados - Administração - Empurrador de Senhas"
+msgstr "Explorador de Dados — Administração — Password Pusher"
 
 #: ../../../app/views/layouts/madmin/application.html.erb:21
 msgid "Staging Environment"
-msgstr "Ambiente de ensaio"
+msgstr "Ambiente de homologação"
 
 #: ../../../app/views/layouts/madmin/application.html.erb:21
 msgid ""
@@ -1250,7 +1230,7 @@ msgstr ""
 #:
 #: ../../../app/views/layouts/mission_control/jobs/_application_selection.html.erb:20
 msgid "Back to Administration Center"
-msgstr "Voltar ao Centro de Administração"
+msgstr "Voltar à Central de Administração"
 
 #:
 #: ../../../app/views/layouts/mission_control/jobs/_application_selection.html.erb:36
@@ -1262,17 +1242,14 @@ msgstr ""
 #:
 #: ../../../app/views/layouts/mission_control/jobs/_application_selection.html.erb:47
 msgid "What are Background Jobs?"
-msgstr "O que são trabalhos de apoio?"
+msgstr "O que são tarefas em segundo plano?"
 
 #:
 #: ../../../app/views/layouts/mission_control/jobs/_application_selection.html.erb:50
 msgid ""
 "Background jobs handle tasks that run asynchronously without blocking the main"
 " application. In Password Pusher, these include:"
-msgstr ""
-"Tarefas em segundo plano gerenciam tarefas que são executadas de forma assíncr"
-"ona sem bloquear o aplicativo principal. No Password Pusher, essas tarefas inc"
-"luem:"
+msgstr "As tarefas em segundo plano são executadas de forma assíncrona, sem bloquear o aplicativo principal. No Password Pusher, elas incluem:"
 
 #:
 #: ../../../app/views/layouts/mission_control/jobs/_application_selection.html.erb:53
@@ -1282,17 +1259,17 @@ msgstr "Notificações por e-mail"
 #:
 #: ../../../app/views/layouts/mission_control/jobs/_application_selection.html.erb:53
 msgid "Sending push expiration alerts and admin notifications"
-msgstr "Envio de alertas push de expiração e notificações administrativas."
+msgstr "Envio de alertas de expiração de envios e notificações administrativas"
 
 #:
 #: ../../../app/views/layouts/mission_control/jobs/_application_selection.html.erb:54
 msgid "Push cleanup"
-msgstr "Limpeza de empurrões"
+msgstr "Limpeza de envios"
 
 #:
 #: ../../../app/views/layouts/mission_control/jobs/_application_selection.html.erb:54
 msgid "Automatically removing expired pushes from the database"
-msgstr "Remover automaticamente notificações push expiradas do banco de dados."
+msgstr "Remoção automática de envios expirados do banco de dados"
 
 #:
 #: ../../../app/views/layouts/mission_control/jobs/_application_selection.html.erb:55
@@ -1328,7 +1305,7 @@ msgstr ""
 #: ../../../app/views/madmin/application/_form.html.erb:42
 #: ../../../app/views/madmin/users/_form.html.erb:14
 msgid "There was %{count} with your submission:"
-msgstr "Havia %{count} com sua submissão:"
+msgstr "Houve %{count} no envio:"
 
 #: ../../../app/views/madmin/application/_form.html.erb:42
 #: ../../../app/views/madmin/users/_form.html.erb:14
@@ -1378,11 +1355,11 @@ msgstr "Editar"
 
 #: ../../../app/views/madmin/application/edit.html.erb:21
 msgid "Update %{name} information"
-msgstr "Informações de atualização %{name}"
+msgstr "Atualizar informações de %{name}"
 
 #: ../../../app/views/madmin/application/index.html.erb:7
 msgid "Manage %{name} records"
-msgstr "Gerenciar registros %{name}"
+msgstr "Gerenciar registros de %{name}"
 
 #: ../../../app/views/madmin/application/index.html.erb:14
 #: ../../../app/views/madmin/application/new.html.erb:1
@@ -1399,7 +1376,7 @@ msgstr "Pesquisar %{name}..."
 #: ../../../app/views/madmin/application/index.html.erb:27
 #: ../../../app/views/madmin/users/index.html.erb:27
 msgid "Search"
-msgstr "Procurar"
+msgstr "Pesquisar"
 
 #: ../../../app/views/madmin/application/index.html.erb:40
 #: ../../../app/views/madmin/users/index.html.erb:40
@@ -1421,7 +1398,7 @@ msgstr[1] "Visualizações"
 
 #: ../../../app/views/madmin/application/new.html.erb:18
 msgid "Create a new %{name} record"
-msgstr "Criar um novo registro %{name}"
+msgstr "Criar um novo registro de %{name}"
 
 #: ../../../app/views/madmin/application/show.html.erb:19
 msgid "View %{name} details"
@@ -1464,7 +1441,7 @@ msgstr "Desconectado"
 #: ../../../app/views/madmin/dashboard/show.html.erb:27
 #: ../../../app/views/madmin/dashboard/show.html.erb:237
 msgid "Back to Admin Center"
-msgstr "Voltar ao Centro de Administração"
+msgstr "Voltar à Central de Administração"
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:40
 msgid "Direct Database Access"
@@ -1524,11 +1501,11 @@ msgstr ""
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:69
 msgid "Pushes:"
-msgstr "Empurrões:"
+msgstr "Envios:"
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:69
 msgid "Monitor password pushes, view expiration status, and track usage"
-msgstr "Monitore o envio de senhas, visualize o status de expiração e acompanhe o uso."
+msgstr "Monitore envios de senhas, consulte o status de expiração e acompanhe o uso."
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:70
 msgid "Audit Logs:"
@@ -1548,7 +1525,7 @@ msgstr "Suporte ao usuário:"
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:76
 msgid "Impersonate users to troubleshoot issues"
-msgstr "Fingir ser outro usuário para solucionar problemas"
+msgstr "Acessar como outro usuário para solucionar problemas"
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:77
 msgid "Data Cleanup:"
@@ -1556,7 +1533,7 @@ msgstr "Limpeza de dados:"
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:77
 msgid "Remove expired pushes or inactive accounts"
-msgstr "Remova notificações expiradas ou contas inativas."
+msgstr "Remova envios expirados ou contas inativas."
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:78
 msgid "Security Review:"
@@ -1580,11 +1557,11 @@ msgstr "Dados principais"
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:101
 msgid "Manage users, pushes, and audit logs."
-msgstr "Gerencie usuários, notificações push e registros de auditoria."
+msgstr "Gerencie usuários, envios e registros de auditoria."
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:109
 msgid "Users"
-msgstr "Utilizadores"
+msgstr "Usuários"
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:110
 msgid "Manage user accounts and permissions"
@@ -1593,11 +1570,11 @@ msgstr "Gerenciar contas de usuário e permissões"
 #: ../../../app/views/madmin/dashboard/show.html.erb:124
 #: ../../../app/views/pushes/index.html.erb:29
 msgid "Pushes"
-msgstr "Empurra"
+msgstr "Envios"
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:125
 msgid "View and manage pushes"
-msgstr "Visualizar e gerenciar notificações push"
+msgstr "Visualize e gerencie envios"
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:139
 msgid "Audit Logs"
@@ -1637,11 +1614,11 @@ msgstr "Ações rápidas"
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:245
 msgid "Admin Management"
-msgstr "Gestão Administrativa"
+msgstr "Gerenciamento de administradores"
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:253
 msgid "Go to Application"
-msgstr "Acesse o aplicativo."
+msgstr "Ir para o aplicativo"
 
 #: ../../../app/views/madmin/dashboard/show.html.erb:261
 msgid "Manage Users"
@@ -1657,7 +1634,7 @@ msgstr "O endereço de e-mail para a nova conta de usuário."
 
 #: ../../../app/views/madmin/users/_form.html.erb:51
 msgid "Auto-confirm account"
-msgstr "Confirmação automática da conta"
+msgstr "Confirmar conta automaticamente"
 
 #: ../../../app/views/madmin/users/_form.html.erb:54
 msgid ""
@@ -1670,7 +1647,7 @@ msgstr ""
 
 #: ../../../app/views/madmin/users/_form.html.erb:70
 msgid "Password Information"
-msgstr "Informações de senha"
+msgstr "Informações da senha"
 
 #: ../../../app/views/madmin/users/_form.html.erb:72
 msgid ""
@@ -1699,7 +1676,7 @@ msgstr ""
 
 #: ../../../app/views/pages/about.html.erb:13
 msgid "What It Is"
-msgstr "O que é isso?"
+msgstr "O que é"
 
 #: ../../../app/views/pages/about.html.erb:15
 msgid ""
@@ -1719,13 +1696,11 @@ msgstr ""
 msgid ""
 "It is open source, free to use and modify, and designed to be self-hosted so y"
 "our data never leaves your infrastructure."
-msgstr ""
-"É de código aberto, gratuito para usar e modificar, e projetado para ser auto-"
-"hospedado, de forma que seus dados nunca saiam da sua infraestrutura."
+msgstr "É um software de código aberto, gratuito para uso e modificação, projetado para hospedagem própria, garantindo que seus dados nunca saiam da sua infraestrutura."
 
 #: ../../../app/views/pages/about.html.erb:23
 msgid "The Story"
-msgstr "A História"
+msgstr "A história"
 
 #: ../../../app/views/pages/about.html.erb:25
 msgid ""
@@ -1791,9 +1766,7 @@ msgstr "URLs"
 
 #: ../../../app/views/pages/about.html.erb:56
 msgid "Send links that redirect only after the recipient opens the push."
-msgstr ""
-"Envie links que redirecionem somente depois que o destinatário abrir a notific"
-"ação push."
+msgstr "Envie links que redirecionam somente depois que o destinatário abrir o envio."
 
 #: ../../../app/views/pages/about.html.erb:64
 #: ../../../app/views/shared/_topnav.html.erb:11
@@ -1818,9 +1791,7 @@ msgstr "Gere códigos QR com prazo de validade para credenciais ou links."
 msgid ""
 "Optional passphrase protection, view/expiration limits, optional deletion by v"
 "iewer, JSON API, and more. See the"
-msgstr ""
-"Proteção opcional por senha, limites de visualização/expiração, exclusão opcio"
-"nal pelo visualizador, API JSON e muito mais. Consulte o"
+msgstr "Proteção opcional por frase secreta, limites de visualização e expiração, exclusão opcional pelo visualizador, API JSON e muito mais. Consulte a"
 
 #: ../../../app/views/pages/about.html.erb:81
 msgid "documentation"
@@ -1918,7 +1889,7 @@ msgstr "Para notícias e atualizações,"
 
 #: ../../../app/views/pages/about.html.erb:140
 msgid "follow on X"
-msgstr "seguir em X"
+msgstr "siga no X"
 
 #: ../../../app/views/pages/about.html.erb:142
 msgid "subscribe to the newsletter"
@@ -1954,7 +1925,7 @@ msgstr "De propriedade privada, sem dívidas e financeiramente responsável"
 
 #: ../../../app/views/pages/about.html.erb:158
 msgid "Fanatical customer service and support"
-msgstr "Atendimento e suporte fanáticos ao cliente"
+msgstr "Atendimento e suporte excepcionais ao cliente"
 
 #: ../../../app/views/pages/about.html.erb:159
 msgid "No venture capital pressure—we build for customers, not investors"
@@ -1972,7 +1943,7 @@ msgstr "Fale diretamente com o fundador e a equipe"
 
 #: ../../../app/views/pages/about.html.erb:162
 msgid "15+ years of proven track record with Password Pusher"
-msgstr "mais de 15 anos de histórico comprovado com o Password Pusher"
+msgstr "Mais de 15 anos de histórico comprovado com o Password Pusher"
 
 #: ../../../app/views/pages/about.html.erb:167
 msgid "Want to Help?"
@@ -1980,7 +1951,7 @@ msgstr "Quer ajudar?"
 
 #: ../../../app/views/pages/about.html.erb:169
 msgid "The biggest help is to spread the word."
-msgstr "A melhor ajuda é divulgar a informação."
+msgstr "A melhor forma de ajudar é divulgar o projeto."
 
 #: ../../../app/views/pages/about.html.erb:170
 msgid "Share Password Pusher with colleagues and friends."
@@ -2024,7 +1995,7 @@ msgstr ""
 
 #: ../../../app/views/pages/about.html.erb:192
 msgid "PowerPoint"
-msgstr "Power Point"
+msgstr "PowerPoint"
 
 #: ../../../app/views/pages/about.html.erb:193
 msgid "and"
@@ -2032,7 +2003,7 @@ msgstr "e"
 
 #: ../../../app/views/pages/about.html.erb:194
 msgid "Keynote"
-msgstr "Palestrante principal"
+msgstr "Keynote"
 
 #: ../../../app/views/pages/about.html.erb:195
 msgid "formats. For questions or assets, reach out via the links above."
@@ -2050,9 +2021,7 @@ msgstr "API v2"
 msgid ""
 "Complete JSON API documentation for creating, retrieving and managing pushes i"
 "n the open-source edition."
-msgstr ""
-"Documentação completa da API JSON para criar, recuperar e gerenciar notificaçõ"
-"es push na versão de código aberto."
+msgstr "Documentação completa da API JSON para criar, recuperar e gerenciar envios na edição de código aberto."
 
 #: ../../../app/views/pages/api.html.erb:11
 msgid "Authentication"
@@ -2068,11 +2037,11 @@ msgstr "Crie um token de API nas configurações da sua conta em"
 
 #: ../../../app/views/pages/api.html.erb:23
 msgid "Public endpoints:"
-msgstr "Pontos de extremidade públicos:"
+msgstr "Endpoints públicos:"
 
 #: ../../../app/views/pages/api.html.erb:24
 msgid "Authenticated endpoints:"
-msgstr "Pontos de extremidade autenticados:"
+msgstr "Endpoints autenticados:"
 
 #: ../../../app/views/pages/api.html.erb:25
 msgid "Anonymous access setting:"
@@ -2080,9 +2049,7 @@ msgstr "Configuração de acesso anônimo:"
 
 #: ../../../app/views/pages/api.html.erb:25
 msgid "When anonymous pushes are disabled, API endpoints require authentication."
-msgstr ""
-"Quando as notificações anônimas estão desativadas, os endpoints da API exigem "
-"autenticação."
+msgstr "Quando os envios anônimos estão desativados, os endpoints da API exigem autenticação."
 
 #: ../../../app/views/pages/api.html.erb:32
 msgid "Base URL"
@@ -2094,7 +2061,7 @@ msgstr "Todos os endpoints são relativos ao seu host de instalação:"
 
 #: ../../../app/views/pages/api.html.erb:40
 msgid "Version Endpoint"
-msgstr "Ponto final da versão"
+msgstr "Endpoint de versão"
 
 #: ../../../app/views/pages/api.html.erb:42
 msgid ""
@@ -2117,7 +2084,7 @@ msgstr "Exemplo de cURL:"
 
 #: ../../../app/views/pages/api.html.erb:75
 msgid "Features Hash"
-msgstr "Características Hash"
+msgstr "Hash de recursos"
 
 #: ../../../app/views/pages/api.html.erb:77
 msgid "Whether anonymous API usage is allowed (Settings.allow_anonymous)"
@@ -2125,7 +2092,7 @@ msgstr "Se o uso anônimo da API é permitido (Settings.allow_anonymous)"
 
 #: ../../../app/views/pages/api.html.erb:78
 msgid "Bearer token authentication support"
-msgstr "Suporte à autenticação por token de portador"
+msgstr "Suporte à autenticação por token Bearer"
 
 #: ../../../app/views/pages/api.html.erb:79
 msgid "Accounts API availability (not available in OSS)"
@@ -2133,7 +2100,7 @@ msgstr "Disponibilidade da API de contas (não disponível no OSS)"
 
 #: ../../../app/views/pages/api.html.erb:80
 msgid "Push creation and management via API"
-msgstr "Criação e gerenciamento de push via API"
+msgstr "Criação e gerenciamento de envios pela API"
 
 #: ../../../app/views/pages/api.html.erb:81
 msgid ""
@@ -2145,27 +2112,27 @@ msgstr ""
 
 #: ../../../app/views/pages/api.html.erb:82
 msgid "File attachments on pushes (Settings.enable_file_pushes)"
-msgstr "Anexos de arquivos em notificações push (Settings.enable_file_pushes)"
+msgstr "Anexos de arquivos em envios (Settings.enable_file_pushes)"
 
 #: ../../../app/views/pages/api.html.erb:83
 msgid "URL push type (Settings.enable_url_pushes)"
-msgstr "Tipo de notificação push de URL (Settings.enable_url_pushes)"
+msgstr "Tipo de envio de URL (Settings.enable_url_pushes)"
 
 #: ../../../app/views/pages/api.html.erb:84
 msgid "QR code push type (Settings.enable_qr_pushes)"
-msgstr "Tipo de notificação push de código QR (Settings.enable_qr_pushes)"
+msgstr "Tipo de envio de código QR (Settings.enable_qr_pushes)"
 
 #: ../../../app/views/pages/api.html.erb:85
 msgid "Requests API availability (not available in OSS)"
-msgstr "Disponibilidade da API Requests (não disponível no OSS)"
+msgstr "Disponibilidade da API de solicitações (não disponível na edição OSS)"
 
 #: ../../../app/views/pages/api.html.erb:91
 msgid "Push Endpoints"
-msgstr "Endpoints de envio"
+msgstr "Endpoints de envios"
 
 #: ../../../app/views/pages/api.html.erb:96
 msgid "Create a new push."
-msgstr "Criar uma nova notificação push."
+msgstr "Criar um novo envio."
 
 #: ../../../app/views/pages/api.html.erb:97
 #: ../../../app/views/pages/api.html.erb:218
@@ -2204,7 +2171,7 @@ msgstr "Sim"
 
 #: ../../../app/views/pages/api.html.erb:109
 msgid "Secret text payload for text, URL or QR pushes."
-msgstr "Texto secreto para notificações push via SMS, URL ou QR Code."
+msgstr "Conteúdo secreto para envios de texto, URL ou código QR."
 
 #: ../../../app/views/pages/api.html.erb:110
 #: ../../../app/views/pages/api.html.erb:111
@@ -2229,15 +2196,11 @@ msgstr "Não"
 msgid ""
 "Files to attach. When present, the push type becomes file unless kind is expli"
 "citly provided."
-msgstr ""
-"Arquivos a serem anexados. Quando presentes, o tipo de envio será \"arquivo\", a"
-" menos que o tipo seja explicitamente fornecido."
+msgstr "Arquivos a serem anexados. Quando presentes, o tipo de envio será \"arquivo\", a menos que o tipo seja informado explicitamente."
 
 #: ../../../app/views/pages/api.html.erb:111
 msgid "Push type: text, file, url, or qr. Defaults to text when not provided."
-msgstr ""
-"Tipo de envio: texto, arquivo, URL ou QR Code. O padrão é texto quando nenhum "
-"tipo é fornecido."
+msgstr "Tipo de envio: texto, arquivo, URL ou código QR. O padrão é texto quando nenhum tipo é informado."
 
 #: ../../../app/views/pages/api.html.erb:112
 msgid "Expiration window in days. If omitted, instance defaults are used."
@@ -2253,7 +2216,7 @@ msgstr ""
 
 #: ../../../app/views/pages/api.html.erb:114
 msgid "Allows the recipient to expire the push."
-msgstr "Permite que o destinatário expire a notificação push."
+msgstr "Permite que o destinatário expire o envio."
 
 #: ../../../app/views/pages/api.html.erb:115
 msgid "Adds an extra retrieval confirmation step."
@@ -2261,7 +2224,7 @@ msgstr "Adiciona uma etapa extra de confirmação de recuperação."
 
 #: ../../../app/views/pages/api.html.erb:116
 msgid "Requires this passphrase to retrieve the payload."
-msgstr "É necessária esta senha para recuperar o conteúdo."
+msgstr "Esta frase secreta é necessária para recuperar o conteúdo."
 
 #: ../../../app/views/pages/api.html.erb:117
 msgid "Optional label shown to the owner."
@@ -2275,24 +2238,19 @@ msgstr "Nota opcional apenas para o proprietário."
 msgid ""
 "Optional recipients for the push creation email. Comma-separated list of email"
 " addresses. Maximum 5 emails. Requires authentication when provided."
-msgstr ""
-"Lista opcional de destinatários para o e-mail de criação da notificação push. "
-"Lista de endereços de e-mail separados por vírgula. Máximo de 5 e-mails. Reque"
-"r autenticação quando fornecida."
+msgstr "Destinatários opcionais para o e-mail de criação do envio. Lista de endereços de e-mail separados por vírgulas. Máximo de 5 e-mails. Requer autenticação quando informada."
 
 #: ../../../app/views/pages/api.html.erb:120
 msgid ""
 "Optional locale for the push creation email. See the list of available locales"
 " in the"
-msgstr ""
-"Localidade opcional para o e-mail de criação da notificação push. Consulte a l"
-"ista de localidades disponíveis em"
+msgstr "Idioma opcional para o e-mail de criação do envio. Consulte a lista de idiomas disponíveis em"
 
 #: ../../../app/views/pages/api.html.erb:120
 #: ../../../app/views/pages/api.html.erb:231
 #: ../../../app/views/pages/api.html.erb:258
 msgid "Supported Locales"
-msgstr "Locais suportados"
+msgstr "Idiomas compatíveis"
 
 #: ../../../app/views/pages/api.html.erb:136
 msgid "cURL example (JSON body):"
@@ -2302,10 +2260,7 @@ msgstr "Exemplo de cURL (corpo JSON):"
 msgid ""
 "Retrieve a push payload by token. This counts as a view and may expire the pus"
 "h when limits are reached."
-msgstr ""
-"Recupere o conteúdo de uma notificação push por meio de um token. Isso conta c"
-"omo uma visualização e pode expirar a notificação quando os limites forem atin"
-"gidos."
+msgstr "Recupere o conteúdo de um envio por token. Isso conta como uma visualização e pode expirar o envio quando os limites forem atingidos."
 
 #: ../../../app/views/pages/api.html.erb:154
 #: ../../../app/views/pages/api.html.erb:173
@@ -2316,23 +2271,19 @@ msgstr "Parâmetros de consulta:"
 
 #: ../../../app/views/pages/api.html.erb:154
 msgid "optional, required when the push is passphrase-protected"
-msgstr "Opcional, obrigatório quando a notificação push estiver protegida por senha."
+msgstr "opcional, obrigatório quando o envio estiver protegido por frase secreta"
 
 #: ../../../app/views/pages/api.html.erb:163
 msgid ""
 "Returns the fully-qualified secret URL for a push without retrieving its paylo"
 "ad."
-msgstr ""
-"Retorna a URL secreta completa de uma notificação push sem recuperar seu conte"
-"údo."
+msgstr "Retorna a URL secreta completa de um envio sem recuperar seu conteúdo."
 
 #: ../../../app/views/pages/api.html.erb:172
 msgid ""
 "Return audit log entries for a push. Authentication and ownership are required"
 "."
-msgstr ""
-"Retorna os registros de auditoria para uma notificação push. Autenticação e co"
-"mprovação de propriedade são necessárias."
+msgstr "Retorna as entradas do registro de auditoria de um envio. Autenticação e propriedade são obrigatórias."
 
 #: ../../../app/views/pages/api.html.erb:173
 #: ../../../app/views/pages/api.html.erb:194
@@ -2344,32 +2295,25 @@ msgstr "Opcional, número inteiro, valor padrão 1, intervalo válido de 1 a 200
 msgid ""
 "Expire a push immediately. Allowed for owners (when authenticated) or for reci"
 "pients when the push was created with deletable_by_viewer enabled."
-msgstr ""
-"Expira uma notificação push imediatamente. Permitido para proprietários (quand"
-"o autenticados) ou para destinatários quando a notificação push foi criada com"
-" a opção `deletable_by_viewer` ativada."
+msgstr "Expira um envio imediatamente. Permitido aos proprietários, quando autenticados, ou aos destinatários quando o envio foi criado com a opção `deletable_by_viewer` habilitada."
 
 #: ../../../app/views/pages/api.html.erb:193
 msgid "List active pushes for the authenticated user."
-msgstr "Liste as notificações push ativas para o usuário autenticado."
+msgstr "Lista os envios ativos do usuário autenticado."
 
 #: ../../../app/views/pages/api.html.erb:204
 msgid "List expired pushes for the authenticated user."
-msgstr "Listar notificações push expiradas para o usuário autenticado."
+msgstr "Lista os envios expirados do usuário autenticado."
 
 #: ../../../app/views/pages/api.html.erb:215
 msgid "Send an email to notify the push creation to the specified recipients."
-msgstr ""
-"Enviar um e-mail para notificar a criação da notificação push aos destinatário"
-"s especificados."
+msgstr "Envia um e-mail para notificar os destinatários especificados sobre a criação do envio."
 
 #: ../../../app/views/pages/api.html.erb:216
 msgid ""
 "Authentication and ownership are required. Only the push owner may send email "
 "notifications."
-msgstr ""
-"Autenticação e comprovação de propriedade são necessárias. Somente o proprietá"
-"rio da conta push pode enviar notificações por e-mail."
+msgstr "Autenticação e propriedade são obrigatórias. Somente o proprietário do envio pode enviar notificações por e-mail."
 
 #: ../../../app/views/pages/api.html.erb:217
 msgid ""
@@ -2415,7 +2359,7 @@ msgstr ""
 
 #: ../../../app/views/pages/api.html.erb:264
 msgid "Locale Code"
-msgstr "Código de localidade"
+msgstr "Código do idioma"
 
 #: ../../../app/views/pages/api.html.erb:265
 msgid "Language"
@@ -2431,7 +2375,7 @@ msgstr "Solicitação bem-sucedida"
 
 #: ../../../app/views/pages/api.html.erb:286
 msgid "Push created or email notification queued"
-msgstr "Push criado ou notificação por e-mail enfileirada"
+msgstr "Envio criado ou notificação por e-mail adicionada à fila"
 
 #: ../../../app/views/pages/api.html.erb:287
 msgid "Invalid request parameters"
@@ -2443,7 +2387,7 @@ msgstr "Autenticação necessária ou token inválido"
 
 #: ../../../app/views/pages/api.html.erb:289
 msgid "Forbidden for current user"
-msgstr "Proibido para o usuário atual"
+msgstr "Acesso proibido para o usuário atual"
 
 #: ../../../app/views/pages/api.html.erb:290
 msgid ""
@@ -2473,7 +2417,7 @@ msgstr "Gerar chave"
 
 #: ../../../app/views/pages/generate_key.html.erb:9
 msgid "Encryption Key Generator"
-msgstr "Gerador de chaves"
+msgstr "Gerador de chave de criptografia"
 
 #: ../../../app/views/pages/generate_key.html.erb:12
 msgid ""
@@ -2536,15 +2480,13 @@ msgstr ""
 
 #: ../../../app/views/pages/generate_key.html.erb:85
 msgid "Reduce Risk"
-msgstr "Reduzir o risco"
+msgstr "Reduza o risco"
 
 #: ../../../app/views/pages/generate_key.html.erb:88
 msgid ""
 "Using short push expirations (e.g., 1 day/1 view) reduces risk even with the d"
 "efault key."
-msgstr ""
-"Usar prazos de expiração curtos para notificações push (por exemplo, 1 dia/1 v"
-"isualização) reduz o risco mesmo com a chave padrão."
+msgstr "Usar prazos curtos de expiração dos envios, por exemplo, 1 dia/1 visualização, reduz o risco mesmo com a chave padrão."
 
 #: ../../../app/views/pages/generate_key.html.erb:98
 msgid "Data Deletion"
@@ -2554,19 +2496,15 @@ msgstr "Exclusão de dados"
 msgid ""
 "Once a push expires, all encrypted data is permanently deleted from the databa"
 "se."
-msgstr ""
-"Após o término de um período de envio, todos os dados criptografados são exclu"
-"ídos permanentemente do banco de dados."
+msgstr "Quando um envio expira, todos os dados criptografados são excluídos permanentemente do banco de dados."
 
 #: ../../../app/views/pages/generate_key.html.erb:111
 msgid "Key Changes"
-msgstr "Principais alterações"
+msgstr "Alterações de chave"
 
 #: ../../../app/views/pages/generate_key.html.erb:114
 msgid "Changing keys makes existing pushes unreadable. New pushes will work normally."
-msgstr ""
-"Alterar as teclas torna as notificações push existentes ilegíveis. Novas notif"
-"icações push funcionarão normalmente."
+msgstr "A alteração das chaves torna os envios existentes ilegíveis. Os novos envios funcionarão normalmente."
 
 #: ../../../app/views/pages/generate_key.html.erb:124
 msgid "Command Line Alternative"
@@ -2580,7 +2518,7 @@ msgstr ""
 
 #: ../../../app/views/pages/generate_key.html.erb:130
 msgid "In your Password Pusher directory"
-msgstr "No seu diretório Password Pusher"
+msgstr "No diretório do Password Pusher"
 
 #: ../../../app/views/pages/generate_key.html.erb:140
 msgid "Learn More"
@@ -2604,7 +2542,7 @@ msgstr ""
 
 #: ../../../app/views/push_created_mailer/notify.html.erb:2
 msgid "%{sender} has sent you a push"
-msgstr "%{sender} enviou uma notificação para você."
+msgstr "%{sender} compartilhou um envio com você"
 
 #: ../../../app/views/push_created_mailer/notify.html.erb:9
 msgid "Secret link:"
@@ -2612,7 +2550,7 @@ msgstr "Link secreto:"
 
 #: ../../../app/views/push_created_mailer/notify.html.erb:11
 msgid "Important Notes:"
-msgstr "Notas Importantes:"
+msgstr "Observações importantes:"
 
 #: ../../../app/views/push_created_mailer/notify.html.erb:13
 msgid ""
@@ -2681,7 +2619,7 @@ msgstr "Salvar"
 #: ../../../app/views/pushes/_qr_form.html.erb:13
 #: ../../../app/views/pushes/_url_form.html.erb:13
 msgid "Saved!"
-msgstr "Salvou!"
+msgstr "Salvo!"
 
 #: ../../../app/views/pushes/_files_form.html.erb:28
 msgid "Uploaded Files"
@@ -2697,14 +2635,14 @@ msgstr "Adicionar arquivos..."
 
 #: ../../../app/views/pushes/_files_form.html.erb:72
 msgid "You can upload up to %{count} files per push."
-msgstr "Você pode enviar até %{count} arquivos por push."
+msgstr "Você pode enviar até %{count} arquivos por envio."
 
 #: ../../../app/views/pushes/_files_form.html.erb:76
 #: ../../../app/views/pushes/_form.html.erb:83
 #: ../../../app/views/pushes/_qr_form.html.erb:73
 #: ../../../app/views/pushes/_url_form.html.erb:44
 msgid "Expire secret link and delete after:"
-msgstr "Expirar o link secreto e excluir após:"
+msgstr "Expirar e excluir o link secreto após:"
 
 #: ../../../app/views/pushes/_files_form.html.erb:110
 #: ../../../app/views/pushes/_form.html.erb:116
@@ -2720,23 +2658,21 @@ msgstr "(o que ocorrer primeiro)"
 #: ../../../app/views/pushes/_url_form.html.erb:84
 #: ../../../app/views/pushes/audit.html.erb:76
 msgid "Passphrase"
-msgstr "Bloqueio de senha"
+msgstr "Frase secreta"
 
 #: ../../../app/views/pushes/_files_form.html.erb:118
 #: ../../../app/views/pushes/_form.html.erb:124
 #: ../../../app/views/pushes/_qr_form.html.erb:114
 #: ../../../app/views/pushes/_url_form.html.erb:87
 msgid "Optional: Require recipients to enter a passphrase to view this push"
-msgstr ""
-"Opcional: exigir que os destinatários insiram uma senha para visualizar este p"
-"ush"
+msgstr "Opcional: exija que os destinatários informem uma frase secreta para visualizar este envio"
 
 #: ../../../app/views/pushes/_files_form.html.erb:129
 #: ../../../app/views/pushes/_form.html.erb:135
 #: ../../../app/views/pushes/_qr_form.html.erb:126
 #: ../../../app/views/pushes/_url_form.html.erb:99
 msgid "Use a 1-click retrieval step"
-msgstr "Use a etapa de recuperação em 1-clique"
+msgstr "Usar uma etapa de recuperação com um clique"
 
 #: ../../../app/views/pushes/_files_form.html.erb:130
 #: ../../../app/views/pushes/_form.html.erb:136
@@ -2757,7 +2693,7 @@ msgstr "Permitir exclusão imediata"
 #: ../../../app/views/pushes/_form.html.erb:145
 #: ../../../app/views/pushes/_qr_form.html.erb:137
 msgid "Allow users to delete this push once retrieved."
-msgstr "Permita que os usuários excluam este push depois de recuperado."
+msgstr "Permita que os usuários excluam este envio após acessá-lo."
 
 #: ../../../app/views/pushes/_files_form.html.erb:148
 #: ../../../app/views/pushes/_form.html.erb:154
@@ -2790,11 +2726,11 @@ msgstr "Mensagem"
 
 #: ../../../app/views/pushes/_files_form.html.erb:169
 msgid "Optional: A message to be included with the push"
-msgstr "Opcional: Uma mensagem a ser incluída com o push"
+msgstr "Opcional: uma mensagem a ser incluída no envio"
 
 #: ../../../app/views/pushes/_files_form.html.erb:173
 msgid "Encrypted and visible to the receiving party"
-msgstr "Criptografado e visível para a parte receptora"
+msgstr "Criptografado e visível para o destinatário"
 
 #: ../../../app/views/pushes/_files_form.html.erb:178
 #: ../../../app/views/pushes/_form.html.erb:171
@@ -2815,14 +2751,12 @@ msgstr "Criptografado e visível apenas para você"
 msgid ""
 "Once expired, all files and content of the push will be deleted immediately an"
 "d entirely."
-msgstr ""
-"Depois de expirado, todos os arquivos e conteúdo do push serão excluídos imedi"
-"atamente e totalmente."
+msgstr "Após a expiração, todos os arquivos e o conteúdo do envio serão excluídos imediatamente e por completo."
 
 #: ../../../app/views/pushes/_files_form.html.erb:190
 #: ../../../app/views/pushes/_url_form.html.erb:138
 msgid "An audit log of activity will be available."
-msgstr "Um log de auditoria da atividade estará disponível."
+msgstr "Um registro de auditoria das atividades estará disponível."
 
 #: ../../../app/views/pushes/_files_form.html.erb:199
 #: ../../../app/views/pushes/_form.html.erb:192
@@ -2836,21 +2770,21 @@ msgstr "Atualizando..."
 #: ../../../app/views/pushes/_qr_form.html.erb:184
 #: ../../../app/views/pushes/_url_form.html.erb:147
 msgid "Update Push"
-msgstr "Atualização Push"
+msgstr "Atualizar envio"
 
 #: ../../../app/views/pushes/_files_form.html.erb:201
 #: ../../../app/views/pushes/_form.html.erb:194
 #: ../../../app/views/pushes/_qr_form.html.erb:186
 #: ../../../app/views/pushes/_url_form.html.erb:149
 msgid "Pushing..."
-msgstr "Empurrando..."
+msgstr "Enviando..."
 
 #: ../../../app/views/pushes/_files_form.html.erb:201
 #: ../../../app/views/pushes/_form.html.erb:194
 #: ../../../app/views/pushes/_qr_form.html.erb:186
 #: ../../../app/views/pushes/_url_form.html.erb:149
 msgid "Push It!"
-msgstr "Envie!"
+msgstr "Enviar!"
 
 #: ../../../app/views/pushes/_form.html.erb:1
 msgid "Securely Send a Password"
@@ -2870,7 +2804,7 @@ msgstr "Digite a senha ou o texto para enviar..."
 #: ../../../app/views/pushes/_qr_form.html.erb:49
 #: ../../../app/views/shared/_pw_generator_modal.html.erb:55
 msgid "Characters"
-msgstr "Caracteres "
+msgstr "Caracteres"
 
 #: ../../../app/views/pushes/_form.html.erb:66
 #: ../../../app/views/pushes/_qr_form.html.erb:56
@@ -2921,13 +2855,11 @@ msgstr "Insira até 1024 caracteres..."
 msgid ""
 "Please obtain and securely store this content in a secure manner, such as in a"
 " password manager."
-msgstr ""
-"Obtenha e armazene esse conteúdo de maneira segura, como em um gerenciador de "
-"senhas."
+msgstr "Salve este conteúdo de forma segura, por exemplo, em um gerenciador de senhas."
 
 #: ../../../app/views/pushes/_show_payload.html.erb:4
 msgid "Your password is blurred out.  Click below to reveal it."
-msgstr "Sua senha está borrada. Clique abaixo para revelá-la."
+msgstr "Sua senha está desfocada. Clique abaixo para revelá-la."
 
 #: ../../../app/views/pushes/_url_form.html.erb:1
 msgid "Securely Send URLs"
@@ -2939,7 +2871,7 @@ msgstr "Redirecionamento de URL"
 
 #: ../../../app/views/pushes/_url_form.html.erb:30
 msgid "Enter the URL to redirect to..."
-msgstr "Digite a URL para redirecionar para..."
+msgstr "Digite a URL de destino..."
 
 #: ../../../app/views/pushes/_url_form.html.erb:100
 msgid "Helps to avoid chat systems and URL scanners from eating up redirects."
@@ -2953,7 +2885,7 @@ msgstr "Será gerada uma URL secreta que redirecionará para a URL especificada.
 
 #: ../../../app/views/pushes/_url_form.html.erb:138
 msgid "Upon expiration, the push URL will be deleted entirely."
-msgstr "Após a expiração, o URL push será totalmente excluído."
+msgstr "Ao expirar, a URL do envio será excluída permanentemente."
 
 #: ../../../app/views/pushes/audit.html.erb:1
 msgid "Audit Log for %{push_id}"
@@ -2967,11 +2899,11 @@ msgstr "Registro de Auditoria"
 
 #: ../../../app/views/pushes/audit.html.erb:7
 msgid "Pushed on"
-msgstr "Empurrado"
+msgstr "Enviado em"
 
 #: ../../../app/views/pushes/audit.html.erb:10
 msgid "Secret URL for this push"
-msgstr "URL secreta para esse push"
+msgstr "URL secreta deste envio"
 
 #: ../../../app/views/pushes/audit.html.erb:16
 msgid "Reference Note"
@@ -2988,19 +2920,19 @@ msgstr "Configurações"
 #: ../../../app/views/pushes/audit.html.erb:34
 #: ../../../app/views/pushes/audit.html.erb:42
 msgid "Expire after"
-msgstr "Expirar depois"
+msgstr "Expirar após"
 
 #: ../../../app/views/pushes/audit.html.erb:36
 msgid "The push expires after this number of views."
-msgstr "O push expira após esse número de visualizações."
+msgstr "O envio expira após esse número de visualizações."
 
 #: ../../../app/views/pushes/audit.html.erb:44
 msgid "The push expires after this number of days."
-msgstr "O push expira após esse número de dias."
+msgstr "O envio expira após esse número de dias."
 
 #: ../../../app/views/pushes/audit.html.erb:51
 msgid "Deletable by Viewers"
-msgstr "Delatável pelos viewers"
+msgstr "Exclusão pelos visualizadores"
 
 #: ../../../app/views/pushes/audit.html.erb:57
 msgid "This allows end users to delete content once retrieved."
@@ -3008,11 +2940,11 @@ msgstr "Isso permite que os usuários finais excluam o conteúdo depois de recup
 
 #: ../../../app/views/pushes/audit.html.erb:64
 msgid "1-click Retrieval Step"
-msgstr "Etapa de recuperação com 1 clique"
+msgstr "Etapa de recuperação com um clique"
 
 #: ../../../app/views/pushes/audit.html.erb:82
 msgid "Require recipients to enter a passphrase to view this push."
-msgstr "Exija que os destinatários insiram uma senha para visualizar este push."
+msgstr "Exija que os destinatários informem uma frase secreta para visualizar este envio."
 
 #: ../../../app/views/pushes/audit.html.erb:88
 msgid "Current Status"
@@ -3037,15 +2969,15 @@ msgstr "Visualizações bem-sucedidas"
 
 #: ../../../app/views/pushes/audit.html.erb:107
 msgid "The number of times this push has been viewed before expiration."
-msgstr "O número de vezes que este push foi visualizado antes da expiração."
+msgstr "Número de vezes que este envio foi visualizado antes de expirar."
 
 #: ../../../app/views/pushes/audit.html.erb:113
 msgid "Failed View Attempts"
-msgstr "Tentativas de visualização com falhas"
+msgstr "Tentativas de visualização malsucedidas"
 
 #: ../../../app/views/pushes/audit.html.erb:114
 msgid "The number of times this push has been viewed after expiration."
-msgstr "O número de vezes que este push foi visualizado após a expiração."
+msgstr "Número de tentativas de visualização deste envio após a expiração."
 
 #: ../../../app/views/pushes/audit.html.erb:120
 msgid "Days Remaining"
@@ -3055,13 +2987,11 @@ msgstr "Dias restantes"
 msgid ""
 "Number of days until this push expires if the maximum view count isn't reached"
 "."
-msgstr ""
-"Número de dias até a expiração desse push, caso a quantidade máxima de visuali"
-"zações não for atingida."
+msgstr "Número de dias até este envio expirar, caso o limite máximo de visualizações não seja atingido."
 
 #: ../../../app/views/pushes/audit.html.erb:131
 msgid "Payload"
-msgstr "Carga útil"
+msgstr "Conteúdo"
 
 #: ../../../app/views/pushes/audit.html.erb:136
 msgid "Contains Message for Receiver"
@@ -3074,11 +3004,11 @@ msgstr "Excluído"
 
 #: ../../../app/views/pushes/audit.html.erb:144
 msgid "Has a text payload been added to this push?"
-msgstr "Uma carga útil de texto foi adicionada a este push?"
+msgstr "Foi adicionado conteúdo de texto a este envio?"
 
 #: ../../../app/views/pushes/audit.html.erb:150
 msgid "Message Length"
-msgstr "Comprimento da mensagem"
+msgstr "Tamanho da mensagem"
 
 #: ../../../app/views/pushes/audit.html.erb:154
 msgid "Not Applicable"
@@ -3086,7 +3016,7 @@ msgstr "Não aplicável"
 
 #: ../../../app/views/pushes/audit.html.erb:158
 msgid "The length of the attached text payload."
-msgstr "O comprimento da carga de texto anexada."
+msgstr "O tamanho do conteúdo de texto anexado."
 
 #: ../../../app/views/pushes/audit.html.erb:164
 msgid "Number of Files Attached"
@@ -3094,7 +3024,7 @@ msgstr "Número de arquivos anexados"
 
 #: ../../../app/views/pushes/audit.html.erb:170
 msgid "The number of files attached to this push. This value will be 0 when expired."
-msgstr "O número de arquivos anexados a este push. Este valor será 0 quando expirado."
+msgstr "Número de arquivos anexados a este envio. Este valor será 0 após a expiração."
 
 #: ../../../app/views/pushes/audit.html.erb:176
 #: ../../../app/views/pushes/show.html.erb:28
@@ -3112,7 +3042,7 @@ msgstr "Todos os arquivos anexados foram excluídos."
 #: ../../../app/views/pushes/audit.html.erb:201
 #: ../../../app/views/pushes/edit.html.erb:1
 msgid "Edit Push"
-msgstr "Editar Push"
+msgstr "Editar envio"
 
 #: ../../../app/views/pushes/audit.html.erb:204
 msgid "Expire Now"
@@ -3120,11 +3050,11 @@ msgstr "Expirar agora"
 
 #: ../../../app/views/pushes/audit.html.erb:212
 msgid "Delete This Push?"
-msgstr "Excluir este push?"
+msgstr "Excluir este envio?"
 
 #: ../../../app/views/pushes/audit.html.erb:216
 msgid "This will expire this secret link and"
-msgstr "Isso irá expirar este link secreto e"
+msgstr "Isso fará este link secreto expirar e"
 
 #: ../../../app/views/pushes/audit.html.erb:216
 msgid "remove all content from the database forever"
@@ -3134,9 +3064,7 @@ msgstr "remover todo o conteúdo do banco de dados para sempre"
 msgid ""
 "The audit log (including future attempted views) will still be maintained goin"
 "g forward."
-msgstr ""
-"O log de auditoria (incluindo tentativas de visualizações futuras) será mantid"
-"o daqui para frente."
+msgstr "O registro de auditoria, incluindo futuras tentativas de visualização, continuará sendo mantido."
 
 #: ../../../app/views/pushes/audit.html.erb:234
 msgid "Activity Log"
@@ -3146,13 +3074,11 @@ msgstr "Registro de atividades"
 msgid ""
 "As the push receives activity, a log of each with identifying information will"
 " show up here."
-msgstr ""
-"À medida que o push recebe atividade, um log de cada um com informações de ide"
-"ntificação aparecerá aqui."
+msgstr "À medida que o envio recebe atividades, cada evento aparecerá aqui com suas informações de identificação."
 
 #: ../../../app/views/pushes/edit.html.erb:6
 msgid "Editing Push"
-msgstr "Impulso de edição"
+msgstr "Editando envio"
 
 #: ../../../app/views/pushes/index.html.erb:1
 #: ../../../app/views/shared/_dashboard_header.html.erb:5
@@ -3162,25 +3088,23 @@ msgstr "Painel"
 
 #: ../../../app/views/pushes/index.html.erb:13
 msgid "No active pushes"
-msgstr "Sem notificações ativas"
+msgstr "Nenhum envio ativo"
 
 #: ../../../app/views/pushes/index.html.erb:15
 msgid "No expired pushes"
-msgstr "Sem notificações expiradas"
+msgstr "Nenhum envio expirado"
 
 #: ../../../app/views/pushes/index.html.erb:17
 msgid "No pushes yet"
-msgstr "Ainda não há nenhum empurrão."
+msgstr "Nenhum envio ainda"
 
 #: ../../../app/views/pushes/index.html.erb:21
 msgid "Create your first secure push to share passwords, files, or URLs."
-msgstr ""
-"Crie sua primeira notificação push segura para compartilhar senhas, arquivos o"
-"u URLs."
+msgstr "Crie seu primeiro envio seguro para compartilhar senhas, arquivos ou URLs."
 
 #: ../../../app/views/pushes/index.html.erb:24
 msgid "Create Your First Push"
-msgstr "Dê o seu primeiro impulso"
+msgstr "Criar seu primeiro envio"
 
 #: ../../../app/views/pushes/index.html.erb:32
 msgid "Name / ID"
@@ -3212,7 +3136,7 @@ msgstr "%{views}v / %{days}d"
 
 #: ../../../app/views/pushes/index.html.erb:98
 msgid "Push Controls"
-msgstr "Controles de envio"
+msgstr "Controles do envio"
 
 #: ../../../app/views/pushes/index.html.erb:100
 #: ../../../app/views/shared/_pw_generator_modal.html.erb:10
@@ -3225,15 +3149,15 @@ msgstr "Envie com segurança uma senha, texto ou arquivo"
 
 #: ../../../app/views/pushes/passphrase.html.erb:1
 msgid "Enter The Secret Passphrase"
-msgstr "Digite a senha secreta"
+msgstr "Digite a frase secreta"
 
 #: ../../../app/views/pushes/passphrase.html.erb:12
 msgid "Enter the secret passphrase provided with this URL"
-msgstr "Digite a senha secreta fornecida com este URL"
+msgstr "Digite a frase secreta fornecida com esta URL"
 
 #: ../../../app/views/pushes/passphrase.html.erb:13
 msgid "Enter the secret passphrase"
-msgstr "Digite a senha secreta"
+msgstr "Digite a frase secreta"
 
 #: ../../../app/views/pushes/passphrase.html.erb:17
 msgid "Go"
@@ -3245,17 +3169,15 @@ msgstr "Clique aqui para prosseguir"
 
 #: ../../../app/views/pushes/preview.html.erb:1
 msgid "Push Preview"
-msgstr "Pré-visualização Push"
+msgstr "Pré-visualização do envio"
 
 #: ../../../app/views/pushes/preview.html.erb:10
 msgid "Push Created"
-msgstr "Empurrão criado"
+msgstr "Envio criado"
 
 #: ../../../app/views/pushes/preview.html.erb:12
 msgid "Copy the link or message below to share this push securely."
-msgstr ""
-"Copie o link ou a mensagem abaixo para compartilhar esta notificação com segur"
-"ança."
+msgstr "Copie o link ou a mensagem abaixo para compartilhar este envio com segurança."
 
 #: ../../../app/views/pushes/preview.html.erb:28
 msgid "QR code"
@@ -3295,11 +3217,11 @@ msgstr "Expira quando o primeiro limite for atingido."
 
 #: ../../../app/views/pushes/preview.html.erb:83
 msgid "Viewers can delete this push."
-msgstr "Os espectadores podem excluir esta notificação."
+msgstr "Os visualizadores podem excluir este envio."
 
 #: ../../../app/views/pushes/preview.html.erb:85
 msgid "Viewers cannot delete this push."
-msgstr "Os visualizadores não podem excluir esta notificação."
+msgstr "Os visualizadores não podem excluir este envio."
 
 #: ../../../app/views/pushes/preview.html.erb:91
 msgid "Includes a"
@@ -3311,13 +3233,13 @@ msgstr "Etapa de recuperação preliminar com 1 clique"
 
 #: ../../../app/views/pushes/preview.html.erb:103
 msgid "View This Push"
-msgstr "Veja esta notificação"
+msgstr "Visualizar este envio"
 
 #: ../../../app/views/pushes/preview.html.erb:107
 #: ../../../app/views/pushes/preview.html.erb:111
 #: ../../../app/views/pushes/preview.html.erb:115
 msgid "Push Another"
-msgstr "empurre outro"
+msgstr "Criar outro envio"
 
 #: ../../../app/views/pushes/preview.html.erb:128
 #: ../../../app/views/pushes/preview.html.erb:142
@@ -3349,7 +3271,7 @@ msgstr "Enviar e-mails"
 msgid ""
 "Tip: Change the secret link language using the dropdown to the right of the UR"
 "L."
-msgstr "Dica: Altere o idioma do link secreto usando o menu suspenso à direita do URL."
+msgstr "Dica: altere o idioma do link secreto usando o menu suspenso à direita da URL."
 
 #: ../../../app/views/pushes/preview.html.erb:183
 msgid ""
@@ -3361,11 +3283,11 @@ msgstr ""
 
 #: ../../../app/views/pushes/print_preview.html.erb:1
 msgid "Your Secret URL"
-msgstr "Seu URL secreto"
+msgstr "Sua URL secreta"
 
 #: ../../../app/views/pushes/print_preview.html.erb:12
 msgid "This data contained here will expire after"
-msgstr "Esses dados contidos aqui expirarão após"
+msgstr "Os dados contidos aqui expirarão após"
 
 #: ../../../app/views/pushes/show.html.erb:1
 msgid "Your Secret Link"
@@ -3385,7 +3307,7 @@ msgstr "A seguinte mensagem foi enviada para você junto com os arquivos abaixo.
 
 #: ../../../app/views/pushes/show.html.erb:15
 msgid "The message is blurred out.  Click below to reveal it."
-msgstr "A mensagem está borrada. Clique abaixo para revelá-lo."
+msgstr "A mensagem está desfocada. Clique abaixo para revelá-la."
 
 #: ../../../app/views/pushes/show.html.erb:41
 #: ../../../app/views/pushes/show.html.erb:75
@@ -3395,7 +3317,7 @@ msgstr "Este link secreto e todo o conteúdo serão excluídos em"
 #: ../../../app/views/pushes/show.html.erb:46
 #: ../../../app/views/pushes/show.html.erb:80
 msgid "0 more views"
-msgstr "mais 0 visualizações"
+msgstr "0 visualizações restantes"
 
 #: ../../../app/views/pushes/show.html.erb:47
 #: ../../../app/views/pushes/show.html.erb:81
@@ -3406,13 +3328,13 @@ msgstr "(esta é a última visualização)."
 #: ../../../app/views/pushes/show.html.erb:84
 msgid "more view"
 msgid_plural "more views"
-msgstr[0] "mais visualização"
-msgstr[1] "mais visualizações"
+msgstr[0] "visualização restante"
+msgstr[1] "visualizações restantes"
 
 #: ../../../app/views/pushes/show.html.erb:51
 #: ../../../app/views/pushes/show.html.erb:85
 msgid "(whichever occurs first)."
-msgstr "(o que quer que ocorra primeiro)."
+msgstr "(o que ocorrer primeiro)."
 
 #: ../../../app/views/pushes/show.html.erb:57
 #: ../../../app/views/pushes/show.html.erb:90
@@ -3425,11 +3347,11 @@ msgstr "Excluir?"
 
 #: ../../../app/views/pushes/show.html.erb:113
 msgid "This will expire this secret link and "
-msgstr "Isso irá expirar este link secreto e"
+msgstr "Isso fará este link secreto expirar e "
 
 #: ../../../app/views/pushes/show.html.erb:114
 msgid "delete all related content from the database forever"
-msgstr "exclua todo o conteúdo relacionado do banco de dados para sempre"
+msgstr "excluir permanentemente todo o conteúdo relacionado do banco de dados"
 
 #: ../../../app/views/pushes/show_expired.html.erb:1
 msgid "Your Secret Link Has Expired"
@@ -3449,7 +3371,7 @@ msgstr ""
 
 #: ../../../app/views/shared/_additional_options.html.erb:3
 msgid "Additional Options"
-msgstr "Opções Adicionais"
+msgstr "Opções adicionais"
 
 #: ../../../app/views/shared/_additional_options.html.erb:13
 msgid "Show / Hide"
@@ -3465,21 +3387,18 @@ msgstr ""
 
 #: ../../../app/views/shared/_dashboard_header.html.erb:9
 msgid "Filter pushes"
-msgstr "Filtros empurram"
+msgstr "Filtrar envios"
 
 #: ../../../app/views/shared/_dashboard_header.html.erb:22
 msgid "New Push"
-msgstr "Novo impulso"
+msgstr "Novo envio"
 
 #: ../../../app/views/shared/_delete_user_button.html.erb:6
 msgid ""
 "⚠️ WARNING: Deleting %{email} will also permanently delete ALL %{count} push(e"
 "s) created by this user. This action cannot be undone. Are you sure you want t"
 "o proceed?"
-msgstr ""
-"⚠️ AVISO: Excluir %{email} também excluirá permanentemente TODAS as notificaçõ"
-"es push %{count} criadas por este usuário. Esta ação não pode ser desfeita. Te"
-"m certeza de que deseja prosseguir?"
+msgstr "⚠️ AVISO: excluir %{email} também excluirá permanentemente TODOS os %{count} envios criados por este usuário. Esta ação não pode ser desfeita. Tem certeza de que deseja continuar?"
 
 #: ../../../app/views/shared/_footer.html.erb:27
 msgid "About"
@@ -3503,11 +3422,11 @@ msgstr "Sair"
 
 #: ../../../app/views/shared/_header.html.erb:68
 msgid "Log In"
-msgstr "Conecte-se"
+msgstr "Entrar"
 
 #: ../../../app/views/shared/_header.html.erb:71
 msgid "Sign Up"
-msgstr "Inscreva-se"
+msgstr "Criar conta"
 
 #: ../../../app/views/shared/_notify_emails_to.html.erb:4
 msgid "Auto-Dispatch: Send Secret Link To"
@@ -3568,7 +3487,7 @@ msgstr "Comprimento mínimo da sílaba"
 
 #: ../../../app/views/shared/_pw_generator_modal.html.erb:32
 msgid "Maximum Syllable Length"
-msgstr "Comprimento Máximo da Sílaba"
+msgstr "Comprimento máximo da sílaba"
 
 #: ../../../app/views/shared/_pw_generator_modal.html.erb:37
 msgid "Options"
@@ -3580,7 +3499,7 @@ msgstr "Incluir números"
 
 #: ../../../app/views/shared/_pw_generator_modal.html.erb:44
 msgid "Use Titlecase"
-msgstr "Usar caixa de título"
+msgstr "Usar iniciais maiúsculas"
 
 #: ../../../app/views/shared/_pw_generator_modal.html.erb:48
 msgid "Use Separators"
@@ -3600,7 +3519,7 @@ msgstr "Consoantes"
 
 #: ../../../app/views/shared/_pw_generator_modal.html.erb:79
 msgid "Reset to Defaults"
-msgstr "Redefinir para padrões"
+msgstr "Restaurar padrões"
 
 #: ../../../app/views/shared/_share_message.html.erb:5
 msgid "Optional message to share"
@@ -3629,7 +3548,7 @@ msgstr "Códigos QR"
 
 #: ../../../app/views/users/first_runs/new.html.erb:1
 msgid "Password Pusher — First Run Setup"
-msgstr "Password Pusher — Configuração da primeira execução"
+msgstr "Password Pusher — Configuração inicial"
 
 #: ../../../app/views/users/first_runs/new.html.erb:22
 msgid "Open Source Edition"
@@ -3637,7 +3556,7 @@ msgstr "Edição de código aberto"
 
 #: ../../../app/views/users/first_runs/new.html.erb:27
 msgid "First Run Setup"
-msgstr "Configuração da primeira execução"
+msgstr "Configuração inicial"
 
 #: ../../../app/views/users/first_runs/new.html.erb:29
 msgid ""
@@ -3650,7 +3569,7 @@ msgstr ""
 #: ../../../app/views/users/first_runs/new.html.erb:38
 #: ../../../app/views/users/first_runs/new.html.erb:98
 msgid "Create Admin Account"
-msgstr "Criar uma conta"
+msgstr "Criar conta de administrador"
 
 #: ../../../app/views/users/first_runs/new.html.erb:39
 msgid "This account will have full access to manage your Password Pusher instance."
@@ -3658,7 +3577,7 @@ msgstr "Esta conta terá acesso total para gerenciar sua instância do Password 
 
 #: ../../../app/views/users/first_runs/new.html.erb:49
 msgid "Boot Code Required"
-msgstr "Código de inicialização necessário"
+msgstr "Código de inicialização obrigatório"
 
 #: ../../../app/views/users/first_runs/new.html.erb:50
 msgid "Enter the boot code shown in the application logs during startup."
@@ -3673,11 +3592,11 @@ msgstr "Código de inicialização"
 
 #: ../../../app/views/users/first_runs/new.html.erb:93
 msgid "Your account will be created and you'll be signed in automatically."
-msgstr "Sua conta será criada e você entrará automaticamente."
+msgstr "Sua conta será criada e o login será realizado automaticamente."
 
 #: ../../../app/views/users/first_runs/new.html.erb:111
 msgid "How to retrieve the boot code"
-msgstr "Como recuperar o código de inicialização"
+msgstr "Como obter o código de inicialização"
 
 #: ../../../app/views/users/first_runs/new.html.erb:112
 msgid ""
@@ -3755,7 +3674,7 @@ msgstr "Perguntas frequentes"
 
 #: ../../../app/views/users/first_runs/new.html.erb:202
 msgid "Docker images"
-msgstr "imagens Docker"
+msgstr "Imagens Docker"
 
 #: ../../../app/views/users/first_runs/new.html.erb:208
 msgid "JSON API"
@@ -3789,9 +3708,7 @@ msgstr "Verificar"
 msgid ""
 "Two-factor authentication is required by the administrator. You must complete "
 "setup to access the application."
-msgstr ""
-"A autenticação de dois fatores é obrigatória para o administrador. Você precis"
-"a concluir a configuração para acessar o aplicativo."
+msgstr "A autenticação de dois fatores é exigida pelo administrador. Conclua a configuração para acessar o aplicativo."
 
 #: ../../../app/views/users/two_factor/backup_codes.html.erb:1
 #: ../../../app/views/users/two_factor/backup_codes.html.erb:6
@@ -3831,7 +3748,7 @@ msgstr "total"
 #: ../../../app/views/users/two_factor/backup_codes.html.erb:41
 #: ../../../app/views/users/two_factor/backup_codes.html.erb:42
 msgid "Copy all codes"
-msgstr "Copie todos os códigos"
+msgstr "Copiar todos os códigos"
 
 #: ../../../app/views/users/two_factor/backup_codes.html.erb:46
 msgid ""
@@ -3843,7 +3760,7 @@ msgstr ""
 
 #: ../../../app/views/users/two_factor/backup_codes.html.erb:52
 msgid "Continue to verify"
-msgstr "Continue a verificar"
+msgstr "Continuar para a verificação"
 
 #: ../../../app/views/users/two_factor/verify.html.erb:1
 msgid "Verify authenticator"
@@ -3867,4 +3784,4 @@ msgstr "Se não conseguir digitalizar o código, insira esta chave secreta manua
 
 #: ../../../app/views/users/two_factor/verify.html.erb:23
 msgid "Enable two-factor authentication"
-msgstr "Habilitar autenticação de dois fatores"
+msgstr "Ativar autenticação de dois fatores"


### PR DESCRIPTION
* Corrects literal, inaccurate, and unnatural translations
* Standardizes the term "push" as "envio" throughout the Brazilian Portuguese locale
* Adjusts terminology and phrasing for Brazilian Portuguese
* Improves message clarity, grammar, consistency, and readability
* Preserves translation placeholders and the original `msgid` structure

## Description

This pull request improves the Brazilian Portuguese (`pt-BR`) translation file.

Several strings contained literal or contextually incorrect translations, especially occurrences of the term "push", which had been translated inconsistently as terms such as "empurrão", "impulso", and "notificação push".

The translations were reviewed and standardized to use "envio", which better represents the meaning of "push" within the Password Pusher interface.

Only the translated `msgstr` entries were updated. Source strings, identifiers, comments, references, and interpolation variables were preserved.

## Related Issue

No related issue.

## Type of Change

* [ ] 📦 Dependency & security updates
* [x] 🔧 Bug fix (non-breaking change which fixes an issue)
* [x] 🥂 Improvement (non-breaking change which improves an existing feature)
* [ ] 🚀 New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
* [ ] 🔐 Security fix
* [ ] 📚 Examples / documentation / tutorials

## Checklist

* [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
* [x] I've added documentation as necessary so users can easily use and understand this feature/fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Locale-only `msgstr` updates with no runtime logic changes; low risk aside from verifying UI strings read correctly in context.
> 
> **Overview**
> Updates **only** `msgstr` entries in `config/locales/gettext/pt_BR/app.po` for Brazilian Portuguese UI strings—no source `msgid` or application code changes.
> 
> The main change is **terminology**: product “push” is standardized as **“envio”** instead of inconsistent terms like “empurrão”, “impulso”, and “notificação push”. Related wording shifts include **“frase secreta”** for passphrase (replacing “senha” in that context), **“conteúdo”** for payload, and clearer admin/API labels (e.g. endpoints, Central de administração).
> 
> Additional edits fix awkward or literal phrasing, tighten grammar, align button/action labels (Entrar, Enviar, Processando…), and keep product name **Password Pusher** where appropriate. Some multi-line `msgstr` blocks are consolidated into single lines without changing meaning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65e618e1f037f67a2ce24863aa33516fbda48e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->