### PR TITLE
Fix custom brand logo falling back to stock dark logo

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,25 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  STOCK_LIGHT_LOGO = "logo-transparent-sm-bare.png"
+  STOCK_DARK_LOGO = "logo-transparent-sm-dark-bare.png"
+
+  # Resolves light/dark brand logo URLs.
+  #
+  # If only one of light_logo / dark_logo is set, that custom file is used for
+  # both theme modes. Stock Password Pusher assets are used only when neither
+  # custom logo is configured.
+  #
+  # @return [Hash] keys :light and :dark with logo src strings
+  def brand_logo_srcs
+    light = Settings.brand&.light_logo.presence
+    dark = Settings.brand&.dark_logo.presence
+    {
+      light: light || dark || asset_path(STOCK_LIGHT_LOGO),
+      dark: dark || light || asset_path(STOCK_DARK_LOGO)
+    }
+  end
+
   # Set the HTML title for the page with a trailing site identifier.
   def title(content)
     content_for(:html_title) { "#{content} | #{Settings.brand.title}" }

--- a/app/views/shared/_brand_logo.html.erb
+++ b/app/views/shared/_brand_logo.html.erb
@@ -9,16 +9,9 @@
 <% height = local_assigns.fetch(:height, 50) %>
 <% css_class = local_assigns.fetch(:css_class, "") %>
 <% style = local_assigns[:style] %>
-<% light_src = if Settings.brand.nil? || Settings.brand.light_logo.nil?
-     asset_path("logo-transparent-sm-bare.png")
-   else
-     Settings.brand.light_logo
-   end %>
-<% dark_src = if Settings.brand.nil? || Settings.brand.dark_logo.nil?
-     asset_path("logo-transparent-sm-dark-bare.png")
-   else
-     Settings.brand.dark_logo
-   end %>
+<% srcs = brand_logo_srcs %>
+<% light_src = srcs[:light] %>
+<% dark_src = srcs[:dark] %>
 <% logo_alt = Settings.brand&.title.presence || _("Password Pusher Logo") %>
 <% img_opts = { alt: logo_alt, class: "logo-light #{css_class}".strip }
    if height.present?

--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -865,6 +865,10 @@ brand:
   #
   # ..for both a light and dark theme
   #
+  # If only one of light_logo / dark_logo is set, that custom file is used for
+  # both theme modes. Stock Password Pusher assets are used only when neither
+  # custom logo is configured.
+  #
   # You can also replace these relative paths with fully qualified HTTP links to
   # external resources such as Amazon S3 etc.
   # e.g. PWP__BRAND__DARK_LOGO='https://mys3bucket.amazonaws.com/a/some-image.png'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -865,6 +865,10 @@ brand:
   #
   # ..for both a light and dark theme
   #
+  # If only one of light_logo / dark_logo is set, that custom file is used for
+  # both theme modes. Stock Password Pusher assets are used only when neither
+  # custom logo is configured.
+  #
   # You can also replace these relative paths with fully qualified HTTP links to
   # external resources such as Amazon S3 etc.
   # e.g. PWP__BRAND__DARK_LOGO='https://mys3bucket.amazonaws.com/a/some-image.png'

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -207,4 +207,45 @@ class ApplicationHelperTest < ActionView::TestCase
     assert qr.html_safe?
     assert qr.is_a?(ActiveSupport::SafeBuffer)
   end
