### PR TITLE
Add light/dark theme toggle and PWP__THEME_MODE instance lock

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,5 +1,7 @@
 $accordion-color: #fff;
-$color-mode-type: media-query;
+/* Use data-bs-theme (not prefers-color-scheme) so the in-app light/dark
+   toggle and PWP__THEME_MODE instance lock control Bootstrap color modes. */
+$color-mode-type: data;
 
 @use 'bootstrap/scss/bootstrap';
 @use 'bootstrap-icons/font/bootstrap-icons';

--- a/app/assets/stylesheets/standard.css
+++ b/app/assets/stylesheets/standard.css
@@ -19,19 +19,28 @@ input[type='file'] {
 }
 
 /* Brand logos follow data-bs-theme (set by theme toggle / instance lock).
-   Do not use Bootstrap d-block/d-none on these imgs — !important utilities
-   would override these rules and show both logos at once. */
+   Use inline-block (not Bootstrap d-block) so text-center layouts can
+   still center the logo, and so !important display utilities cannot
+   force both logos visible at once. */
+.brand-logo {
+  display: inline-block;
+  max-width: 100%;
+}
 .brand-logo .logo-light {
-  display: block;
+  display: inline-block;
+  max-width: 100%;
+  height: auto;
 }
 .brand-logo .logo-dark {
   display: none;
+  max-width: 100%;
+  height: auto;
 }
 html[data-bs-theme="dark"] .brand-logo .logo-light {
   display: none;
 }
 html[data-bs-theme="dark"] .brand-logo .logo-dark {
-  display: block;
+  display: inline-block;
 }
 
 .page { margin: 6px; }

--- a/app/assets/stylesheets/standard.css
+++ b/app/assets/stylesheets/standard.css
@@ -18,6 +18,17 @@ input[type='file'] {
     justify-content: center;
 }
 
+/* Brand logos follow data-bs-theme (set by theme toggle / instance lock) */
+.brand-logo .logo-dark {
+  display: none;
+}
+html[data-bs-theme="dark"] .brand-logo .logo-light {
+  display: none;
+}
+html[data-bs-theme="dark"] .brand-logo .logo-dark {
+  display: block;
+}
+
 .page { margin: 6px; }
 .first { margin: 6px; }
 .prev { margin: 6px; }

