### PR TITLE
Keep Devise validation errors after Turbo auth form submissions

### DIFF
--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -28,8 +28,11 @@
   <%= stylesheet_link_tag PasswordPusher::Theme.stylesheet_logical_name, "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
   <%= tag.meta name: 'turbo-drive-enabled', content: ENV.key?('TURBO_DRIVE_ENABLED') ? ENV['TURBO_DRIVE_ENABLED'].to_s.downcase : true %>
-  <%# Full page load so password managers (e.g. 1Password) can detect and fill auth forms after Turbo navigation %>
-  <meta name="turbo-visit-control" content="reload">
+  <%# GET-only: full page load so password managers can detect auth forms after Turbo navigation.
+      Omit on POST/PUT/PATCH (including 422s) so Turbo can keep rendered validation errors. %>
+  <% if request.get? %>
+    <meta name="turbo-visit-control" content="reload">
+  <% end %>
 </head>
 
 <body class="d-flex flex-column min-vh-100">

--- a/test/integration/login_turbo_visit_control_test.rb
+++ b/test/integration/login_turbo_visit_control_test.rb
@@ -17,6 +17,22 @@ class LoginTurboVisitControlTest < ActionDispatch::IntegrationTest
     assert_select 'meta[name="turbo-visit-control"][content="reload"]'
   end
 
+  test "failed auth form response omits turbo-visit-control so Turbo keeps validation errors" do
+    Settings.disable_signups = false
+    InvisibleCaptcha.timestamp_enabled = false
+    InvisibleCaptcha.spinner_enabled = false
+
+    post user_registration_path, params: {
+      user: {email: "bad@example.com", password: "1", password_confirmation: "2"}
+    }
+
+    assert_response :unprocessable_content
+    assert_select 'meta[name="turbo-visit-control"]', count: 0
+  ensure
+    InvisibleCaptcha.timestamp_enabled = true
+    InvisibleCaptcha.spinner_enabled = true
+  end
+
   test "header Log In and Sign Up links disable Turbo" do
     Settings.disable_logins = false
     Settings.disable_signups = false


### PR DESCRIPTION
## Summary
- Login layout only emits `turbo-visit-control` `reload` on GET, so password managers still get a full page load on auth navigation
- Failed sign-up (and other Turbo auth POSTs that return 422) no longer include that meta tag, so Turbo can keep rendered validation errors instead of reloading the empty GET form

## Test plan
- [ ] Visit Log In / Sign Up from an in-app Turbo link and confirm the page fully reloads (1Password can detect the form)
- [ ] Submit an invalid sign-up form and confirm validation errors remain on the page
- [ ] Submit invalid password reset / confirmation / unlock forms if those pages are enabled, and confirm errors remain