### PR TITLE
Remove BETA tag from Administration Center

### DIFF
--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -12,11 +12,6 @@
         <%= _("Administration Center") %>
       <% end %>
     </h1>
-    <div class="mt-2">
-      <span class="badge bg-warning text-dark px-2 py-1 fw-semibold" style="font-size: 0.7rem;">
-        <%= _("BETA") %>
-      </span>
-    </div>
   </div>
 </div>
 

--- a/app/views/madmin/application/_navigation.html.erb
+++ b/app/views/madmin/application/_navigation.html.erb
@@ -12,11 +12,6 @@
         Administration Center
       <% end %>
     </h1>
-    <div class="mt-2">
-      <span class="badge bg-warning text-dark px-2 py-1 fw-semibold" style="font-size: 0.7rem;">
-        BETA
-      </span>
-    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

Drops the BETA badge from the Administration Center sidebar. The admin UI is no longer experimental.

### Changes

- Remove the BETA badge from the admin navigation header
- Remove the same badge from the Data Explorer (madmin) navigation header

### Impact

- No migrations, env vars, or route changes
- Unused `_("BETA")` gettext string remains until the next translation sync