### PR TITLE
Add Docker-style _FILE support for encryption secrets

### DIFF
--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -1,14 +1,20 @@
 # frozen_string_literal: true
 
+require "password_pusher/env_or_file"
+
 # Application Encryption Key
 #
 # Set the environment variable PWPUSH_MASTER_KEY to set your encryption key.
+# Alternatively, set PWPUSH_MASTER_KEY_FILE to a path whose contents are the key
+# (Docker Compose/Swarm secrets convention). The env var wins if both are set.
 #
 # Example:
 #   export PWPUSH_MASTER_KEY=749b1022e1cb83fb04f3022eacaf3bfef60c6d47f83e6fb41f534a05fc69929f
+#   export PWPUSH_MASTER_KEY_FILE=/run/secrets/pwpush_master_key
 #
-# If this environment variable is not set, a default encryption key will be used.
-# For key rotation, put old encryption key(s) in PWPUSH_MASTER_KEY_PREVIOUS (comma-separated).
+# If neither is set, a default encryption key will be used.
+# For key rotation, put old encryption key(s) in PWPUSH_MASTER_KEY_PREVIOUS
+# (comma-separated), or PWPUSH_MASTER_KEY_PREVIOUS_FILE pointing at such a file.
 #
 # Changing an encryption key where old pushes already exist will make those older pushes
 # unreadable.  In other words, the payloads will be garbled.  New pushes going forward
@@ -20,14 +26,16 @@
 #
 # To generate a new encryption key, run the following:
 #   > rails c
-#   > Lockbox.gnerate_key
+#   > Lockbox.generate_key
 #
 # or go to https://pwpush.com/pages/generate_key
 #
-Lockbox.master_key = ENV.fetch("PWPUSH_MASTER_KEY", "749b1022e1cb83fb04f3022eacaf3bfef60c6d47f83e6fb41f534a05fc69929f")
+Lockbox.master_key = PasswordPusher::EnvOrFile.read("PWPUSH_MASTER_KEY") ||
+  "749b1022e1cb83fb04f3022eacaf3bfef60c6d47f83e6fb41f534a05fc69929f"
 
-if ENV.key?("PWPUSH_MASTER_KEY_PREVIOUS")
-  Lockbox.default_options[:previous_versions] = ENV.fetch("PWPUSH_MASTER_KEY_PREVIOUS").split(",").map do |previous_key|
+previous = PasswordPusher::EnvOrFile.read("PWPUSH_MASTER_KEY_PREVIOUS")
+if previous
+  Lockbox.default_options[:previous_versions] = previous.split(",").map do |previous_key|
     {master_key: previous_key}
   end
 end

--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -35,7 +35,7 @@ Lockbox.master_key = PasswordPusher::EnvOrFile.read("PWPUSH_MASTER_KEY") ||
 
 previous = PasswordPusher::EnvOrFile.read("PWPUSH_MASTER_KEY_PREVIOUS")
 if previous
-  Lockbox.default_options[:previous_versions] = previous.split(",").map do |previous_key|
+  Lockbox.default_options[:previous_versions] = previous.split(",").map(&:strip).reject(&:empty?).map do |previous_key|
     {master_key: previous_key}
   end
 end

--- a/containers/docker/entrypoint.sh
+++ b/containers/docker/entrypoint.sh
@@ -47,6 +47,16 @@ Documentation: https://docs.pwpush.com
 Support: https://docs.pwpush.com/docs/support/
 "
 
+# Resolve SECRET_KEY_BASE from a Docker secrets-style file when the env var is unset.
+# SECRET_KEY_BASE wins when both are set. Fail loudly if _FILE is set but unreadable.
+if [ -z "$SECRET_KEY_BASE" ] && [ -n "$SECRET_KEY_BASE_FILE" ]; then
+    if [ ! -r "$SECRET_KEY_BASE_FILE" ]; then
+        echo "ERROR: SECRET_KEY_BASE_FILE is set but not readable: $SECRET_KEY_BASE_FILE"
+        exit 1
+    fi
+    export SECRET_KEY_BASE=$(tr -d '[:space:]' < "$SECRET_KEY_BASE_FILE")
+fi
+
 # Validate or generate SECRET_KEY_BASE
 if [ -z "$SECRET_KEY_BASE" ]; then
     echo "⚠️  SECRET_KEY_BASE not set; generating a random key for this boot."

--- a/containers/docker/entrypoint.sh
+++ b/containers/docker/entrypoint.sh
@@ -51,10 +51,15 @@ Support: https://docs.pwpush.com/docs/support/
 # SECRET_KEY_BASE wins when both are set. Fail loudly if _FILE is set but unreadable.
 if [ -z "$SECRET_KEY_BASE" ] && [ -n "$SECRET_KEY_BASE_FILE" ]; then
     if [ ! -r "$SECRET_KEY_BASE_FILE" ]; then
-        echo "ERROR: SECRET_KEY_BASE_FILE is set but not readable: $SECRET_KEY_BASE_FILE"
+        echo "ERROR: SECRET_KEY_BASE_FILE is set but not readable: $SECRET_KEY_BASE_FILE" >&2
         exit 1
     fi
