### PR TITLE
Honor theme toggle on the background jobs page

### DIFF
--- a/app/views/layouts/mission_control/jobs/_application_selection.html.erb
+++ b/app/views/layouts/mission_control/jobs/_application_selection.html.erb
@@ -1,5 +1,5 @@
 <!-- Background Jobs Header -->
-<div style="margin-bottom: 1rem; padding: 1rem; background-color: white; border-bottom: 1px solid #e5e5e5;">
+<div class="jobs-theme-header">
   <!-- Top Section with Logo and Back Button -->
   <div class="level mb-4">
     <div class="level-left">
@@ -10,6 +10,9 @@
       </div>
     </div>
     <div class="level-right">
+      <div class="level-item">
+        <%= render partial: "layouts/mission_control/jobs/theme_toggle" %>
+      </div>
       <div class="level-item">
         <%= link_to "/admin", class: "button is-light" do %>
           <span class="icon is-small">

--- a/app/views/layouts/mission_control/jobs/_theme_styles.html.erb
+++ b/app/views/layouts/mission_control/jobs/_theme_styles.html.erb
@@ -1,0 +1,160 @@
+<%# Mission Control uses Bulma, not Bootstrap. Dark styles follow data-bs-theme
+    (theme toggle / PWP__THEME_MODE). Fully-qualified selectors — no nesting. %>
+<style>
+  .jobs-theme-header {
+    margin-bottom: 1rem;
+    padding: 1rem;
+    background-color: white;
+    border-bottom: 1px solid #e5e5e5;
+  }
+
+  #theme-mode-toggle {
+    min-width: 2.25rem;
+  }
+
+  html,
+  body {
+    min-height: 100vh;
+  }
+
+  html[data-bs-theme="dark"],
+  html[data-bs-theme="dark"] body,
+  html[data-bs-theme="dark"] .section {
+    background-color: #121212;
+    color: #e9ecef;
+  }
+
+  html[data-bs-theme="dark"] .title,
+  html[data-bs-theme="dark"] .subtitle,
+  html[data-bs-theme="dark"] .has-text-dark {
+    color: #e9ecef !important;
+  }
+
+  html[data-bs-theme="dark"] .has-text-grey,
+  html[data-bs-theme="dark"] .subtitle {
+    color: #adb5bd !important;
+  }
+
+  html[data-bs-theme="dark"] a {
+    color: #6495ed;
+  }
+
+  html[data-bs-theme="dark"] a:hover {
+    color: #5080e0;
+  }
+
+  html[data-bs-theme="dark"] .navbar,
+  html[data-bs-theme="dark"] .navbar-menu {
+    background-color: #121212;
+  }
+
+  html[data-bs-theme="dark"] .jobs-theme-header {
+    background-color: #1e1e1e;
+    border-bottom-color: #2d2d2d;
+  }
+
+  html[data-bs-theme="dark"] .tabs ul {
+    border-bottom-color: #2d2d2d;
+  }
+
+  html[data-bs-theme="dark"] .tabs a {
+    color: #adb5bd;
+    border-color: transparent;
+  }
+
+  html[data-bs-theme="dark"] .tabs a:hover {
+    color: #e9ecef;
+    background-color: #1e1e1e;
+    border-bottom-color: #495057;
+  }
+
+  html[data-bs-theme="dark"] .tabs li.is-active a {
+    color: #e9ecef;
+    background-color: #1e1e1e;
+    border-color: #2d2d2d;
+    border-bottom-color: transparent;
+  }
+
+  html[data-bs-theme="dark"] .table {
+    background-color: #1e1e1e;
+    color: #e9ecef;
+  }
+
+  html[data-bs-theme="dark"] .table thead th,
+  html[data-bs-theme="dark"] .table td,
+  html[data-bs-theme="dark"] .table th {
+    background-color: #1e1e1e;
+    color: #e9ecef;
+    border-color: #2d2d2d !important;
+  }
+
+  html[data-bs-theme="dark"] .table.is-hoverable tbody tr:hover,
+  html[data-bs-theme="dark"] .table.is-hoverable tbody tr:hover td {
+    background-color: #2d2d2d;
+  }
+
+  html[data-bs-theme="dark"] .button {
+    background-color: #2d2d2d;
+    border-color: #495057;
+    color: #e9ecef;
+  }
+
+  html[data-bs-theme="dark"] .button:hover,
+  html[data-bs-theme="dark"] .button.is-hovered {
+    background-color: #495057;
+    border-color: #6c757d;
+    color: #fff;
+  }
+
+  html[data-bs-theme="dark"] .button.is-light {
+    background-color: #2d2d2d;
+    color: #e9ecef;
+  }
+
+  html[data-bs-theme="dark"] .notification {
+    background-color: #1e1e1e;
+    color: #e9ecef;
+  }
+
+  html[data-bs-theme="dark"] .notification.is-info,
+  html[data-bs-theme="dark"] .notification.is-info.is-light {
+    background-color: #1a2730;
+    color: #cfe2ff;
+  }
+
+  html[data-bs-theme="dark"] .notification.is-warning,
+  html[data-bs-theme="dark"] .notification.is-danger,
+  html[data-bs-theme="dark"] .notification.is-success {
+    color: #e9ecef;
+  }
+
+  html[data-bs-theme="dark"] .box {
+    background-color: #1e1e1e;
+    color: #e9ecef;
+  }
+
+  html[data-bs-theme="dark"] .tag:not(body) {
+    background-color: #2d2d2d;
+    color: #e9ecef;
+  }
+
+  html[data-bs-theme="dark"] input,
+  html[data-bs-theme="dark"] select,
+  html[data-bs-theme="dark"] textarea,
+  html[data-bs-theme="dark"] .input,
+  html[data-bs-theme="dark"] .select select {
+    background-color: #2d2d2d;
+    border-color: #495057;
+    color: #e9ecef;
+  }
+
+  html[data-bs-theme="dark"] code,
+  html[data-bs-theme="dark"] pre {
+    background-color: #2d2d2d;
+    color: #e9ecef;
+  }
+
+  html[data-bs-theme="dark"] hr {
+    background-color: #2d2d2d;
+  }
+</style>

