### PR TITLE
Fix 1Password autofill on login after Turbo navigation

### DIFF
--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -28,6 +28,8 @@
   <%= stylesheet_link_tag PasswordPusher::Theme.stylesheet_logical_name, "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
   <%= tag.meta name: 'turbo-drive-enabled', content: ENV.key?('TURBO_DRIVE_ENABLED') ? ENV['TURBO_DRIVE_ENABLED'].to_s.downcase : true %>
+  <%# Full page load so password managers (e.g. 1Password) can detect and fill auth forms after Turbo navigation %>
+  <meta name="turbo-visit-control" content="reload">
 </head>
 
 <body class="d-flex flex-column min-vh-100">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -57,10 +57,10 @@
         </div>
       <% else %>
         <% unless Settings.disable_logins %>
-          <%= link_to _('Log In'), new_user_session_path, class: "btn btn-outline-secondary" %>
+          <%= link_to _('Log In'), new_user_session_path, class: "btn btn-outline-secondary", data: { turbo: false } %>
         <% end %>
         <% unless Settings.disable_signups %>
-          <%= link_to _('Sign Up'), new_user_registration_path, class: "btn btn-primary" %>
+          <%= link_to _('Sign Up'), new_user_registration_path, class: "btn btn-primary", data: { turbo: false } %>
         <% end %>
       <% end %>
     </nav>

--- a/test/integration/login_turbo_visit_control_test.rb
+++ b/test/integration/login_turbo_visit_control_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Password managers (e.g. 1Password) scan forms on full page load. Turbo Drive
+# navigation to Devise auth pages can leave them unable to autofill until refresh.
+# The login layout forces a full reload; header auth links skip Turbo.
+class LoginTurboVisitControlTest < ActionDispatch::IntegrationTest
+  teardown do
+    Settings.reload!
+  end
+
+  test "login layout includes turbo-visit-control reload meta" do
+    get new_user_session_path
+
+    assert_response :success
+    assert_select 'meta[name="turbo-visit-control"][content="reload"]'
+  end
+
+  test "header Log In and Sign Up links disable Turbo" do
+    Settings.disable_logins = false
+    Settings.disable_signups = false
+
+    get root_path
+
+    assert_response :success
+    assert_select "a[href='#{new_user_session_path}'][data-turbo=false]"
+    assert_select "a[href='#{new_user_registration_path}'][data-turbo=false]"
+  end
+end


### PR DESCRIPTION
## Summary
- Force a full page load on Devise auth pages via `turbo-visit-control` reload meta in the login layout so password managers (e.g. 1Password) can detect and fill forms after in-app Turbo navigation.
- Disable Turbo on header Log In and Sign Up links so the common path skips an extra Turbo fetch.
- Add integration coverage for the meta tag and header `data-turbo="false"` attributes.

## Test plan
- [ ] Click Log In from the homepage (Turbo path previously broken) and confirm 1Password autofill / toolbar fill works without a hard refresh
- [ ] Open `/users/sign_in` directly and confirm login still works
- [ ] Confirm Sign Up from the header also full-loads
- [ ] Run `bin/rails test test/integration/login_turbo_visit_control_test.rb`