-    export SECRET_KEY_BASE=$(tr -d '[:space:]' < "$SECRET_KEY_BASE_FILE")
+    SECRET_KEY_BASE="$(tr -d '[:space:]' < "$SECRET_KEY_BASE_FILE")"
+    if [ -z "$SECRET_KEY_BASE" ]; then
+        echo "ERROR: SECRET_KEY_BASE_FILE is set but the file is empty: $SECRET_KEY_BASE_FILE" >&2
+        exit 1
+    fi
+    export SECRET_KEY_BASE
 fi
 
 # Validate or generate SECRET_KEY_BASE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,11 @@ x-env: &x-env
     # Generate a new key here: https://us.pwpush.com/generate_key
     # PWPUSH_MASTER_KEY: ""
     #
+    # Docker secrets (_FILE): instead of the env vars above, you can set:
+    #   PWPUSH_MASTER_KEY_FILE, PWPUSH_MASTER_KEY_PREVIOUS_FILE, SECRET_KEY_BASE_FILE
+    # to a path whose contents are the secret (e.g. /run/secrets/...). The env var wins if both are set.
+    # See: https://docs.pwpush.com/docs/application-encryption/
+    #
     # TLS_DOMAIN: For automatic TLS/SSL (e.g. HTTPS via Let's Encrypt), create a DNS record that
     #   points to this host, then set this env var to that domain (e.g. pwpush.example.com).
     #   The container will provision and renew certificates automatically.

--- a/lib/password_pusher/env_or_file.rb
+++ b/lib/password_pusher/env_or_file.rb
@@ -6,7 +6,8 @@ module PasswordPusher
   #
   # Resolution order:
   # 1. If +NAME+ is set and non-empty, use that value.
-  # 2. Else if +NAME_FILE+ is set, read and strip that file (fail if unreadable).
+  # 2. Else if +NAME_FILE+ is set, read and strip that file
+  #    (fail if unreadable or empty).
   # 3. Else return +nil+ (caller applies its own default).
   module EnvOrFile
     class Error < StandardError; end
@@ -20,11 +21,18 @@ module PasswordPusher
       path = ENV["#{name}_FILE"]
       return nil if path.nil? || path.empty?
 
-      unless File.readable?(path)
-        raise Error, "#{name}_FILE is set but not readable: #{path}"
+      contents = begin
+        File.read(path)
+      rescue SystemCallError, IOError => e
+        raise Error, "#{name}_FILE is set but not readable: #{path} (#{e.message})"
       end
 
-      File.read(path).strip
+      stripped = contents.strip
+      if stripped.empty?
+        raise Error, "#{name}_FILE is set but the file is empty: #{path}"
+      end
+
+      stripped
     end
   end
 end

--- a/lib/password_pusher/env_or_file.rb
+++ b/lib/password_pusher/env_or_file.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module PasswordPusher
+  # Resolve a secret from an environment variable, or from a file path given by
+  # a companion +NAME_FILE+ variable (Docker Compose/Swarm secrets convention).
+  #
+  # Resolution order:
+  # 1. If +NAME+ is set and non-empty, use that value.
+  # 2. Else if +NAME_FILE+ is set, read and strip that file (fail if unreadable).
+  # 3. Else return +nil+ (caller applies its own default).
+  module EnvOrFile
+    class Error < StandardError; end
+
+    module_function
+
+    def read(name)
+      value = ENV[name]
+      return value if value && !value.empty?
+
+      path = ENV["#{name}_FILE"]
+      return nil if path.nil? || path.empty?
+
+      unless File.readable?(path)
+        raise Error, "#{name}_FILE is set but not readable: #{path}"
+      end
+
+      File.read(path).strip
+    end
+  end
+end

--- a/test/lib/password_pusher/env_or_file_test.rb
+++ b/test/lib/password_pusher/env_or_file_test.rb
@@ -98,4 +98,41 @@ class PasswordPusher::EnvOrFileTest < ActiveSupport::TestCase
 
     assert_nil PasswordPusher::EnvOrFile.read(ENV_NAME)
   end
+
+  test "raises when _FILE points to an empty file" do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "secret")
+      File.write(path, "")
+      ENV[FILE_ENV_NAME] = path
+
+      error = assert_raises(PasswordPusher::EnvOrFile::Error) do
+        PasswordPusher::EnvOrFile.read(ENV_NAME)
+      end
+      assert_match(/empty/, error.message)
+    end
+  end
+
+  test "raises when _FILE points to a whitespace-only file" do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "secret")
+      File.write(path, " \n\t\n")
+      ENV[FILE_ENV_NAME] = path
+
+      error = assert_raises(PasswordPusher::EnvOrFile::Error) do
+        PasswordPusher::EnvOrFile.read(ENV_NAME)
+      end
+      assert_match(/empty/, error.message)
+    end
+  end
+
+  test "raises EnvOrFile::Error when _FILE points to a directory" do
+    Dir.mktmpdir do |dir|
+      ENV[FILE_ENV_NAME] = dir
+
+      error = assert_raises(PasswordPusher::EnvOrFile::Error) do
+        PasswordPusher::EnvOrFile.read(ENV_NAME)
+      end
+      assert_match(/not readable/, error.message)
+    end
+  end
 end

