### PR TITLE
Honor theme toggle preference in the admin center

### DIFF
--- a/app/views/admin/_javascript.html.erb
+++ b/app/views/admin/_javascript.html.erb
@@ -35,312 +35,299 @@
     font-weight: 600;
   }
 
-  /* Dark Theme Support — follows data-bs-theme (toggle / PWP__THEME_MODE), not OS alone. */
-  html[data-bs-theme="dark"] {
-    /* Body and Background */
-    body {
-      background-color: #121212 !important;
-      color: #e9ecef !important;
-    }
+  /* Dark Theme Support — follows data-bs-theme (toggle / PWP__THEME_MODE), not OS alone.
+     Fully-qualified selectors (no nesting) so this raw <style> block is portable. */
+  html[data-bs-theme="dark"] body {
+    background-color: #121212 !important;
+    color: #e9ecef !important;
+  }
 
-    body.bg-light {
-      background-color: #121212 !important;
-    }
+  html[data-bs-theme="dark"] body.bg-light {
+    background-color: #121212 !important;
+  }
 
-    /* Sidebar */
-    aside.bg-white {
-      background-color: #1e1e1e !important;
-      border-color: #2d2d2d !important;
-    }
+  html[data-bs-theme="dark"] aside.bg-white {
+    background-color: #1e1e1e !important;
+    border-color: #2d2d2d !important;
+  }
 
-    /* Header/Top Bar */
-    header.bg-white {
-      background-color: #1e1e1e !important;
-      border-color: #2d2d2d !important;
-    }
+  html[data-bs-theme="dark"] header.bg-white {
+    background-color: #1e1e1e !important;
+    border-color: #2d2d2d !important;
+  }
 
-    /* Navigation Links - Default State */
-    .text-dark {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .text-dark {
+    color: #e9ecef !important;
+  }
 
-    .text-muted {
-      color: #adb5bd !important;
-    }
+  html[data-bs-theme="dark"] .text-muted {
+    color: #adb5bd !important;
+  }
 
-    /* Headings */
-    h1, h2, h3, h4, h5, h6,
-    .h1, .h2, .h3, .h4, .h5, .h6 {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] h1,
+  html[data-bs-theme="dark"] h2,
+  html[data-bs-theme="dark"] h3,
+  html[data-bs-theme="dark"] h4,
+  html[data-bs-theme="dark"] h5,
+  html[data-bs-theme="dark"] h6,
+  html[data-bs-theme="dark"] .h1,
+  html[data-bs-theme="dark"] .h2,
+  html[data-bs-theme="dark"] .h3,
+  html[data-bs-theme="dark"] .h4,
+  html[data-bs-theme="dark"] .h5,
+  html[data-bs-theme="dark"] .h6 {
+    color: #e9ecef !important;
+  }
 
-    /* Cards */
-    .card {
-      background-color: #1e1e1e !important;
-      border-color: #2d2d2d !important;
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .card {
+    background-color: #1e1e1e !important;
+    border-color: #2d2d2d !important;
+    color: #e9ecef !important;
+  }
 
-    .card-body {
-      background-color: #1e1e1e !important;
-    }
+  html[data-bs-theme="dark"] .card-body {
+    background-color: #1e1e1e !important;
+  }
 
-    /* Alerts */
-    .alert-danger {
-      background-color: #2d1f1f !important;
-      border-color: #5c3333 !important;
-      color: #f8d7da !important;
-    }
+  html[data-bs-theme="dark"] .alert-danger {
+    background-color: #2d1f1f !important;
+    border-color: #5c3333 !important;
+    color: #f8d7da !important;
+  }
 
-    .alert-info {
-      background-color: #1a2730 !important;
-      border-color: #2d4a5c !important;
-      color: #cfe2ff !important;
-    }
+  html[data-bs-theme="dark"] .alert-info {
+    background-color: #1a2730 !important;
+    border-color: #2d4a5c !important;
+    color: #cfe2ff !important;
+  }
 
-    .alert-warning {
-      background-color: #332b1f !important;
-      border-color: #664d26 !important;
-      color: #fff3cd !important;
-    }
+  html[data-bs-theme="dark"] .alert-warning {
+    background-color: #332b1f !important;
+    border-color: #664d26 !important;
+    color: #fff3cd !important;
+  }
 
-    .alert-heading {
-      color: inherit !important;
-    }
+  html[data-bs-theme="dark"] .alert-heading {
+    color: inherit !important;
+  }
 
-    .text-danger-emphasis,
-    .text-info-emphasis,
-    .text-warning-emphasis,
-    .text-primary-emphasis {
-      color: inherit !important;
-    }
+  html[data-bs-theme="dark"] .text-danger-emphasis,
+  html[data-bs-theme="dark"] .text-info-emphasis,
+  html[data-bs-theme="dark"] .text-warning-emphasis,
+  html[data-bs-theme="dark"] .text-primary-emphasis {
+    color: inherit !important;
+  }
 
-    /* Backgrounds */
-    .bg-light {
-      background-color: #2d2d2d !important;
-    }
+  html[data-bs-theme="dark"] .bg-light {
+    background-color: #2d2d2d !important;
+  }
 
-    .bg-white {
-      background-color: #1e1e1e !important;
-    }
+  html[data-bs-theme="dark"] .bg-white {
+    background-color: #1e1e1e !important;
+  }
 
-    .bg-primary.bg-gradient {
-      background-color: #4169E1 !important;
-    }
+  html[data-bs-theme="dark"] .bg-primary.bg-gradient {
+    background-color: #4169E1 !important;
+  }
 
-    /* Borders */
-    .border-bottom,
-    .border-end,
-    .border {
-      border-color: #2d2d2d !important;
-    }
+  html[data-bs-theme="dark"] .border-bottom,
+  html[data-bs-theme="dark"] .border-end,
+  html[data-bs-theme="dark"] .border {
+    border-color: #2d2d2d !important;
+  }
 
-    .border-primary {
-      border-color: #4169E1 !important;
-    }
+  html[data-bs-theme="dark"] .border-primary {
+    border-color: #4169E1 !important;
+  }
 
-    /* Hover States */
-    .hover-bg-light:hover {
-      background-color: rgba(255, 255, 255, 0.1) !important;
-    }
+  html[data-bs-theme="dark"] .hover-bg-light:hover {
+    background-color: rgba(255, 255, 255, 0.1) !important;
+  }
 
-    /* Active States */
-    .bg-primary.bg-opacity-10 {
-      background-color: rgba(65, 105, 225, 0.2) !important;
-    }
+  html[data-bs-theme="dark"] .bg-primary.bg-opacity-10 {
+    background-color: rgba(65, 105, 225, 0.2) !important;
+  }
 
-    .bg-success.bg-opacity-10 {
-      background-color: rgba(119, 179, 0, 0.2) !important;
-    }
+  html[data-bs-theme="dark"] .bg-success.bg-opacity-10 {
+    background-color: rgba(119, 179, 0, 0.2) !important;
+  }
 
-    .bg-warning.bg-opacity-10 {
-      background-color: rgba(255, 136, 0, 0.2) !important;
-    }
+  html[data-bs-theme="dark"] .bg-warning.bg-opacity-10 {
+    background-color: rgba(255, 136, 0, 0.2) !important;
+  }
 
-    .bg-info.bg-opacity-10 {
-      background-color: rgba(153, 51, 204, 0.2) !important;
-    }
+  html[data-bs-theme="dark"] .bg-info.bg-opacity-10 {
+    background-color: rgba(153, 51, 204, 0.2) !important;
+  }
 
-    .bg-danger.bg-opacity-10 {
-      background-color: rgba(204, 0, 0, 0.2) !important;
-    }
+  html[data-bs-theme="dark"] .bg-danger.bg-opacity-10 {
+    background-color: rgba(204, 0, 0, 0.2) !important;
+  }
 
-    /* Text Colors for Active/Emphasis States */
-    .text-primary {
-      color: #6495ed !important;
-    }
+  html[data-bs-theme="dark"] .text-primary {
+    color: #6495ed !important;
+  }
 
-    .text-success {
-      color: #77b300 !important;
-    }
+  html[data-bs-theme="dark"] .text-success {
+    color: #77b300 !important;
+  }
 
-    .text-warning {
-      color: #f80 !important;
-    }
+  html[data-bs-theme="dark"] .text-warning {
+    color: #f80 !important;
+  }
 
-    .text-info {
-      color: #93c !important;
-    }
+  html[data-bs-theme="dark"] .text-info {
+    color: #93c !important;
+  }
 
-    .text-danger {
-      color: #ff6b6b !important;
-    }
+  html[data-bs-theme="dark"] .text-danger {
+    color: #ff6b6b !important;
+  }
 
-    /* Buttons */
-    .btn-outline-secondary {
-      color: #adb5bd !important;
-      border-color: #495057 !important;
-    }
+  html[data-bs-theme="dark"] .btn-outline-secondary {
+    color: #adb5bd !important;
+    border-color: #495057 !important;
+  }
 
-    .btn-outline-secondary:hover {
-      background-color: #495057 !important;
-      color: #fff !important;
-    }
+  html[data-bs-theme="dark"] .btn-outline-secondary:hover {
+    background-color: #495057 !important;
+    color: #fff !important;
+  }
 
-    .btn-outline-primary {
-      color: #6495ed !important;
-      border-color: #4169E1 !important;
-    }
+  html[data-bs-theme="dark"] .btn-outline-primary {
+    color: #6495ed !important;
+    border-color: #4169E1 !important;
+  }
 
-    .btn-outline-primary:hover {
-      background-color: #4169E1 !important;
-      color: #fff !important;
-    }
+  html[data-bs-theme="dark"] .btn-outline-primary:hover {
+    background-color: #4169E1 !important;
+    color: #fff !important;
+  }
 
-    .btn-outline-success {
-      color: #77b300 !important;
-      border-color: #77b300 !important;
-    }
+  html[data-bs-theme="dark"] .btn-outline-success {
+    color: #77b300 !important;
+    border-color: #77b300 !important;
+  }
 
-    .btn-outline-success:hover {
-      background-color: #77b300 !important;
-      color: #fff !important;
-    }
+  html[data-bs-theme="dark"] .btn-outline-success:hover {
+    background-color: #77b300 !important;
+    color: #fff !important;
+  }
 
-    .btn-primary {
-      background-color: #4169E1 !important;
-      border-color: #4169E1 !important;
-    }
+  html[data-bs-theme="dark"] .btn-primary {
+    background-color: #4169E1 !important;
+    border-color: #4169E1 !important;
+  }
 
-    .btn-warning {
-      background-color: #f80 !important;
-      border-color: #f80 !important;
-      color: #000 !important;
-    }
+  html[data-bs-theme="dark"] .btn-warning {
+    background-color: #f80 !important;
+    border-color: #f80 !important;
+    color: #000 !important;
+  }
 
-    /* Badges */
-    .badge.bg-warning {
-      background-color: #f80 !important;
-      color: #000 !important;
-    }
+  html[data-bs-theme="dark"] .badge.bg-warning {
+    background-color: #f80 !important;
+    color: #000 !important;
+  }
 
-    .badge.bg-primary {
-      background-color: #4169E1 !important;
-    }
+  html[data-bs-theme="dark"] .badge.bg-primary {
+    background-color: #4169E1 !important;
+  }
 
-    .badge.bg-success {
-      background-color: #77b300 !important;
-    }
+  html[data-bs-theme="dark"] .badge.bg-success {
+    background-color: #77b300 !important;
+  }
 
-    .badge.bg-danger {
-      background-color: #c00 !important;
-    }
+  html[data-bs-theme="dark"] .badge.bg-danger {
+    background-color: #c00 !important;
+  }
 
-    /* Form Elements */
-    input[type="text"],
-    input[type="email"],
-    input[type="password"],
-    input[type="number"],
-    input[type="datetime-local"],
-    select,
-    textarea {
-      background-color: #2d2d2d !important;
-      border-color: #495057 !important;
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] input[type="text"],
+  html[data-bs-theme="dark"] input[type="email"],
+  html[data-bs-theme="dark"] input[type="password"],
+  html[data-bs-theme="dark"] input[type="number"],
+  html[data-bs-theme="dark"] input[type="datetime-local"],
+  html[data-bs-theme="dark"] select,
+  html[data-bs-theme="dark"] textarea {
+    background-color: #2d2d2d !important;
+    border-color: #495057 !important;
+    color: #e9ecef !important;
+  }
 
-    input[type="text"]:focus,
-    input[type="email"]:focus,
-    input[type="password"]:focus,
-    input[type="number"]:focus,
-    input[type="datetime-local"]:focus,
-    select:focus,
-    textarea:focus {
-      background-color: #2d2d2d !important;
-      border-color: #6495ed !important;
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] input[type="text"]:focus,
+  html[data-bs-theme="dark"] input[type="email"]:focus,
+  html[data-bs-theme="dark"] input[type="password"]:focus,
+  html[data-bs-theme="dark"] input[type="number"]:focus,
+  html[data-bs-theme="dark"] input[type="datetime-local"]:focus,
+  html[data-bs-theme="dark"] select:focus,
+  html[data-bs-theme="dark"] textarea:focus {
+    background-color: #2d2d2d !important;
+    border-color: #6495ed !important;
+    color: #e9ecef !important;
+  }
 
-    /* Tables */
-    .table {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .table {
+    color: #e9ecef !important;
+  }
 
-    .table thead th {
-      background-color: #282828 !important;
-      color: #e9ecef !important;
-      border-color: #2d2d2d !important;
-    }
+  html[data-bs-theme="dark"] .table thead th {
+    background-color: #282828 !important;
+    color: #e9ecef !important;
+    border-color: #2d2d2d !important;
+  }
 
-    .table > :not(caption) > * > * {
-      background-color: #282828 !important;
-      color: #e9ecef !important;
-      border-color: #2d2d2d !important;
-    }
+  html[data-bs-theme="dark"] .table > :not(caption) > * > * {
+    background-color: #282828 !important;
+    color: #e9ecef !important;
+    border-color: #2d2d2d !important;
+  }
 
-    .table-striped > tbody > tr:nth-of-type(2n+1) > * {
-      background-color: #212529 !important;
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .table-striped > tbody > tr:nth-of-type(2n+1) > * {
+    background-color: #212529 !important;
+    color: #e9ecef !important;
+  }
 
-    /* Links */
-    a {
-      color: #6495ed !important;
-    }
+  html[data-bs-theme="dark"] a {
+    color: #6495ed !important;
+  }
 
-    a:hover {
-      color: #5080e0 !important;
-    }
+  html[data-bs-theme="dark"] a:hover {
+    color: #5080e0 !important;
+  }
 
-    /* Breadcrumb */
-    .breadcrumb-item a {
-      color: #adb5bd !important;
-    }
+  html[data-bs-theme="dark"] .breadcrumb-item a {
+    color: #adb5bd !important;
+  }
 
-    .breadcrumb-item.active {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .breadcrumb-item.active {
+    color: #e9ecef !important;
+  }
 
-    /* SVG Icons */
-    svg {
-      filter: brightness(1.2);
-    }
+  html[data-bs-theme="dark"] svg {
+    filter: brightness(1.2);
+  }
 
-    /* Specific overrides for navigation */
-    nav a.text-decoration-none {
-      color: #adb5bd !important;
-    }
+  html[data-bs-theme="dark"] nav a.text-decoration-none {
+    color: #adb5bd !important;
+  }
 
-    nav a.text-decoration-none:hover {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] nav a.text-decoration-none:hover {
+    color: #e9ecef !important;
+  }
 
-    /* Footer */
-    footer a {
-      color: #adb5bd !important;
-    }
+  html[data-bs-theme="dark"] footer a {
+    color: #adb5bd !important;
+  }
 
-    footer a:hover {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] footer a:hover {
+    color: #e9ecef !important;
+  }
 
-    /* Display headings */
-    .display-4 {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .display-4 {
+    color: #e9ecef !important;
+  }
 
-    .lead {
-      color: #adb5bd !important;
-    }
+  html[data-bs-theme="dark"] .lead {
+    color: #adb5bd !important;
   }
 </style>

--- a/app/views/admin/_javascript.html.erb
+++ b/app/views/admin/_javascript.html.erb
@@ -35,8 +35,8 @@
     font-weight: 600;
   }
 
-  /* Dark Theme Support */
-  @media (prefers-color-scheme: dark) {
+  /* Dark Theme Support — follows data-bs-theme (toggle / PWP__THEME_MODE), not OS alone. */
+  html[data-bs-theme="dark"] {
     /* Body and Background */
     body {
       background-color: #121212 !important;

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
+<html lang="<%= I18n.locale %>"
+      data-controller="theme"
+      data-theme-mode="<%= Settings.theme_mode %>"
+      data-theme-instance-mode-value="<%= Settings.theme_mode %>"
+      data-theme-label-light-value="<%= _("Use light theme") %>"
+      data-theme-label-dark-value="<%= _("Use dark theme") %>"
+      data-theme-label-system-value="<%= _("Use system theme") %>"
+      <% if Settings.theme_mode_locked? %> data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
   <head>
+    <%= render partial: "shared/theme_boot" %>
     <meta charset="utf-8">
     <meta name="ROBOTS" content="NOODP">
     <meta name="viewport" content="initial-scale=1">
@@ -47,6 +55,8 @@
 
             <!-- Admin Actions -->
             <div class="d-flex align-items-center gap-3">
+              <%= render partial: "shared/theme_toggle" %>
+
               <!-- System Status -->
               <div class="d-flex align-items-center px-3 py-1 rounded-pill text-sm fw-medium bg-success bg-opacity-10 text-success">
                 <div class="rounded-circle bg-success me-2" style="width: 8px; height: 8px;"></div>

--- a/app/views/layouts/madmin/application.html.erb
+++ b/app/views/layouts/madmin/application.html.erb
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
+<html lang="<%= I18n.locale %>"
+      data-controller="theme"
+      data-theme-mode="<%= Settings.theme_mode %>"
+      data-theme-instance-mode-value="<%= Settings.theme_mode %>"
+      data-theme-label-light-value="<%= _("Use light theme") %>"
+      data-theme-label-dark-value="<%= _("Use dark theme") %>"
+      data-theme-label-system-value="<%= _("Use system theme") %>"
+      <% if Settings.theme_mode_locked? %> data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
   <head>
+    <%= render partial: "shared/theme_boot" %>
     <meta charset="utf-8">
     <meta name="ROBOTS" content="NOODP">
     <meta name="viewport" content="initial-scale=1">
@@ -30,6 +38,12 @@
 
       <!-- Main Content -->
       <main class="flex-grow-1 d-flex flex-column">
+        <header class="bg-white border-bottom px-4 py-3">
+          <div class="d-flex align-items-center justify-content-end">
+            <%= render partial: "shared/theme_toggle" %>
+          </div>
+        </header>
+
         <!-- Page Content -->
         <div class="flex-grow-1 p-4">
           <%= render "madmin/application/flash" %>

--- a/app/views/madmin/application/_javascript.html.erb
+++ b/app/views/madmin/application/_javascript.html.erb
@@ -70,8 +70,8 @@
     font-weight: 500;
   }
 
-  /* Dark Theme Support */
-  @media (prefers-color-scheme: dark) {
+  /* Dark Theme Support — follows data-bs-theme (toggle / PWP__THEME_MODE), not OS alone. */
+  html[data-bs-theme="dark"] {
     /* Body and Background */
     body {
       background-color: #121212 !important;

--- a/app/views/madmin/application/_javascript.html.erb
+++ b/app/views/madmin/application/_javascript.html.erb
@@ -70,295 +70,283 @@
     font-weight: 500;
   }
 
-  /* Dark Theme Support — follows data-bs-theme (toggle / PWP__THEME_MODE), not OS alone. */
-  html[data-bs-theme="dark"] {
-    /* Body and Background */
-    body {
-      background-color: #121212 !important;
-      color: #e9ecef !important;
-    }
+  /* Dark Theme Support — follows data-bs-theme (toggle / PWP__THEME_MODE), not OS alone.
+     Fully-qualified selectors (no nesting) so this raw <style> block is portable. */
+  html[data-bs-theme="dark"] body {
+    background-color: #121212 !important;
+    color: #e9ecef !important;
+  }
 
-    body.bg-light {
-      background-color: #121212 !important;
-    }
+  html[data-bs-theme="dark"] body.bg-light {
+    background-color: #121212 !important;
+  }
 
-    /* Sidebar */
-    aside.bg-white {
-      background-color: #1e1e1e !important;
-      border-color: #2d2d2d !important;
-    }
+  html[data-bs-theme="dark"] aside.bg-white {
+    background-color: #1e1e1e !important;
+    border-color: #2d2d2d !important;
+  }
 
-    /* Header/Top Bar */
-    header.bg-white {
-      background-color: #1e1e1e !important;
-      border-color: #2d2d2d !important;
-    }
+  html[data-bs-theme="dark"] header.bg-white {
+    background-color: #1e1e1e !important;
+    border-color: #2d2d2d !important;
+  }
 
-    /* Navigation Links - Default State */
-    .text-dark {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .text-dark {
+    color: #e9ecef !important;
+  }
 
-    .text-muted {
-      color: #adb5bd !important;
-    }
+  html[data-bs-theme="dark"] .text-muted {
+    color: #adb5bd !important;
+  }
 
-    /* Headings */
-    h1, h2, h3, h4, h5, h6,
-    .h1, .h2, .h3, .h4, .h5, .h6 {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] h1,
+  html[data-bs-theme="dark"] h2,
+  html[data-bs-theme="dark"] h3,
+  html[data-bs-theme="dark"] h4,
+  html[data-bs-theme="dark"] h5,
+  html[data-bs-theme="dark"] h6,
+  html[data-bs-theme="dark"] .h1,
+  html[data-bs-theme="dark"] .h2,
+  html[data-bs-theme="dark"] .h3,
+  html[data-bs-theme="dark"] .h4,
+  html[data-bs-theme="dark"] .h5,
+  html[data-bs-theme="dark"] .h6 {
+    color: #e9ecef !important;
+  }
 
-    /* Cards */
-    .card {
-      background-color: #1e1e1e !important;
-      border-color: #2d2d2d !important;
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .card {
+    background-color: #1e1e1e !important;
+    border-color: #2d2d2d !important;
+    color: #e9ecef !important;
+  }
 
-    .card-body {
-      background-color: #1e1e1e !important;
-    }
+  html[data-bs-theme="dark"] .card-body {
+    background-color: #1e1e1e !important;
+  }
 
-    /* Alerts */
-    .alert-danger {
-      background-color: #2d1f1f !important;
-      border-color: #5c3333 !important;
-      color: #f8d7da !important;
-    }
+  html[data-bs-theme="dark"] .alert-danger {
+    background-color: #2d1f1f !important;
+    border-color: #5c3333 !important;
+    color: #f8d7da !important;
+  }
 
-    .alert-info {
-      background-color: #1a2730 !important;
-      border-color: #2d4a5c !important;
-      color: #cfe2ff !important;
-    }
+  html[data-bs-theme="dark"] .alert-info {
+    background-color: #1a2730 !important;
+    border-color: #2d4a5c !important;
+    color: #cfe2ff !important;
+  }
 
-    .alert-warning {
-      background-color: #332b1f !important;
-      border-color: #664d26 !important;
-      color: #fff3cd !important;
-    }
+  html[data-bs-theme="dark"] .alert-warning {
+    background-color: #332b1f !important;
+    border-color: #664d26 !important;
+    color: #fff3cd !important;
+  }
 
-    .alert-heading {
-      color: inherit !important;
-    }
+  html[data-bs-theme="dark"] .alert-heading {
+    color: inherit !important;
+  }
 
-    .text-danger-emphasis,
-    .text-info-emphasis,
-    .text-warning-emphasis,
-    .text-primary-emphasis {
-      color: inherit !important;
-    }
+  html[data-bs-theme="dark"] .text-danger-emphasis,
+  html[data-bs-theme="dark"] .text-info-emphasis,
+  html[data-bs-theme="dark"] .text-warning-emphasis,
+  html[data-bs-theme="dark"] .text-primary-emphasis {
+    color: inherit !important;
+  }
 
-    /* Backgrounds */
-    .bg-light {
-      background-color: #2d2d2d !important;
-    }
+  html[data-bs-theme="dark"] .bg-light {
+    background-color: #2d2d2d !important;
+  }
 
-    .bg-white {
-      background-color: #1e1e1e !important;
-    }
+  html[data-bs-theme="dark"] .bg-white {
+    background-color: #1e1e1e !important;
+  }
 
-    /* Borders */
-    .border-bottom,
-    .border-end,
-    .border {
-      border-color: #2d2d2d !important;
-    }
+  html[data-bs-theme="dark"] .border-bottom,
+  html[data-bs-theme="dark"] .border-end,
+  html[data-bs-theme="dark"] .border {
+    border-color: #2d2d2d !important;
+  }
 
-    /* Hover States */
-    .hover-bg-light:hover {
-      background-color: rgba(255, 255, 255, 0.1) !important;
-    }
+  html[data-bs-theme="dark"] .hover-bg-light:hover {
+    background-color: rgba(255, 255, 255, 0.1) !important;
+  }
 
-    /* Active States */
-    .bg-primary.bg-opacity-10 {
-      background-color: rgba(65, 105, 225, 0.2) !important;
-    }
+  html[data-bs-theme="dark"] .bg-primary.bg-opacity-10 {
+    background-color: rgba(65, 105, 225, 0.2) !important;
+  }
 
-    .bg-success.bg-opacity-10 {
-      background-color: rgba(119, 179, 0, 0.2) !important;
-    }
+  html[data-bs-theme="dark"] .bg-success.bg-opacity-10 {
+    background-color: rgba(119, 179, 0, 0.2) !important;
+  }
 
-    .bg-warning.bg-opacity-10 {
-      background-color: rgba(255, 136, 0, 0.2) !important;
-    }
+  html[data-bs-theme="dark"] .bg-warning.bg-opacity-10 {
+    background-color: rgba(255, 136, 0, 0.2) !important;
+  }
 
-    .bg-info.bg-opacity-10 {
-      background-color: rgba(153, 51, 204, 0.2) !important;
-    }
+  html[data-bs-theme="dark"] .bg-info.bg-opacity-10 {
+    background-color: rgba(153, 51, 204, 0.2) !important;
+  }
 
-    .bg-danger.bg-opacity-10 {
-      background-color: rgba(204, 0, 0, 0.2) !important;
-    }
+  html[data-bs-theme="dark"] .bg-danger.bg-opacity-10 {
+    background-color: rgba(204, 0, 0, 0.2) !important;
+  }
 
-    /* Text Colors for Active/Emphasis States */
-    .text-primary {
-      color: #6495ed !important;
-    }
+  html[data-bs-theme="dark"] .text-primary {
+    color: #6495ed !important;
+  }
 
-    .text-success {
-      color: #77b300 !important;
-    }
+  html[data-bs-theme="dark"] .text-success {
+    color: #77b300 !important;
+  }
 
-    .text-warning {
-      color: #f80 !important;
-    }
+  html[data-bs-theme="dark"] .text-warning {
+    color: #f80 !important;
+  }
 
-    .text-info {
-      color: #93c !important;
-    }
+  html[data-bs-theme="dark"] .text-info {
+    color: #93c !important;
+  }
 
-    .text-danger {
-      color: #ff6b6b !important;
-    }
+  html[data-bs-theme="dark"] .text-danger {
+    color: #ff6b6b !important;
+  }
 
-    /* Buttons */
-    .btn-outline-secondary {
-      color: #adb5bd !important;
-      border-color: #495057 !important;
-    }
+  html[data-bs-theme="dark"] .btn-outline-secondary {
+    color: #adb5bd !important;
+    border-color: #495057 !important;
+  }
 
-    .btn-outline-secondary:hover {
-      background-color: #495057 !important;
-      color: #fff !important;
-    }
+  html[data-bs-theme="dark"] .btn-outline-secondary:hover {
+    background-color: #495057 !important;
+    color: #fff !important;
+  }
 
-    .btn-outline-primary {
-      color: #6495ed !important;
-      border-color: #4169E1 !important;
-    }
+  html[data-bs-theme="dark"] .btn-outline-primary {
+    color: #6495ed !important;
+    border-color: #4169E1 !important;
+  }
 
-    .btn-outline-primary:hover {
-      background-color: #4169E1 !important;
-      color: #fff !important;
-    }
+  html[data-bs-theme="dark"] .btn-outline-primary:hover {
+    background-color: #4169E1 !important;
+    color: #fff !important;
+  }
 
-    .btn-outline-success {
-      color: #77b300 !important;
-      border-color: #77b300 !important;
-    }
+  html[data-bs-theme="dark"] .btn-outline-success {
+    color: #77b300 !important;
+    border-color: #77b300 !important;
+  }
 
-    .btn-outline-success:hover {
-      background-color: #77b300 !important;
-      color: #fff !important;
-    }
+  html[data-bs-theme="dark"] .btn-outline-success:hover {
+    background-color: #77b300 !important;
+    color: #fff !important;
+  }
 
-    .btn-primary {
-      background-color: #4169E1 !important;
-      border-color: #4169E1 !important;
-    }
+  html[data-bs-theme="dark"] .btn-primary {
+    background-color: #4169E1 !important;
+    border-color: #4169E1 !important;
+  }
 
-    .btn-warning {
-      background-color: #f80 !important;
-      border-color: #f80 !important;
-      color: #000 !important;
-    }
+  html[data-bs-theme="dark"] .btn-warning {
+    background-color: #f80 !important;
+    border-color: #f80 !important;
+    color: #000 !important;
+  }
 
-    /* Badges */
-    .badge.bg-warning {
-      background-color: #f80 !important;
-      color: #000 !important;
-    }
+  html[data-bs-theme="dark"] .badge.bg-warning {
+    background-color: #f80 !important;
+    color: #000 !important;
+  }
 
-    .badge.bg-primary {
-      background-color: #4169E1 !important;
-    }
+  html[data-bs-theme="dark"] .badge.bg-primary {
+    background-color: #4169E1 !important;
+  }
 
-    .badge.bg-success {
-      background-color: #77b300 !important;
-    }
+  html[data-bs-theme="dark"] .badge.bg-success {
+    background-color: #77b300 !important;
+  }
 
-    .badge.bg-danger {
-      background-color: #c00 !important;
-    }
+  html[data-bs-theme="dark"] .badge.bg-danger {
+    background-color: #c00 !important;
+  }
 
-    /* Form Elements */
-    .madmin-form input[type="text"],
-    .madmin-form input[type="email"],
-    .madmin-form input[type="password"],
-    .madmin-form input[type="number"],
-    .madmin-form input[type="datetime-local"],
-    .madmin-form select,
-    .madmin-form textarea {
-      background-color: #2d2d2d !important;
-      border-color: #495057 !important;
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .madmin-form input[type="text"],
+  html[data-bs-theme="dark"] .madmin-form input[type="email"],
+  html[data-bs-theme="dark"] .madmin-form input[type="password"],
+  html[data-bs-theme="dark"] .madmin-form input[type="number"],
+  html[data-bs-theme="dark"] .madmin-form input[type="datetime-local"],
+  html[data-bs-theme="dark"] .madmin-form select,
+  html[data-bs-theme="dark"] .madmin-form textarea {
+    background-color: #2d2d2d !important;
+    border-color: #495057 !important;
+    color: #e9ecef !important;
+  }
 
-    .madmin-form input[type="text"]:focus,
-    .madmin-form input[type="email"]:focus,
-    .madmin-form input[type="password"]:focus,
-    .madmin-form input[type="number"]:focus,
-    .madmin-form input[type="datetime-local"]:focus,
-    .madmin-form select:focus,
-    .madmin-form textarea:focus {
-      background-color: #2d2d2d !important;
-      border-color: #6495ed !important;
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .madmin-form input[type="text"]:focus,
+  html[data-bs-theme="dark"] .madmin-form input[type="email"]:focus,
+  html[data-bs-theme="dark"] .madmin-form input[type="password"]:focus,
+  html[data-bs-theme="dark"] .madmin-form input[type="number"]:focus,
+  html[data-bs-theme="dark"] .madmin-form input[type="datetime-local"]:focus,
+  html[data-bs-theme="dark"] .madmin-form select:focus,
+  html[data-bs-theme="dark"] .madmin-form textarea:focus {
+    background-color: #2d2d2d !important;
+    border-color: #6495ed !important;
+    color: #e9ecef !important;
+  }
 
-    /* Tables */
-    .table {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .table {
+    color: #e9ecef !important;
+  }
 
-    .table thead th {
-      background-color: #282828 !important;
-      color: #e9ecef !important;
-      border-color: #2d2d2d !important;
-    }
+  html[data-bs-theme="dark"] .table thead th {
+    background-color: #282828 !important;
+    color: #e9ecef !important;
+    border-color: #2d2d2d !important;
+  }
 
-    .table > :not(caption) > * > * {
-      background-color: #282828 !important;
-      color: #e9ecef !important;
-      border-color: #2d2d2d !important;
-    }
+  html[data-bs-theme="dark"] .table > :not(caption) > * > * {
+    background-color: #282828 !important;
+    color: #e9ecef !important;
+    border-color: #2d2d2d !important;
+  }
 
-    .table-striped > tbody > tr:nth-of-type(2n+1) > * {
-      background-color: #212529 !important;
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .table-striped > tbody > tr:nth-of-type(2n+1) > * {
+    background-color: #212529 !important;
+    color: #e9ecef !important;
+  }
 
-    /* Links */
-    a {
-      color: #6495ed !important;
-    }
+  html[data-bs-theme="dark"] a {
+    color: #6495ed !important;
+  }
 
-    a:hover {
-      color: #5080e0 !important;
-    }
+  html[data-bs-theme="dark"] a:hover {
+    color: #5080e0 !important;
+  }
 
-    /* Breadcrumb */
-    .breadcrumb-item a {
-      color: #adb5bd !important;
-    }
+  html[data-bs-theme="dark"] .breadcrumb-item a {
+    color: #adb5bd !important;
+  }
 
-    .breadcrumb-item.active {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] .breadcrumb-item.active {
+    color: #e9ecef !important;
+  }
 
-    /* SVG Icons */
-    svg {
-      filter: brightness(1.2);
-    }
+  html[data-bs-theme="dark"] svg {
+    filter: brightness(1.2);
+  }
 
-    /* Specific overrides for navigation */
-    nav a.text-decoration-none {
-      color: #adb5bd !important;
-    }
+  html[data-bs-theme="dark"] nav a.text-decoration-none {
+    color: #adb5bd !important;
+  }
 
-    nav a.text-decoration-none:hover {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] nav a.text-decoration-none:hover {
+    color: #e9ecef !important;
+  }
 
-    /* Footer */
-    footer a {
-      color: #adb5bd !important;
-    }
+  html[data-bs-theme="dark"] footer a {
+    color: #adb5bd !important;
+  }
 
-    footer a:hover {
-      color: #e9ecef !important;
-    }
+  html[data-bs-theme="dark"] footer a:hover {
+    color: #e9ecef !important;
   }
 </style>

--- a/test/integration/theme_mode_test.rb
+++ b/test/integration/theme_mode_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class ThemeModeTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
   teardown do
     Settings.reload!
   end
@@ -90,5 +92,46 @@ class ThemeModeTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match(/localStorage\.getItem\("theme"\)/, response.body)
     assert_match(/data-bs-theme/, response.body)
+  end
+
+  test "admin includes theme toggle and boot script when theme_mode is auto" do
+    Settings.theme_mode = "auto"
+    sign_in users(:mr_admin)
+
+    get admin_root_path
+
+    assert_response :success
+    assert_select "html[data-controller=theme]"
+    assert_select "html[data-theme-mode=auto]"
+    assert_select "#theme-mode-toggle"
+    assert_select "html[data-bs-theme]", count: 0
+    assert_match(/localStorage\.getItem\("theme"\)/, response.body)
+    assert_match(/html\[data-bs-theme="dark"\]/, response.body)
+  end
+
+  test "admin locks data-bs-theme and hides toggle when theme_mode is dark" do
+    Settings.theme_mode = "dark"
+    sign_in users(:mr_admin)
+
+    get admin_root_path
+
+    assert_response :success
+    assert_select "html[data-theme-mode=dark]"
+    assert_select "html[data-bs-theme=dark]"
+    assert_select "#theme-mode-toggle", count: 0
+  end
+
+  test "data explorer includes theme toggle when theme_mode is auto" do
+    Settings.theme_mode = "auto"
+    sign_in users(:mr_admin)
+
+    get madmin_root_path
+
+    assert_response :success
+    assert_select "html[data-controller=theme]"
+    assert_select "html[data-theme-mode=auto]"
+    assert_select "#theme-mode-toggle"
+    assert_match(/localStorage\.getItem\("theme"\)/, response.body)
+    assert_match(/html\[data-bs-theme="dark"\]/, response.body)
   end
 end

--- a/test/system/theme_mode_system_test.rb
+++ b/test/system/theme_mode_system_test.rb
@@ -45,6 +45,22 @@ class ThemeModeSystemTest < ApplicationSystemTestCase
     assert_equal "dark", page.evaluate_script("document.documentElement.getAttribute('data-bs-theme')")
   end
 
+  test "theme preference applies on admin dashboard" do
+    Settings.theme_mode = "auto"
+    login_as(users(:mr_admin), scope: :user)
+
+    visit root_path
+    page.execute_script("localStorage.setItem('theme', 'dark')")
+
+    visit admin_root_path
+
+    assert_selector "#theme-mode-toggle"
+    assert_equal "dark", page.evaluate_script("document.documentElement.getAttribute('data-bs-theme')")
+
+    find("#theme-mode-toggle").click
+    assert_equal "system", page.evaluate_script("localStorage.getItem('theme')")
+  end
+
   private
 
   def clear_theme_storage


### PR DESCRIPTION
## Summary

Admin and Data Explorer ignored the visitor theme toggle because they used a separate layout and still keyed dark CSS off the OS.

### Changes
- Apply the theme boot script, Stimulus controller, and toggle on admin and Data Explorer layouts
- Switch admin/madmin dark CSS from `prefers-color-scheme` to `html[data-bs-theme="dark"]`
- Cover toggle presence, locked mode, and preference persistence in integration and system tests

### Impact
- Saved light/dark/system preference now carries into `/admin` and Data Explorer
- `PWP__THEME_MODE` lock continues to hide the toggle in those areas
- `/admin/jobs` (Mission Control) is unchanged

## Test plan
- [ ] Set dark (or light) via the header toggle, then open `/admin` — preference should apply
- [ ] Cycle the toggle on the admin dashboard and confirm it persists back on the main app
- [ ] With `PWP__THEME_MODE=dark` (or light), confirm the admin toggle is hidden and the lock is forced
- [ ] Open Data Explorer and confirm the same behavior