--- a/app/views/layouts/mission_control/jobs/_theme_toggle.html.erb
+++ b/app/views/layouts/mission_control/jobs/_theme_toggle.html.erb
@@ -14,6 +14,7 @@
       var icon = document.getElementById("theme-mode-toggle-icon")
       if (!btn) return
 
+      var sessionPreference = null
       var order = ["light", "dark", "system"]
       var labels = {
         light: <%= raw _("Use dark theme").to_json %>,
@@ -27,6 +28,9 @@
           var value = localStorage.getItem("theme")
           if (value === "light" || value === "dark" || value === "system") return value
         } catch (e) {}
+        if (sessionPreference === "light" || sessionPreference === "dark" || sessionPreference === "system") {
+          return sessionPreference
+        }
         return "system"
       }
 
@@ -35,8 +39,8 @@
         return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
       }
 
-      function apply() {
-        var preference = stored()
+      function apply(preference) {
+        preference = preference || stored()
         document.documentElement.setAttribute("data-bs-theme", resolve(preference))
         btn.dataset.themePreference = preference
         btn.setAttribute("title", labels[preference])
@@ -47,8 +51,9 @@
       btn.addEventListener("click", function (event) {
         event.preventDefault()
         var next = order[(order.indexOf(stored()) + 1) % order.length]
+        sessionPreference = next
         try { localStorage.setItem("theme", next) } catch (e) {}
-        apply()
+        apply(next)
       })
 
       apply()

--- a/app/views/layouts/mission_control/jobs/_theme_toggle.html.erb
+++ b/app/views/layouts/mission_control/jobs/_theme_toggle.html.erb
@@ -1,0 +1,57 @@
+<%# Mission Control has its own importmap, so this toggle is self-contained.
+    It uses the same localStorage.theme key as theme_controller.js. %>
+<% if Settings.theme_mode == "auto" %>
+  <button type="button"
+          class="button"
+          id="theme-mode-toggle"
+          title="<%= _("Use system theme") %>"
+          aria-label="<%= _("Use system theme") %>">
+    <span aria-hidden="true" id="theme-mode-toggle-icon">◐</span>
+  </button>
+  <script nonce="<%= request.content_security_policy_nonce %>">
+    (function () {
+      var btn = document.getElementById("theme-mode-toggle")
+      var icon = document.getElementById("theme-mode-toggle-icon")
+      if (!btn) return
+
+      var order = ["light", "dark", "system"]
+      var labels = {
+        light: <%= raw _("Use dark theme").to_json %>,
+        dark: <%= raw _("Use light theme").to_json %>,
+        system: <%= raw _("Use system theme").to_json %>
+      }
+      var icons = { light: "☾", dark: "☀", system: "◐" }
+
+      function stored() {
+        try {
+          var value = localStorage.getItem("theme")
+          if (value === "light" || value === "dark" || value === "system") return value
+        } catch (e) {}
+        return "system"
+      }
+
+      function resolve(preference) {
+        if (preference === "light" || preference === "dark") return preference
+        return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+      }
+
+      function apply() {
+        var preference = stored()
+        document.documentElement.setAttribute("data-bs-theme", resolve(preference))
+        btn.dataset.themePreference = preference
+        btn.setAttribute("title", labels[preference])
+        btn.setAttribute("aria-label", labels[preference])
+        if (icon) icon.textContent = icons[preference]
+      }
+
+      btn.addEventListener("click", function (event) {
+        event.preventDefault()
+        var next = order[(order.indexOf(stored()) + 1) % order.length]
+        try { localStorage.setItem("theme", next) } catch (e) {}
+        apply()
+      })
+
+      apply()
+    })()
+  </script>
+<% end %>

--- a/app/views/layouts/mission_control/jobs/application.html.erb
+++ b/app/views/layouts/mission_control/jobs/application.html.erb
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="<%= I18n.locale %>"
+      data-theme-mode="<%= Settings.theme_mode %>"
+      <% if Settings.theme_mode_locked? %> data-bs-theme="<%= Settings.theme_mode %>"<% end %>>
+<head>
+  <%= render partial: "shared/theme_boot" %>
+  <title>Mission control - <%= page_title %></title>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="turbo-cache-control" content="no-cache">
+
+  <%= stylesheet_link_tag "mission_control/jobs/bulma.min" %>
+  <%= stylesheet_link_tag "mission_control/jobs/application", "data-turbo-track": "reload" %>
+  <%= javascript_importmap_tags "application", importmap: MissionControl::Jobs.importmap %>
+  <%= render partial: "layouts/mission_control/jobs/theme_styles" %>
+</head>
+<body>
+
+<section class="section">
+  <div class="container">
+    <%= render "layouts/mission_control/jobs/application_selection" %>
+    <%= render "layouts/mission_control/jobs/flash" %>
+    <%= render "layouts/mission_control/jobs/navigation" %>
+    <%= yield %>
+  </div>
+</section>
+
+</body>
+</html>

--- a/test/integration/theme_mode_test.rb
+++ b/test/integration/theme_mode_test.rb
@@ -134,4 +134,31 @@ class ThemeModeTest < ActionDispatch::IntegrationTest
     assert_match(/localStorage\.getItem\("theme"\)/, response.body)
     assert_match(/html\[data-bs-theme="dark"\]/, response.body)
   end
+
+  test "background jobs includes theme toggle and boot script when theme_mode is auto" do
+    Settings.theme_mode = "auto"
+    sign_in users(:mr_admin)
+
+    get "/admin/jobs"
+
+    assert_response :success
+    assert_select "html[data-theme-mode=auto]"
+    assert_select "#theme-mode-toggle"
+    assert_select "html[data-bs-theme]", count: 0
+    assert_match(/localStorage\.getItem\("theme"\)/, response.body)
+    assert_match(/html\[data-bs-theme="dark"\]/, response.body)
+    assert_match(/min-height:\s*100vh/, response.body)
+  end
+
+  test "background jobs locks data-bs-theme and hides toggle when theme_mode is dark" do
+    Settings.theme_mode = "dark"
+    sign_in users(:mr_admin)
+
+    get "/admin/jobs"
+
+    assert_response :success
+    assert_select "html[data-theme-mode=dark]"
+    assert_select "html[data-bs-theme=dark]"
+    assert_select "#theme-mode-toggle", count: 0
+  end
 end

--- a/test/system/theme_mode_system_test.rb
+++ b/test/system/theme_mode_system_test.rb
@@ -61,6 +61,22 @@ class ThemeModeSystemTest < ApplicationSystemTestCase
     assert_equal "system", page.evaluate_script("localStorage.getItem('theme')")
   end
 
+  test "theme preference applies on background jobs" do
+    Settings.theme_mode = "auto"
+    login_as(users(:mr_admin), scope: :user)
+
+    visit root_path
+    page.execute_script("localStorage.setItem('theme', 'dark')")
+
+    visit "/admin/jobs"
+
+    assert_selector "#theme-mode-toggle"
+    assert_equal "dark", page.evaluate_script("document.documentElement.getAttribute('data-bs-theme')")
+
+    find("#theme-mode-toggle").click
+    assert_equal "system", page.evaluate_script("localStorage.getItem('theme')")
+  end
+
   private
 
   def clear_theme_storage


### PR DESCRIPTION
## Summary

`/admin/jobs` is Mission Control’s own Bulma layout, so it ignored the visitor theme toggle and left a white gap below the content in dark mode.

### Changes
- Override the Mission Control layout to apply the saved preference before first paint
- Add a self-contained toggle (same `localStorage.theme` key) next to Back to Administration Center
- Dark styles keyed off `data-bs-theme`, with `html`/`body` filling the viewport
- Integration and system coverage for toggle presence, lock, and preference persistence

### Impact
- Light/dark/system preference now carries into `/admin/jobs`
- `PWP__THEME_MODE` lock continues to hide the toggle there

## Test plan
- [ ] Set dark via the header toggle, then open `/admin/jobs` — preference should apply with no white band at the bottom
- [ ] Cycle the jobs-page toggle and confirm it persists back on the main app
- [ ] With `PWP__THEME_MODE=dark` (or light), confirm the jobs toggle is hidden and the lock is forced