--- a/test/lib/password_pusher/env_or_file_test.rb
+++ b/test/lib/password_pusher/env_or_file_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+require "fileutils"
+
+class PasswordPusher::EnvOrFileTest < ActiveSupport::TestCase
+  ENV_NAME = "PWPUSH_ENV_OR_FILE_TEST"
+  FILE_ENV_NAME = "#{ENV_NAME}_FILE"
+
+  setup do
+    @original_env = ENV[ENV_NAME]
+    @original_file_env = ENV[FILE_ENV_NAME]
+    ENV.delete(ENV_NAME)
+    ENV.delete(FILE_ENV_NAME)
+  end
+
+  teardown do
+    if @original_env.nil?
+      ENV.delete(ENV_NAME)
+    else
+      ENV[ENV_NAME] = @original_env
+    end
+
+    if @original_file_env.nil?
+      ENV.delete(FILE_ENV_NAME)
+    else
+      ENV[FILE_ENV_NAME] = @original_file_env
+    end
+  end
+
+  test "returns ENV value when set and ignores _FILE" do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "secret")
+      File.write(path, "from-file")
+      ENV[ENV_NAME] = "from-env"
+      ENV[FILE_ENV_NAME] = path
+
+      assert_equal "from-env", PasswordPusher::EnvOrFile.read(ENV_NAME)
+    end
+  end
+
+  test "returns stripped file contents when ENV unset and _FILE set" do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "secret")
+      File.write(path, "secret-from-file\n")
+      ENV[FILE_ENV_NAME] = path
+
+      assert_equal "secret-from-file", PasswordPusher::EnvOrFile.read(ENV_NAME)
+    end
+  end
+
+  test "raises when _FILE is set but path is missing" do
+    ENV[FILE_ENV_NAME] = "/nonexistent/path/to/secret"
+
+    error = assert_raises(PasswordPusher::EnvOrFile::Error) do
+      PasswordPusher::EnvOrFile.read(ENV_NAME)
+    end
+    assert_match(/not readable/, error.message)
+    assert_match(FILE_ENV_NAME, error.message)
+  end
+
+  test "raises when _FILE is set but path is unreadable" do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "secret")
+      File.write(path, "secret")
+      File.chmod(0o000, path)
+      ENV[FILE_ENV_NAME] = path
+
+      begin
+        error = assert_raises(PasswordPusher::EnvOrFile::Error) do
+          PasswordPusher::EnvOrFile.read(ENV_NAME)
+        end
+        assert_match(/not readable/, error.message)
+      ensure
+        File.chmod(0o600, path)
+      end
+    end
+  end
+
+  test "uses file when ENV is empty and _FILE is set" do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "secret")
+      File.write(path, "from-file")
+      ENV[ENV_NAME] = ""
+      ENV[FILE_ENV_NAME] = path
+
+      assert_equal "from-file", PasswordPusher::EnvOrFile.read(ENV_NAME)
+    end
+  end
+
+  test "returns nil when neither ENV nor _FILE is set" do
+    assert_nil PasswordPusher::EnvOrFile.read(ENV_NAME)
+  end
+
+  test "returns nil when _FILE is empty" do
+    ENV[FILE_ENV_NAME] = ""
+
+    assert_nil PasswordPusher::EnvOrFile.read(ENV_NAME)
+  end
+end


### PR DESCRIPTION
## Summary

Adds Docker Compose/Swarm-style `_FILE` support so encryption secrets can be loaded from mounted files instead of environment variables.

Fixes #848

### Changes

- Add `PasswordPusher::EnvOrFile` helper (env wins; `_FILE` fallback; fail if file unreadable)
- Use helper for `PWPUSH_MASTER_KEY` and `PWPUSH_MASTER_KEY_PREVIOUS` in Lockbox initializer
- Resolve `SECRET_KEY_BASE_FILE` in Docker entrypoint before generate-if-missing
- Document `_FILE` vars in `docker-compose.yml` comments
- Unit tests for resolution rules

### Impact

- Additive and backward compatible: existing env-only deploys unchanged
- New optional vars: `PWPUSH_MASTER_KEY_FILE`, `PWPUSH_MASTER_KEY_PREVIOUS_FILE`, `SECRET_KEY_BASE_FILE`
- Missing/unreadable `_FILE` path fails startup (does not fall back to default key)

## Test plan

- [x] `bin/ci` green (901 unit + 119 system tests)
- [ ] Confirm env-only `PWPUSH_MASTER_KEY` / `SECRET_KEY_BASE` still work
- [ ] Confirm Compose secrets mount via `_FILE` vars boots and encrypts/decrypts
- [ ] Confirm bad `_FILE` path exits with clear error