--- a/app/assets/stylesheets/standard.css
+++ b/app/assets/stylesheets/standard.css
@@ -21,20 +21,23 @@ input[type='file'] {
 /* Brand logos follow data-bs-theme (set by theme toggle / instance lock).
    Use inline-block (not Bootstrap d-block) so text-center layouts can
    still center the logo, and so !important display utilities cannot
-   force both logos visible at once. */
+   force both logos visible at once.
+   Do not set height:auto here — that overrides the HTML height attribute
+   and blows up large custom logo assets in the header. */
 .brand-logo {
   display: inline-block;
   max-width: 100%;
+  line-height: 0;
 }
 .brand-logo .logo-light {
   display: inline-block;
   max-width: 100%;
-  height: auto;
+  width: auto;
 }
 .brand-logo .logo-dark {
   display: none;
   max-width: 100%;
-  height: auto;
+  width: auto;
 }
 html[data-bs-theme="dark"] .brand-logo .logo-light {
   display: none;

--- a/app/assets/stylesheets/standard.css
+++ b/app/assets/stylesheets/standard.css
@@ -18,7 +18,12 @@ input[type='file'] {
     justify-content: center;
 }
 
-/* Brand logos follow data-bs-theme (set by theme toggle / instance lock) */
+/* Brand logos follow data-bs-theme (set by theme toggle / instance lock).
+   Do not use Bootstrap d-block/d-none on these imgs — !important utilities
+   would override these rules and show both logos at once. */
+.brand-logo .logo-light {
+  display: block;
+}
 .brand-logo .logo-dark {
   display: none;
 }

--- a/app/assets/stylesheets/themes/default.css
+++ b/app/assets/stylesheets/themes/default.css
@@ -116,183 +116,188 @@ pre {
  }
 
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    /* --bs-blue: #2a9fd6; */
-    --bs-indigo: #6610f2;
-    --bs-purple: #6f42c1;
-    --bs-pink: #e83e8c;
-    --bs-red: #c00;
-    --bs-orange: #fd7e14;
-    --bs-yellow: #FFFF00;
-    --bs-green: #77b300;
-    --bs-teal: #20c997;
-    --bs-cyan: #93c;
-    --bs-white: #fff;
-    --bs-gray: #555;
-    --bs-gray-dark: #222;
-    --bs-gray-100: #f8f9fa;
-    --bs-gray-200: #e9ecef;
-    --bs-gray-300: #dee2e6;
-    --bs-gray-400: #adafae;
-    --bs-gray-500: #888;
-    --bs-gray-600: #555;
-    --bs-gray-700: #282828;
-    --bs-gray-800: #222;
-    --bs-gray-900: #212529;
-    --bs-primary: #4169E1;
-    --bs-secondary: #555;
-    --bs-success: #77b300;
-    --bs-info: #93c;
-    --bs-warning: #f80;
-    --bs-danger: #c00;
-    --bs-light: #222;
-    --bs-dark: #adafae;
-    --bs-secondary-color: #ccc;
-    --bs-primary-rgb: 42, 159, 214;
-    --bs-secondary-rgb: 85, 85, 85;
-    --bs-success-rgb: 119, 179, 0;
-    --bs-info-rgb: 153, 51, 204;
-    --bs-warning-rgb: 255, 136, 0;
-    --bs-danger-rgb: 204, 0, 0;
-    --bs-light-rgb: 34, 34, 34;
-    --bs-dark-rgb: 173, 175, 174;
-    --bs-white-rgb: 255, 255, 255;
-    --bs-black-rgb: 0, 0, 0;
-    --bs-body-rgb: 173, 175, 174;
-    /* --bs-body-color: #adb5bd; */
-    --bs-ans-serif: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-    --bs-font-monospace: 'Roboto Mono', SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-    --bs-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
-    --bs-body-font-family: var(--bs-font-sans-serif);
-    --bs-body-font-size: 1.1rem;
-    --bs-body-font-weight: 400;
-    --bs-body-line-height: 1.5;
-    --bs-body-color: var(--bs-gray-300);
-    --bs-link-color: var(--bs-yellow);
-    --bs-body-bg: #060606;
-    --bs-tertiary-bg: #888;
-  
-  }
+/* Dark mode follows data-bs-theme (theme toggle / PWP__THEME_MODE), not OS alone. */
+html[data-bs-theme="dark"] {
+  /* --bs-blue: #2a9fd6; */
+  --bs-indigo: #6610f2;
+  --bs-purple: #6f42c1;
+  --bs-pink: #e83e8c;
+  --bs-red: #c00;
+  --bs-orange: #fd7e14;
+  --bs-yellow: #FFFF00;
+  --bs-green: #77b300;
+  --bs-teal: #20c997;
+  --bs-cyan: #93c;
+  --bs-white: #fff;
+  --bs-gray: #555;
+  --bs-gray-dark: #222;
+  --bs-gray-100: #f8f9fa;
+  --bs-gray-200: #e9ecef;
+  --bs-gray-300: #dee2e6;
+  --bs-gray-400: #adafae;
+  --bs-gray-500: #888;
+  --bs-gray-600: #555;
+  --bs-gray-700: #282828;
+  --bs-gray-800: #222;
+  --bs-gray-900: #212529;
+  --bs-primary: #4169E1;
+  --bs-secondary: #555;
+  --bs-success: #77b300;
+  --bs-info: #93c;
+  --bs-warning: #f80;
+  --bs-danger: #c00;
+  --bs-light: #222;
+  --bs-dark: #adafae;
+  --bs-secondary-color: #ccc;
+  --bs-primary-rgb: 42, 159, 214;
+  --bs-secondary-rgb: 85, 85, 85;
+  --bs-success-rgb: 119, 179, 0;
+  --bs-info-rgb: 153, 51, 204;
+  --bs-warning-rgb: 255, 136, 0;
+  --bs-danger-rgb: 204, 0, 0;
+  --bs-light-rgb: 34, 34, 34;
+  --bs-dark-rgb: 173, 175, 174;
+  --bs-white-rgb: 255, 255, 255;
+  --bs-black-rgb: 0, 0, 0;
+  --bs-body-rgb: 173, 175, 174;
+  /* --bs-body-color: #adb5bd; */
+  --bs-ans-serif: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --bs-font-monospace: 'Roboto Mono', SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --bs-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
+  --bs-body-font-family: var(--bs-font-sans-serif);
+  --bs-body-font-size: 1.1rem;
+  --bs-body-font-weight: 400;
+  --bs-body-line-height: 1.5;
+  --bs-body-color: var(--bs-gray-300);
+  --bs-link-color: var(--bs-yellow);
+  --bs-body-bg: #060606;
+  --bs-tertiary-bg: #888;
+}
 
-  .form-floating > .form-control:focus ~ label, .form-floating > .form-control:not(:placeholder-shown) ~ label, .form-floating > .form-control-plaintext ~ label, .form-floating > .form-select ~ label {
-    color: var(--bs-white-100);
-  }
+html[data-bs-theme="dark"] .form-floating > .form-control:focus ~ label,
+html[data-bs-theme="dark"] .form-floating > .form-control:not(:placeholder-shown) ~ label,
+html[data-bs-theme="dark"] .form-floating > .form-control-plaintext ~ label,
+html[data-bs-theme="dark"] .form-floating > .form-select ~ label {
+  color: var(--bs-white-100);
+}
 
-  .navbar-dark, .navbar[data-bs-theme="dark"] {
-    background-color: var(--bs-black-300);
-  }
+html[data-bs-theme="dark"] .navbar-dark,
+html[data-bs-theme="dark"] .navbar[data-bs-theme="dark"] {
+  background-color: var(--bs-black-300);
+}
 
-  .table thead th {
-    color: var(--bs-body-color);
-    background-color: var(--bs-gray-700);
-  }
+html[data-bs-theme="dark"] .table thead th {
+  color: var(--bs-body-color);
+  background-color: var(--bs-gray-700);
+}
 
-  .table > :not(caption) > * > * {
-    color: var(--bs-body-color);
-    background-color: var(--bs-gray-700);
-  }
+html[data-bs-theme="dark"] .table > :not(caption) > * > * {
+  color: var(--bs-body-color);
+  background-color: var(--bs-gray-700);
+}
 
-  .table-striped > tbody > tr:nth-of-type(2n+1) > *
-  {
-    background-color: var(--bs-gray-900);
-    color: var(--bs-body-color);
-  }
+html[data-bs-theme="dark"] .table-striped > tbody > tr:nth-of-type(2n+1) > * {
+  background-color: var(--bs-gray-900);
+  color: var(--bs-body-color);
+}
 
-  .nav-tabs .nav-link.active {
-    color: var(--bs-white);
-    background-color: #121212;;
-    border-color: var(--bs-gray-700);
-  }
+html[data-bs-theme="dark"] .nav-tabs .nav-link.active {
+  color: var(--bs-white);
+  background-color: #121212;
+  border-color: var(--bs-gray-700);
+}
 
-  .accordion-button {
-    color: var(--bs-body-color);
-    background-color: var(--bs-gray-700);
-  }
+html[data-bs-theme="dark"] .accordion-button {
+  color: var(--bs-body-color);
+  background-color: var(--bs-gray-700);
+}
 
-  .accordion-button:not(.collapsed) {
-    color: var(--bs-body-color);
-    background-color: var(--bs-gray-700);
-    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.125);
-  }
+html[data-bs-theme="dark"] .accordion-button:not(.collapsed) {
+  color: var(--bs-body-color);
+  background-color: var(--bs-gray-700);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.125);
+}
 