+
+  # Test brand_logo_srcs
+  test "brand_logo_srcs uses stock assets when neither logo is set" do
+    Settings.brand.light_logo = nil
+    Settings.brand.dark_logo = nil
+
+    srcs = brand_logo_srcs
+
+    assert_equal asset_path(ApplicationHelper::STOCK_LIGHT_LOGO), srcs[:light]
+    assert_equal asset_path(ApplicationHelper::STOCK_DARK_LOGO), srcs[:dark]
+  end
+
+  test "brand_logo_srcs uses light logo for both modes when only light is set" do
+    Settings.brand.light_logo = "/logos/acme.png"
+    Settings.brand.dark_logo = nil
+
+    srcs = brand_logo_srcs
+
+    assert_equal "/logos/acme.png", srcs[:light]
+    assert_equal "/logos/acme.png", srcs[:dark]
+  end
+
+  test "brand_logo_srcs uses dark logo for both modes when only dark is set" do
+    Settings.brand.light_logo = nil
+    Settings.brand.dark_logo = "/logos/acme-dark.png"
+
+    srcs = brand_logo_srcs
+
+    assert_equal "/logos/acme-dark.png", srcs[:light]
+    assert_equal "/logos/acme-dark.png", srcs[:dark]
+  end
+
+  test "brand_logo_srcs uses each custom logo when both are set" do
+    Settings.brand.light_logo = "/logos/acme.png"
+    Settings.brand.dark_logo = "/logos/acme-dark.png"
+
+    srcs = brand_logo_srcs
+
+    assert_equal "/logos/acme.png", srcs[:light]
+    assert_equal "/logos/acme-dark.png", srcs[:dark]
+  end
 end

--- a/test/integration/theme_mode_test.rb
+++ b/test/integration/theme_mode_test.rb
@@ -86,6 +86,50 @@ class ThemeModeTest < ActionDispatch::IntegrationTest
     assert_select "header picture", count: 0
   end
 
+  test "brand logos use stock assets when neither custom logo is set" do
+    Settings.brand.light_logo = nil
+    Settings.brand.dark_logo = nil
+
+    get root_path
+
+    assert_response :success
+    assert_select "header .brand-logo img.logo-light[src*='logo-transparent-sm-bare']"
+    assert_select "header .brand-logo img.logo-dark[src*='logo-transparent-sm-dark-bare']"
+  end
+
+  test "brand logos use light logo for both modes when only light is set" do
+    Settings.brand.light_logo = "/logos/acme.png"
+    Settings.brand.dark_logo = nil
+
+    get root_path
+
+    assert_response :success
+    assert_select "header .brand-logo img.logo-light[src=?]", "/logos/acme.png"
+    assert_select "header .brand-logo img.logo-dark[src=?]", "/logos/acme.png"
+  end
+
+  test "brand logos use dark logo for both modes when only dark is set" do
+    Settings.brand.light_logo = nil
+    Settings.brand.dark_logo = "/logos/acme-dark.png"
+
+    get root_path
+
+    assert_response :success
+    assert_select "header .brand-logo img.logo-light[src=?]", "/logos/acme-dark.png"
+    assert_select "header .brand-logo img.logo-dark[src=?]", "/logos/acme-dark.png"
+  end
+
+  test "brand logos use each custom logo when both are set" do
+    Settings.brand.light_logo = "/logos/acme.png"
+    Settings.brand.dark_logo = "/logos/acme-dark.png"
+
+    get root_path
+
+    assert_response :success
+    assert_select "header .brand-logo img.logo-light[src=?]", "/logos/acme.png"
+    assert_select "header .brand-logo img.logo-dark[src=?]", "/logos/acme-dark.png"
+  end
+
   test "theme boot script is present in head" do
     get root_path
 


### PR DESCRIPTION
## Summary

- When only `PWP__BRAND__LIGHT_LOGO` or only `PWP__BRAND__DARK_LOGO` is set, use that custom file for both light and dark theme modes
- Stock Password Pusher logos are used only when neither custom logo is configured
- Adds helper + integration coverage for neither / light-only / dark-only / both

Fixes #4752

### Impact
- Restores pre-2.11.0 branding behavior for installs that only set `LIGHT_LOGO`
- No migration required; existing dual-logo configs unchanged

## Test plan
- [ ] Run with only `PWP__BRAND__LIGHT_LOGO` set; confirm custom logo in light and dark (OS preference + theme toggle)
- [ ] Run with only `DARK_LOGO` set; confirm same custom logo in both modes
- [ ] Run with both set; confirm each mode uses its own logo
- [ ] Run with neither set; confirm stock light/dark assets
- [ ] `bin/rails test test/helpers/application_helper_test.rb test/integration/theme_mode_test.rb`