### PR TITLE
Fix tests after language-string sync updated Rails validation copy

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -119,6 +119,15 @@ search:
 ## Consider these keys used:
 ignore_unused:
   - 'devise.*'
+  # Rails uses these internally; i18n-tasks cannot see the references
+  - 'activerecord.attributes.user.*'
+  - 'activerecord.errors.messages.*'
+  - 'datetime.*'
+  - 'errors.messages.*'
+  - 'flash.actions.*'
+  - 'helpers.select.prompt'
+  - 'helpers.submit.submit'
+  - 'number.human.decimal_units.units.*'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,24 +27,34 @@ en:
     distance_in_words:
       about_x_hours:
         one: about %{count} hour
+        other: about %{count} hours
       about_x_months:
         one: about %{count} month
+        other: about %{count} months
       about_x_years:
         one: about %{count} year
+        other: about %{count} years
       almost_x_years:
         one: almost %{count} year
+        other: almost %{count} years
       less_than_x_seconds:
         one: less than %{count} second
+        other: less than %{count} seconds
       over_x_years:
         one: over %{count} year
+        other: over %{count} years
       x_days:
         one: "%{count} day"
+        other: "%{count} days"
       x_minutes:
         one: "%{count} minute"
+        other: "%{count} minutes"
       x_months:
         one: "%{count} month"
+        other: "%{count} months"
       x_seconds:
         one: "%{count} second"
+        other: "%{count} seconds"
     prompts:
       second: Second
   devise:
@@ -64,9 +74,12 @@ en:
       present: must be left blank
       too_long:
         one: is too long (maximum is %{count} character)
+        other: is too long (maximum is %{count} characters)
       too_short:
         one: is too short (minimum is %{count} character)
+        other: is too short (minimum is %{count} characters)
       wrong_length:
+        one: has an incorrect length (must be %{count} character)
         other: has an incorrect length (must be %{count} characters)
   flash:
     actions:

--- a/test/models/audit_log_test.rb
+++ b/test/models/audit_log_test.rb
@@ -53,7 +53,7 @@ class AuditLogTest < ActiveSupport::TestCase
   test "must belong to a user if creating a notify_by_email" do
     audit_log = AuditLog.new(kind: :creation_email_send, push: @push)
     assert_not audit_log.valid?
-    assert_includes audit_log.errors.full_messages, "User can't be blank"
+    assert_includes audit_log.errors.full_messages, "User cannot be left blank"
 
     audit_log = AuditLog.new(kind: :creation_email_send, push: @push, user: @luca)
     assert audit_log.valid?

--- a/test/models/concerns/pwpush/notifiable_by_email_test.rb
+++ b/test/models/concerns/pwpush/notifiable_by_email_test.rb
@@ -33,7 +33,7 @@ class Pwpush::NotifiableByEmailTest < ActiveSupport::TestCase
     @push.notify_emails_to = nil
 
     assert_not @push.valid?
-    assert_includes @push.errors[:notify_emails_to], "can't be blank"
+    assert_includes @push.errors[:notify_emails_to], "cannot be left blank"
   end
 
   # Test notify_emails_to_locale validation
@@ -59,7 +59,7 @@ class Pwpush::NotifiableByEmailTest < ActiveSupport::TestCase
     @push.notify_emails_to_locale = "invalid_locale"
 
     assert_not @push.valid?
-    assert_includes @push.errors[:notify_emails_to_locale], "is not included in the list"
+    assert_includes @push.errors[:notify_emails_to_locale], "is not within the available options"
   end
 
   # Test notify_by_email_availability validation

--- a/test/models/notify_by_email_test.rb
+++ b/test/models/notify_by_email_test.rb
@@ -69,7 +69,7 @@ class NotifyByEmailTest < ActiveSupport::TestCase
       status: :invalid_status
     )
     assert_not notify.valid?
-    assert_includes notify.errors[:status], "is not included in the list"
+    assert_includes notify.errors[:status], "is not within the available options"
   end
 
   test "default status should be pending" do

--- a/test/system/push_creation_workflows_test.rb
+++ b/test/system/push_creation_workflows_test.rb
@@ -107,7 +107,7 @@ class PushCreationWorkflowsTest < ApplicationSystemTestCase
     # HTML5 validation may prevent submission, or Rails validation may show error
     sleep 1
     # Either we're still on the form page or we see an error
-    assert(page.current_path.include?("new") || page.has_text?(/can't be blank|required/i, wait: 5))
+    assert(page.current_path.include?("new") || page.has_text?(/cannot be left blank|can't be blank|required/i, wait: 5))
   end
 
   # URL Push Creation
@@ -154,7 +154,7 @@ class PushCreationWorkflowsTest < ApplicationSystemTestCase
 
     # Should show validation error or stay on page
     sleep 1
-    assert(page.current_path.include?("new") || page.has_text?(/can't be blank|required/i, wait: 5))
+    assert(page.current_path.include?("new") || page.has_text?(/cannot be left blank|can't be blank|required/i, wait: 5))
   end
 
   # File Push Creation

--- a/test/unit/send_notify_by_email_job_test.rb
+++ b/test/unit/send_notify_by_email_job_test.rb
@@ -62,7 +62,7 @@ class SendNotifyByEmailJobTest < ActiveJob::TestCase
     @notify_by_email.reload
     assert_equal "failed", @notify_by_email.status
     assert @notify_by_email.successful_sends.blank?
-    assert_equal "Recipient emails can't be blank.", @notify_by_email.error_message
+    assert_equal "Recipient emails cannot be left blank.", @notify_by_email.error_message
   end
 
   test "perform does not send mail when notifying by email is not available" do


### PR DESCRIPTION
## Summary

Aligns tests and English plural forms with the latest Translation.io language-string sync, which rewrote Rails validation messages and left some plural keys incomplete.

### Changes

- Update model/job tests to expect the new English validation copy (`cannot be left blank`, `is not within the available options`)
- Add missing `:one`/`:other` plural forms in `config/locales/en.yml`
- Ignore Rails framework i18n keys in `i18n-tasks` so unused-key checks do not fail on internally used strings

### Impact

- No migrations, env vars, or route changes
- Please run `rake apnotic:translate` when convenient so the new English plural keys sync to Translation.io