### PR TITLE
Show app version in admin sidebar navigation

### DIFF
--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -12,6 +12,11 @@
         <%= _("Administration Center") %>
       <% end %>
     </h1>
+    <% if Version.current.present? %>
+      <span class="badge bg-secondary bg-opacity-10 text-secondary px-2 py-1">
+        v<%= Version.current %>
+      </span>
+    <% end %>
   </div>
 </div>
 

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -173,6 +173,43 @@ class AdminDashboardTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  def test_version_is_visible_in_admin_navigation_when_present
+    @mr_admin = users(:mr_admin)
+    sign_in @mr_admin
+
+    Version.stub :current, "1.0.53" do
+      get admin_root_path
+      assert_response :success
+      assert_match(/v1\.0\.53/, response.body)
+
+      get admin_users_path
+      assert_response :success
+      assert_match(/v1\.0\.53/, response.body)
+    end
+  end
+
+  def test_version_is_not_visible_in_admin_navigation_when_nil
+    @mr_admin = users(:mr_admin)
+    sign_in @mr_admin
+
+    Version.stub :current, nil do
+      get admin_users_path
+      assert_response :success
+      assert_no_match(/\bv\d+\.\d+/, response.body)
+    end
+  end
+
+  def test_version_is_not_visible_in_admin_navigation_when_blank
+    @mr_admin = users(:mr_admin)
+    sign_in @mr_admin
+
+    Version.stub :current, "" do
+      get admin_users_path
+      assert_response :success
+      assert_no_match(/\bv\d+\.\d+/, response.body)
+    end
+  end
+
   # Test admin dashboard content and statistics
   def test_admin_dashboard_content
     @mr_admin = users(:mr_admin)


### PR DESCRIPTION
## Summary

Shows the running app version in the Administration Center sidebar so it is visible on every admin page, including when the public footer version is hidden.

Fixes #2693

### Changes

- Add `v<%= Version.current %>` badge to the admin sidebar header
- Add integration coverage for present / nil / blank version in shared navigation

### Impact

- No migrations, env vars, or route changes
- Admin version display is independent of `PWP__SHOW_VERSION`