-  .accordion-item {
-    background-color: var(--bs-body-bg);
-  }
+html[data-bs-theme="dark"] .accordion-item {
+  background-color: var(--bs-body-bg);
+}
 
-  .list-group-item {
-    color: var(--bs-body-color);
-    background-color: var(--bs-gray-700);
-  }
+html[data-bs-theme="dark"] .list-group-item {
+  color: var(--bs-body-color);
+  background-color: var(--bs-gray-700);
+}
 
-  .form-control {
-    color: var(--bs-body-color);
-    background-color: var(--bs-gray-700);
-  }
+html[data-bs-theme="dark"] .form-control {
+  color: var(--bs-body-color);
+  background-color: var(--bs-gray-700);
+}
 
-  .form-control:focus {
-    color: var(--bs-body-color);
-    background-color: var(--bs-gray-700);
-  }
+html[data-bs-theme="dark"] .form-control:focus {
+  color: var(--bs-body-color);
+  background-color: var(--bs-gray-700);
+}
 
-  .form-control:disabled, .form-control[readonly] {
-    background-color: var(--bs-gray-800);
-  }
+html[data-bs-theme="dark"] .form-control:disabled,
+html[data-bs-theme="dark"] .form-control[readonly] {
+  background-color: var(--bs-gray-800);
+}
 
-  .card {
-    color: var(--bs-body-color);
-    background-color: var(--bs-gray-700);
-  }
+html[data-bs-theme="dark"] .card {
+  color: var(--bs-body-color);
+  background-color: var(--bs-gray-700);
+}
 
-  .card-header {
-    color: var(--bs-body-color);
-    background-color: var(--bs-gray-600);
-  }
+html[data-bs-theme="dark"] .card-header {
+  color: var(--bs-body-color);
+  background-color: var(--bs-gray-600);
+}
 
-  .btn-primary {
-    background-color: var(--bs-primary)
-  }
+html[data-bs-theme="dark"] .btn-primary {
+  background-color: var(--bs-primary);
+}
 
-  pre, code, kbd, samp {
-    color: var(--bs-gray-300);
-  }
+html[data-bs-theme="dark"] pre,
+html[data-bs-theme="dark"] code,
+html[data-bs-theme="dark"] kbd,
+html[data-bs-theme="dark"] samp {
+  color: var(--bs-gray-300);
+}
 
-  .bg-light {
-    background-color: var(--bs-gray-600);
-  }
+html[data-bs-theme="dark"] .bg-light {
+  background-color: var(--bs-gray-600);
+}
 
-  .payload pre {
-    color: var(--bs-body-bg);
-  }
+html[data-bs-theme="dark"] .payload pre {
+  color: var(--bs-body-bg);
+}
 
-  .text-primary {
-    color: var(--bs-yellow) !important;
-  }
+html[data-bs-theme="dark"] .text-primary {
+  color: var(--bs-yellow) !important;
+}
 
-  .text-secondary {
-    color: var(--bs-yellow) !important;
-  }
+html[data-bs-theme="dark"] .text-secondary {
+  color: var(--bs-yellow) !important;
+}
 
-  .display-1 {
-    font-family: 'Roboto Slab', 'Roboto', -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-    color: var(--bs-yellow);
-  }
+html[data-bs-theme="dark"] .display-1 {
+  font-family: 'Roboto Slab', 'Roboto', -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  color: var(--bs-yellow);
+}
 
-  .display-2 {
-    font-family: 'Roboto Slab', 'Roboto', -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-  }
+html[data-bs-theme="dark"] .display-2 {
+  font-family: 'Roboto Slab', 'Roboto', -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+}
 
-  .modal-header {
-    background-color: var(--bs-gray-600);
-  }
+html[data-bs-theme="dark"] .modal-header {
+  background-color: var(--bs-gray-600);
+}
 
-  .modal-body {
-    color: var(--bs-gray-300);
-    background-color: var(--bs-body-bg);
-  }
+html[data-bs-theme="dark"] .modal-body {
+  color: var(--bs-gray-300);
+  background-color: var(--bs-body-bg);
+}
 
-  .modal-footer {
-    background-color: var(--bs-body-bg);
-  }
+html[data-bs-theme="dark"] .modal-footer {
+  background-color: var(--bs-body-bg);
 }
 

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -22,6 +22,7 @@ export default class extends Controller {
   connect() {
     this.mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
     this.boundOnSystemChange = this.onSystemChange.bind(this)
+    this.sessionPreference = null
 
     this.apply()
 
@@ -41,10 +42,19 @@ export default class extends Controller {
   }
 
   get storedPreference() {
-    const value = localStorage.getItem("theme")
-    if (value === "light" || value === "dark" || value === "system") {
-      return value
+    try {
+      const value = localStorage.getItem("theme")
+      if (value === "light" || value === "dark" || value === "system") {
+        return value
+      }
+    } catch (_error) {
+      // Privacy modes / disabled storage — fall through
     }
+
+    if (this.sessionPreference === "light" || this.sessionPreference === "dark" || this.sessionPreference === "system") {
+      return this.sessionPreference
+    }
+
     return "system"
   }
 
@@ -87,7 +97,14 @@ export default class extends Controller {
     const order = ["light", "dark", "system"]
     const current = this.storedPreference
     const next = order[(order.indexOf(current) + 1) % order.length]
-    localStorage.setItem("theme", next)
+    this.sessionPreference = next
+
+    try {
+      localStorage.setItem("theme", next)
+    } catch (_error) {
+      // Keep sessionPreference so the toggle still works without storage
+    }
+
     this.apply()
   }
 

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -1,27 +1,121 @@
 import { Controller } from "@hotwired/stimulus"
 
+// Light / dark / system theme control via Bootstrap data-bs-theme.
+//
+// Instance lock (data-theme-instance-mode-value):
+//   light | dark — force that mode; ignore localStorage and OS
+//   auto         — follow localStorage.theme, else OS preference
+//
+// When auto, cycle() rotates: light → dark → system → light …
+// Preference is stored in localStorage.theme (anonymous-safe).
+
 export default class extends Controller {
+  static values = {
+    instanceMode: { type: String, default: "auto" },
+    labelLight: { type: String, default: "Use light theme" },
+    labelDark: { type: String, default: "Use dark theme" },
+    labelSystem: { type: String, default: "Use system theme" }
+  }
+
+  static targets = ["icon", "button"]
 
   connect() {
-    this.prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)")
-    
-    // Initial check
-    this.handleThemeChange(this.prefersDarkScheme)
-    
-    // Listen for changes
-    this.prefersDarkScheme.addEventListener('change', this.handleThemeChange.bind(this))
+    this.mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+    this.boundOnSystemChange = this.onSystemChange.bind(this)
+
+    this.apply()
+
+    if (this.isAuto) {
+      this.mediaQuery.addEventListener("change", this.boundOnSystemChange)
+    }
   }
 
   disconnect() {
-    // Clean up event listener when controller disconnects
-    this.prefersDarkScheme.removeEventListener('change', this.handleThemeChange.bind(this))
-  }
-
-  handleThemeChange(e) {
-    if (e.matches) {
-      document.documentElement.setAttribute('data-bs-theme', 'dark')
-    } else {
-      document.documentElement.setAttribute('data-bs-theme', 'light')
+    if (this.mediaQuery && this.boundOnSystemChange) {
+      this.mediaQuery.removeEventListener("change", this.boundOnSystemChange)
     }
   }
-} 
+
+  get isAuto() {
+    return this.instanceModeValue === "auto"
+  }
+
+  get storedPreference() {
+    const value = localStorage.getItem("theme")
+    if (value === "light" || value === "dark" || value === "system") {
+      return value
+    }
+    return "system"
+  }
+
+  get systemPrefersDark() {
+    return this.mediaQuery.matches
+  }
+
+  resolveMode() {
+    if (!this.isAuto) {
+      return this.instanceModeValue === "dark" ? "dark" : "light"
+    }
+
+    const preference = this.storedPreference
+    if (preference === "light" || preference === "dark") {
+      return preference
+    }
+    return this.systemPrefersDark ? "dark" : "light"
+  }
+
+  apply() {
+    const mode = this.resolveMode()
+    document.documentElement.setAttribute("data-bs-theme", mode)
+    this.updateButton(mode)
+  }
+
+  onSystemChange() {
+    if (this.isAuto && this.storedPreference === "system") {
+      this.apply()
+    }
+  }
+
+  cycle(event) {
+    if (event) {
+      event.preventDefault()
+    }
+    if (!this.isAuto) {
+      return
+    }
+
+    const order = ["light", "dark", "system"]
+    const current = this.storedPreference
+    const next = order[(order.indexOf(current) + 1) % order.length]
+    localStorage.setItem("theme", next)
+    this.apply()
+  }
+
+  updateButton(resolvedMode) {
+    if (!this.hasButtonTarget) {
+      return
+    }
+
+    const preference = this.isAuto ? this.storedPreference : this.instanceModeValue
+    let iconClass = "bi-circle-half"
+    let label = this.labelSystemValue
+
+    if (preference === "light") {
+      iconClass = "bi-moon"
+      label = this.labelDarkValue
+    } else if (preference === "dark") {
+      iconClass = "bi-sun"
+      label = this.labelLightValue
+    }
+
+    this.buttonTarget.setAttribute("title", label)
+    this.buttonTarget.setAttribute("aria-label", label)
+
+    if (this.hasIconTarget) {
+      this.iconTarget.className = `bi ${iconClass}`
+    }
+
+    this.buttonTarget.dataset.themePreference = preference
+    this.buttonTarget.dataset.themeResolved = resolvedMode
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
       data-theme-label-light-value="<%= _("Use light theme") %>"
       data-theme-label-dark-value="<%= _("Use dark theme") %>"
       data-theme-label-system-value="<%= _("Use system theme") %>"
-      <% if Settings.theme_mode_locked? %>data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
+      <% if Settings.theme_mode_locked? %> data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
 <head>
   <%= render partial: "shared/theme_boot" %>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>" data-controller="theme">
+<html lang="<%= I18n.locale %>"
+      data-controller="theme"
+      data-theme-mode="<%= Settings.theme_mode %>"
+      data-theme-instance-mode-value="<%= Settings.theme_mode %>"
+      data-theme-label-light-value="<%= _("Use light theme") %>"
+      data-theme-label-dark-value="<%= _("Use dark theme") %>"
+      data-theme-label-system-value="<%= _("Use system theme") %>"
+      <% if Settings.theme_mode_locked? %>data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
 <head>
+  <%= render partial: "shared/theme_boot" %>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
   <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>

--- a/app/views/layouts/bare.html.erb
+++ b/app/views/layouts/bare.html.erb
@@ -3,7 +3,7 @@
       data-controller="theme"
       data-theme-mode="<%= Settings.theme_mode %>"
       data-theme-instance-mode-value="<%= Settings.theme_mode %>"
-      <% if Settings.theme_mode_locked? %>data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
+      <% if Settings.theme_mode_locked? %> data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
 <head>
   <%= render partial: "shared/theme_boot" %>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/app/views/layouts/bare.html.erb
+++ b/app/views/layouts/bare.html.erb
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>" data-controller="theme">
+<html lang="<%= I18n.locale %>"
+      data-controller="theme"
+      data-theme-mode="<%= Settings.theme_mode %>"
+      data-theme-instance-mode-value="<%= Settings.theme_mode %>"
+      <% if Settings.theme_mode_locked? %>data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
 <head>
+  <%= render partial: "shared/theme_boot" %>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
   <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -6,7 +6,7 @@
       data-theme-label-light-value="<%= _("Use light theme") %>"
       data-theme-label-dark-value="<%= _("Use dark theme") %>"
       data-theme-label-system-value="<%= _("Use system theme") %>"
-      <% if Settings.theme_mode_locked? %>data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
+      <% if Settings.theme_mode_locked? %> data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
 <head>
   <%= render partial: "shared/theme_boot" %>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>" data-controller="theme">
+<html lang="<%= I18n.locale %>"
+      data-controller="theme"
+      data-theme-mode="<%= Settings.theme_mode %>"
+      data-theme-instance-mode-value="<%= Settings.theme_mode %>"
+      data-theme-label-light-value="<%= _("Use light theme") %>"
+      data-theme-label-dark-value="<%= _("Use dark theme") %>"
+      data-theme-label-system-value="<%= _("Use system theme") %>"
+      <% if Settings.theme_mode_locked? %>data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
 <head>
+  <%= render partial: "shared/theme_boot" %>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
   <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>
@@ -26,18 +34,11 @@
   <div class="container-fluid d-flex flex-column min-vh-100 justify-content-center align-items-center">
     <%= render partial: 'shared/alerts' %>
     <main class="col-12 col-sm-6 col-md-5 col-lg-4 col-xl-3 text-center">
+      <div class="d-flex justify-content-end mb-2">
+        <%= render partial: "shared/theme_toggle" %>
+      </div>
       <%= link_to root_path(locale: locale.to_s), hreflang: locale.to_s do %>
-        <picture>
-        <% if Settings.brand.nil? || Settings.brand.light_logo.nil? %>
-            <source srcset="<%= asset_path('logo-transparent-sm-bare.png') %>" media="(prefers-color-scheme: light) or (prefers-color-scheme: no-preference)">
-            <source srcset="<%= asset_path('logo-transparent-sm-dark-bare.png') %>" media="(prefers-color-scheme: dark)">
-            <img src="<%= asset_path('logo-transparent-sm-bare.png') %>" alt="<%= _('Password Pusher Logo') %>" style='max-height: 120px; max-width: 100%; height: auto;'>
-          <% else %>
-            <source srcset="<%= Settings.brand.light_logo %>" media="(prefers-color-scheme: light) or (prefers-color-scheme: no-preference)">
-            <source srcset="<%= Settings.brand.dark_logo %>" media="(prefers-color-scheme: dark)">
-            <img src="<%= Settings.brand.light_logo %>" alt="" style='max-height: 120px; max-width: 100%; height: auto;'>
-          <% end %>
-        </picture>
+        <%= render partial: "shared/brand_logo", locals: { height: nil, css_class: "", style: "max-height: 120px; max-width: 100%; height: auto;" } %>
       <% end %>
 
       <%= yield %>

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -31,12 +31,12 @@
 </head>
 
 <body class="d-flex flex-column min-vh-100">
+  <div class="position-absolute top-0 end-0 p-3">
+    <%= render partial: "shared/theme_toggle" %>
+  </div>
   <div class="container-fluid d-flex flex-column min-vh-100 justify-content-center align-items-center">
     <%= render partial: 'shared/alerts' %>
     <main class="col-12 col-sm-6 col-md-5 col-lg-4 col-xl-3 text-center">
-      <div class="d-flex justify-content-end mb-2">
-        <%= render partial: "shared/theme_toggle" %>
-      </div>
       <%= link_to root_path(locale: locale.to_s), hreflang: locale.to_s do %>
         <%= render partial: "shared/brand_logo", locals: { height: nil, css_class: "", style: "max-height: 120px; max-width: 100%; height: auto;" } %>
       <% end %>

--- a/app/views/layouts/naked.html.erb
+++ b/app/views/layouts/naked.html.erb
@@ -3,7 +3,7 @@
       data-controller="theme"
       data-theme-mode="<%= Settings.theme_mode %>"
       data-theme-instance-mode-value="<%= Settings.theme_mode %>"
-      <% if Settings.theme_mode_locked? %>data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
+      <% if Settings.theme_mode_locked? %> data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
 <head>
   <%= render partial: "shared/theme_boot" %>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/app/views/layouts/naked.html.erb
+++ b/app/views/layouts/naked.html.erb
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>" data-controller="theme">
+<html lang="<%= I18n.locale %>"
+      data-controller="theme"
+      data-theme-mode="<%= Settings.theme_mode %>"
+      data-theme-instance-mode-value="<%= Settings.theme_mode %>"
+      <% if Settings.theme_mode_locked? %>data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
 <head>
+  <%= render partial: "shared/theme_boot" %>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
   <title><%= content_for?(:html_title) ? yield(:html_title) : Settings.brand.title %></title>

--- a/app/views/shared/_brand_logo.html.erb
+++ b/app/views/shared/_brand_logo.html.erb
@@ -19,7 +19,8 @@
    else
      Settings.brand.dark_logo
    end %>
-<% img_opts = { alt: _("Password Pusher Logo"), class: "logo-light #{css_class}".strip }
+<% logo_alt = Settings.brand&.title.presence || _("Password Pusher Logo") %>
+<% img_opts = { alt: logo_alt, class: "logo-light #{css_class}".strip }
    if height.present?
      img_opts[:height] = height
      # Inline height beats stylesheet rules; keeps large custom assets at the intended size

--- a/app/views/shared/_brand_logo.html.erb
+++ b/app/views/shared/_brand_logo.html.erb
@@ -20,8 +20,14 @@
      Settings.brand.dark_logo
    end %>
 <% img_opts = { alt: _("Password Pusher Logo"), class: "logo-light #{css_class}".strip }
-   img_opts[:height] = height if height.present?
-   img_opts[:style] = style if style.present? %>
+   if height.present?
+     img_opts[:height] = height
+     # Inline height beats stylesheet rules; keeps large custom assets at the intended size
+     height_style = "height: #{height}px; width: auto;"
+     img_opts[:style] = [height_style, style].compact_blank.join(" ")
+   elsif style.present?
+     img_opts[:style] = style
+   end %>
 <% dark_opts = img_opts.merge(class: "logo-dark #{css_class}".strip) %>
 <span class="brand-logo">
   <%= image_tag light_src, **img_opts %>

--- a/app/views/shared/_brand_logo.html.erb
+++ b/app/views/shared/_brand_logo.html.erb
@@ -7,7 +7,7 @@
     style: optional inline style on each img
 %>
 <% height = local_assigns.fetch(:height, 50) %>
-<% css_class = local_assigns.fetch(:css_class, "d-block") %>
+<% css_class = local_assigns.fetch(:css_class, "") %>
 <% style = local_assigns[:style] %>
 <% light_src = if Settings.brand.nil? || Settings.brand.light_logo.nil?
      asset_path("logo-transparent-sm-bare.png")

--- a/app/views/shared/_brand_logo.html.erb
+++ b/app/views/shared/_brand_logo.html.erb
@@ -1,0 +1,29 @@
+<%#
+  Brand logo that follows data-bs-theme (not prefers-color-scheme).
+
+  locals:
+    height: optional height in px (default 50); omit or nil to skip height attr
+    css_class: optional extra classes on each img
+    style: optional inline style on each img
+%>
+<% height = local_assigns.fetch(:height, 50) %>
+<% css_class = local_assigns.fetch(:css_class, "d-block") %>
+<% style = local_assigns[:style] %>
+<% light_src = if Settings.brand.nil? || Settings.brand.light_logo.nil?
+     asset_path("logo-transparent-sm-bare.png")
+   else
+     Settings.brand.light_logo
+   end %>
+<% dark_src = if Settings.brand.nil? || Settings.brand.dark_logo.nil?
+     asset_path("logo-transparent-sm-dark-bare.png")
+   else
+     Settings.brand.dark_logo
+   end %>
+<% img_opts = { alt: _("Password Pusher Logo"), class: "logo-light #{css_class}".strip }
+   img_opts[:height] = height if height.present?
+   img_opts[:style] = style if style.present? %>
+<% dark_opts = img_opts.merge(class: "logo-dark #{css_class}".strip) %>
+<span class="brand-logo">
+  <%= image_tag light_src, **img_opts %>
+  <%= image_tag dark_src, **dark_opts %>
+</span>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,17 +3,7 @@
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-center gap-2">
       <div class="d-flex align-items-center gap-2">
         <%= link_to root_path(locale: locale.to_s), class: "text-decoration-none" do %>
-          <picture>
-            <% if Settings.brand.nil? || Settings.brand.light_logo.nil? %>
-              <source srcset="<%= asset_path('logo-transparent-sm-bare.png') %>" media="(prefers-color-scheme: light) or (prefers-color-scheme: no-preference)">
-              <source srcset="<%= asset_path('logo-transparent-sm-dark-bare.png') %>" media="(prefers-color-scheme: dark)">
-              <img src="<%= asset_path('logo-transparent-sm-bare.png') %>" alt="<%= _('Password Pusher Logo') %>" height="28" class="d-block">
-            <% else %>
-              <source srcset="<%= Settings.brand.light_logo %>" media="(prefers-color-scheme: light) or (prefers-color-scheme: no-preference)">
-              <source srcset="<%= Settings.brand.dark_logo %>" media="(prefers-color-scheme: dark)">
-              <img src="<%= Settings.brand.light_logo %>" alt="<%= _('Password Pusher Logo') %>" height="28" class="d-block">
-            <% end %>
-          </picture>
+          <%= render partial: "shared/brand_logo", locals: { height: 28 } %>
         <% end %>
         <span class="text-muted small">
           &copy; <%= Time.now.year %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,17 +2,7 @@
   <header class="d-flex flex-wrap justify-content-center py-3 mb-4 border-bottom">
     <%= link_to root_path, class: 'd-flex align-items-center mb-3 mb-md-0 me-md-auto text-body-emphasis text-decoration-none', hreflang: locale.to_s do %>
       <div class="me-3">
-        <picture>
-          <% if Settings.brand.nil? || Settings.brand.light_logo.nil? %>
-            <source srcset="<%= asset_path('logo-transparent-sm-bare.png') %>" media="(prefers-color-scheme: light) or (prefers-color-scheme: no-preference)">
-            <source srcset="<%= asset_path('logo-transparent-sm-dark-bare.png') %>" media="(prefers-color-scheme: dark)">
-            <img src="<%= asset_path('logo-transparent-sm-bare.png') %>" alt="<%= _('Password Pusher Logo') %>" height="50" class="d-block">
-          <% else %>
-            <source srcset="<%= Settings.brand.light_logo %>" media="(prefers-color-scheme: light) or (prefers-color-scheme: no-preference)">
-            <source srcset="<%= Settings.brand.dark_logo %>" media="(prefers-color-scheme: dark)">
-            <img src="<%= Settings.brand.light_logo %>" alt="<%= _('Password Pusher Logo') %>" height="50" class="d-block">
-          <% end %>
-        </picture>
+        <%= render partial: "shared/brand_logo", locals: { height: 50 } %>
       </div>
       <div class="d-none d-sm-block">
         <span class="fs-4 fw-semibold d-block lh-sm"><%= Settings.brand.title %></span>
@@ -21,6 +11,8 @@
     <% end %>
 
     <nav class="d-flex align-items-center gap-2">
+      <%= render partial: "shared/theme_toggle" %>
+
       <% if current_user %>
         <%= link_to pushes_path, class: "btn btn-primary d-flex align-items-center gap-2" do %>
           <em class="bi bi-grid-3x3-gap-fill"></em>

--- a/app/views/shared/_theme_boot.html.erb
+++ b/app/views/shared/_theme_boot.html.erb
@@ -1,0 +1,24 @@
+<%# Apply data-bs-theme before first paint to avoid a flash.
+    Reads instance lock from data-theme-mode on <html>, then localStorage.theme,
+    then prefers-color-scheme. Must stay in sync with theme_controller.js. %>
+<script nonce="<%= request.content_security_policy_nonce %>">
+  (function () {
+    var root = document.documentElement
+    var instanceMode = (root.getAttribute("data-theme-mode") || "auto").toLowerCase()
+    var mode
+
+    if (instanceMode === "light" || instanceMode === "dark") {
+      mode = instanceMode
+    } else {
+      var stored = null
+      try { stored = localStorage.getItem("theme") } catch (e) {}
+      if (stored === "light" || stored === "dark") {
+        mode = stored
+      } else {
+        mode = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+      }
+    }
+
+    root.setAttribute("data-bs-theme", mode)
+  })()
+</script>

--- a/app/views/shared/_theme_toggle.html.erb
+++ b/app/views/shared/_theme_toggle.html.erb
@@ -1,0 +1,13 @@
+<%# Theme toggle button — only rendered when theme_mode is auto.
+    Labels come from data-theme-label-*-value on the html[data-controller=theme] element. %>
+<% if Settings.theme_mode == "auto" %>
+  <button type="button"
+          class="btn btn-outline-secondary d-flex align-items-center"
+          id="theme-mode-toggle"
+          data-theme-target="button"
+          data-action="click->theme#cycle"
+          title="<%= _("Use system theme") %>"
+          aria-label="<%= _("Use system theme") %>">
+    <em class="bi bi-circle-half" data-theme-target="icon" aria-hidden="true"></em>
+  </button>
+<% end %>

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -968,6 +968,23 @@ noindex: true
 #
 theme: 'default'
 
+### Theme Mode (Light / Dark)
+#
+# Controls whether the application follows the visitor's OS preference or
+# forces light/dark for the entire instance.
+#
+# Values:
+#   auto  - Follow OS preference; visitors can override with the header toggle
+#   light - Force light mode for all visitors (hides the toggle)
+#   dark  - Force dark mode for all visitors (hides the toggle)
+#
+# Environment Variable Override: PWP__THEME_MODE='auto'
+#
+# This is separate from PWP__THEME (Bootswatch skin). theme_mode only controls
+# the light/dark axis via Bootstrap's data-bs-theme attribute.
+#
+theme_mode: 'auto'
+
 ### Pre-compilation (DEPRECATED)
 #
 # DEPRECATED: Precompilation now happens automatically when PWP__THEME is set.

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -45,3 +45,20 @@ module SettingsExtensions
 end
 
 Settings.extend(SettingsExtensions)
+
+# Prepend so we override Config's theme_mode reader (extend alone loses to
+# singleton methods Config defines on Settings).
+module ThemeModeExtension
+  THEME_MODES = %w[auto light dark].freeze
+
+  def theme_mode
+    raw = super.to_s.strip.downcase
+    THEME_MODES.include?(raw) ? raw : "auto"
+  end
+
+  def theme_mode_locked?
+    theme_mode != "auto"
+  end
+end
+
+Settings.singleton_class.prepend(ThemeModeExtension)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -968,6 +968,23 @@ noindex: true
 #
 theme: 'default'
 
+### Theme Mode (Light / Dark)
+#
+# Controls whether the application follows the visitor's OS preference or
+# forces light/dark for the entire instance.
+#
+# Values:
+#   auto  - Follow OS preference; visitors can override with the header toggle
+#   light - Force light mode for all visitors (hides the toggle)
+#   dark  - Force dark mode for all visitors (hides the toggle)
+#
+# Environment Variable Override: PWP__THEME_MODE='auto'
+#
+# This is separate from PWP__THEME (Bootswatch skin). theme_mode only controls
+# the light/dark axis via Bootstrap's data-bs-theme attribute.
+#
+theme_mode: 'auto'
+
 ### Pre-compilation (DEPRECATED)
 #
 # DEPRECATED: Precompilation now happens automatically when PWP__THEME is set.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,7 @@ x-env: &x-env
     # PWP__SHOW_GDPR_CONSENT_BANNER: "false"
     # PWP__NOINDEX: "true" # Default; set false only for public demos
     # PWP__THEME: "default" # See: https://docs.pwpush.com/docs/rebranding/#themes
+    # PWP__THEME_MODE: "auto" # auto | light | dark — lock light/dark or allow visitor toggle
     # PWP_PRECOMPILE: "false"  # DEPRECATED. Precompilation now happens automatically when PWP__THEME is set. Keeping for backward compatibility.
 
     # --- Locale ---

--- a/test/integration/theme_mode_test.rb
+++ b/test/integration/theme_mode_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ThemeModeTest < ActionDispatch::IntegrationTest
+  teardown do
+    Settings.reload!
+  end
+
+  test "root includes theme toggle when theme_mode is auto" do
+    Settings.theme_mode = "auto"
+
+    get root_path
+
+    assert_response :success
+    assert_select "html[data-theme-mode=auto]"
+    assert_select "html[data-controller=theme]"
+    assert_select "#theme-mode-toggle"
+    assert_select "html[data-bs-theme]", count: 0
+  end
+
+  test "login includes theme toggle when theme_mode is auto" do
+    Settings.theme_mode = "auto"
+
+    get new_user_session_path
+
+    assert_response :success
+    assert_select "#theme-mode-toggle"
+  end
+
+  test "theme toggle is hidden when theme_mode is light" do
+    Settings.theme_mode = "light"
+
+    get root_path
+
+    assert_response :success
+    assert_select "html[data-theme-mode=light]"
+    assert_select "html[data-bs-theme=light]"
+    assert_select "#theme-mode-toggle", count: 0
+  end
+
+  test "theme toggle is hidden when theme_mode is dark" do
+    Settings.theme_mode = "dark"
+
+    get root_path
+
+    assert_response :success
+    assert_select "html[data-theme-mode=dark]"
+    assert_select "html[data-bs-theme=dark]"
+    assert_select "#theme-mode-toggle", count: 0
+  end
+
+  test "login locks data-bs-theme when theme_mode is dark" do
+    Settings.theme_mode = "dark"
+
+    get new_user_session_path
+
+    assert_response :success
+    assert_select "html[data-bs-theme=dark]"
+    assert_select "#theme-mode-toggle", count: 0
+  end
+
+  test "invalid theme_mode falls back to auto" do
+    Settings.theme_mode = "neon"
+
+    assert_equal "auto", Settings.theme_mode
+    assert_not Settings.theme_mode_locked?
+
+    get root_path
+
+    assert_response :success
+    assert_select "html[data-theme-mode=auto]"
+    assert_select "#theme-mode-toggle"
+  end
+
+  test "brand logos use data-bs-theme classes not picture sources" do
+    Settings.theme_mode = "auto"
+
+    get root_path
+
+    assert_response :success
+    assert_select ".brand-logo img.logo-light"
+    assert_select ".brand-logo img.logo-dark"
+    assert_select "header picture", count: 0
+  end
+
+  test "theme boot script is present in head" do
+    get root_path
+
+    assert_response :success
+    assert_match(/localStorage\.getItem\("theme"\)/, response.body)
+    assert_match(/data-bs-theme/, response.body)
+  end
+end

--- a/test/system/theme_mode_system_test.rb
+++ b/test/system/theme_mode_system_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class ThemeModeSystemTest < ApplicationSystemTestCase
+  teardown do
+    Settings.reload!
+    clear_theme_storage
+  end
+
+  test "theme toggle cycles light dark and system" do
+    Settings.theme_mode = "auto"
+
+    visit root_path
+    clear_theme_storage
+
+    # Start from a known preference and reload so the boot script + controller apply it
+    page.execute_script("localStorage.setItem('theme', 'light')")
+    visit root_path
+
+    assert_selector "#theme-mode-toggle"
+    assert_equal "light", page.evaluate_script("localStorage.getItem('theme')")
+    assert_equal "light", page.evaluate_script("document.documentElement.getAttribute('data-bs-theme')")
+
+    find("#theme-mode-toggle").click
+    assert_equal "dark", page.evaluate_script("localStorage.getItem('theme')")
+    assert_equal "dark", page.evaluate_script("document.documentElement.getAttribute('data-bs-theme')")
+
+    find("#theme-mode-toggle").click
+    assert_equal "system", page.evaluate_script("localStorage.getItem('theme')")
+    resolved = page.evaluate_script("document.documentElement.getAttribute('data-bs-theme')")
+    assert_includes %w[light dark], resolved
+
+    find("#theme-mode-toggle").click
+    assert_equal "light", page.evaluate_script("localStorage.getItem('theme')")
+    assert_equal "light", page.evaluate_script("document.documentElement.getAttribute('data-bs-theme')")
+  end
+
+  test "locked theme_mode hides toggle and forces dark" do
+    Settings.theme_mode = "dark"
+
+    visit root_path
+
+    assert_no_selector "#theme-mode-toggle"
+    assert_equal "dark", page.evaluate_script("document.documentElement.getAttribute('data-bs-theme')")
+  end
+
+  private
+
+  def clear_theme_storage
+    return unless page.current_url.present? && page.current_url.start_with?("http")
+
+    page.execute_script("try { localStorage.removeItem('theme') } catch (e) {}")
+  rescue Selenium::WebDriver::Error::WebDriverError,
+    Selenium::WebDriver::Error::InvalidSessionIdError,
+    Selenium::WebDriver::Error::NoSuchWindowError,
+    Selenium::WebDriver::Error::JavascriptError
+    # Browser already closed or on a non-http page
+  end
+end


### PR DESCRIPTION
## Summary

Adds a header light/dark/system toggle for visitors and an instance-level lock via `PWP__THEME_MODE`, closing the long-standing request to force light (or dark) mode.

Fixes #861

### Changes

- Header and login theme toggle (cycles light → dark → system via `localStorage`)
- `PWP__THEME_MODE=auto|light|dark` to lock the instance and hide the toggle
- Early nonce’d boot script to avoid theme flash; logos follow `data-bs-theme`
- Default theme CSS and Bootstrap color mode use `data-bs-theme` instead of OS media queries alone

### Impact

- New env var: `PWP__THEME_MODE` (default `auto`)
- Separate from `PWP__THEME` (Bootswatch skin)
- New gettext strings — run `rake apnotic:translate` after merge
- Docs PR: https://github.com/apnotic/pwpush-docs/pull/48