### PR TITLE
Add pagination metadata headers to API list endpoints

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,9 +1,68 @@
 class Api::BaseController < ApplicationController
+  # Maximum `page` query param for paginated API list endpoints (bounds OFFSET cost).
+  API_MAX_PAGE = 200
+  # Fixed page size for paginated API list endpoints.
+  API_PAGE_SIZE = 50
+
   prepend_before_action :require_api_authentication
 
   helper :all
 
   private
+
+  # Sets RFC 5988 Link and X-* pagination headers on the response.
+  # Does not alter the JSON body. Call only on successful paginated responses.
+  #
+  # @param page [Integer] current page number
+  # @param per_page [Integer] page size (typically API_PAGE_SIZE)
+  # @param total [Integer] total matching records
+  def set_pagination_headers(page:, per_page:, total:)
+    total = total.to_i
+    per_page = per_page.to_i
+    page = page.to_i
+    total_pages = (per_page.positive? && total.positive?) ? (total.to_f / per_page).ceil : 0
+
+    response.set_header("X-Page", page.to_s)
+    response.set_header("X-Per-Page", per_page.to_s)
+    response.set_header("X-Total", total.to_s)
+    response.set_header("X-Total-Pages", total_pages.to_s)
+
+    link_parts = []
+    if total_pages.positive?
+      link_parts << %(<#{pagination_page_url(1)}>; rel="first")
+      link_parts << %(<#{pagination_page_url(total_pages)}>; rel="last")
+      link_parts << %(<#{pagination_page_url(page - 1)}>; rel="prev") if page > 1
+      link_parts << %(<#{pagination_page_url(page + 1)}>; rel="next") if page < total_pages
+    end
+
+    response.set_header("Link", link_parts.join(", ")) if link_parts.any?
+  end
+
+  def pagination_page_url(page_number)
+    query = request.query_parameters.merge("page" => page_number.to_s)
+    "#{request.base_url}#{request.path}?#{query.to_query}"
+  end
+
+  # Validates and sanitizes the page parameter for pagination (rejects page > API_MAX_PAGE).
+  # Returns the validated page number or renders an error response.
+  #
+  # @return [Integer, nil] validated page number or nil if error rendered
+  def validate_page_parameter
+    begin
+      page = Integer(params[:page] || 1)
+      page = [page, 1].max  # Ensure minimum of 1
+    rescue ArgumentError, TypeError
+      render json: {error: "Invalid page parameter"}, status: :bad_request
+      return nil
+    end
+
+    if page > API_MAX_PAGE
+      render json: {error: "Invalid page parameter"}, status: :bad_request
+      return nil
+    end
+
+    page
+  end
 
   def require_api_authentication
     return if user_signed_in?

--- a/app/controllers/api/v1/pushes_controller.rb
+++ b/app/controllers/api/v1/pushes_controller.rb
@@ -222,6 +222,7 @@ class Api::V1::PushesController < Api::BaseController
     - Event type (view, failed_view, expire, etc)
 
     Results are paginated with a maximum of 50 audit log entries per page and 200 pages total.
+    Pagination metadata is returned in response headers (Link, X-Page, X-Per-Page, X-Total, X-Total-Pages).
 
     Authentication is required. Only the owner of the push can retrieve its audit log.
     Requests for pushes not owned by the authenticated user will receive a 403 Forbidden response.
@@ -268,7 +269,13 @@ class Api::V1::PushesController < Api::BaseController
     @audit_logs = @push.audit_logs
       .order(created_at: :desc)
       .page(page)
-      .per(50)
+      .per(API_PAGE_SIZE)
+
+    set_pagination_headers(
+      page: @audit_logs.current_page,
+      per_page: @audit_logs.limit_value,
+      total: @audit_logs.total_count
+    )
 
     @secret_url = helpers.secret_url(@push)
     render json: {views: @audit_logs}.to_json(except: %i[user_id push_id id])
@@ -324,6 +331,7 @@ class Api::V1::PushesController < Api::BaseController
 
     Returns the list of pushes that are still active.
     Results are paginated with a maximum of 50 pushes per page and 200 pages total.
+    Pagination metadata is returned in response headers (Link, X-Page, X-Per-Page, X-Total, X-Total-Pages).
 
     == Parameters
 
@@ -363,8 +371,14 @@ class Api::V1::PushesController < Api::BaseController
     @pushes = Push.includes(:audit_logs)
       .where(user_id: current_user.id, expired: false)
       .page(page)
-      .per(50)
+      .per(API_PAGE_SIZE)
       .order(created_at: :desc)
+
+    set_pagination_headers(
+      page: @pushes.current_page,
+      per_page: @pushes.limit_value,
+      total: @pushes.total_count
+    )
 
     render template: "pushes/index", status: :ok
   end
@@ -376,6 +390,7 @@ class Api::V1::PushesController < Api::BaseController
 
     Returns the list of pushes that have expired.
     Results are paginated with a maximum of 50 pushes per page and 200 pages total.
+    Pagination metadata is returned in response headers (Link, X-Page, X-Per-Page, X-Total, X-Total-Pages).
 
     == Parameters
 
@@ -415,8 +430,14 @@ class Api::V1::PushesController < Api::BaseController
     @pushes = Push.includes(:audit_logs)
       .where(user_id: current_user.id, expired: true)
       .page(page)
-      .per(50)
+      .per(API_PAGE_SIZE)
       .order(created_at: :desc)
+
+    set_pagination_headers(
+      page: @pushes.current_page,
+      per_page: @pushes.limit_value,
+      total: @pushes.total_count
+    )
 
     render template: "pushes/index", status: :ok
   end
@@ -433,29 +454,6 @@ class Api::V1::PushesController < Api::BaseController
     ((request.path.include?("/p.json") || params["controller"] == "api/v2/pushes") &&
       permitted_params.key?(:files)) ||
       permitted_params[:kind] == "file"
-  end
-
-  # validate_page_parameter
-  #
-  # Validates and sanitizes the page parameter for pagination
-  # Returns the validated page number or renders an error response
-  #
-  # @return [Integer, nil] validated page number or nil if error rendered
-  def validate_page_parameter
-    begin
-      page = Integer(params[:page] || 1)
-      page = [page, 1].max  # Ensure minimum of 1
-    rescue ArgumentError, TypeError
-      render json: {error: "Invalid page parameter"}, status: :bad_request
-      return nil
-    end
-
-    if page > 200
-      render json: {error: "Invalid page parameter"}, status: :bad_request
-      return nil
-    end
-
-    page
   end
 
   def set_push

--- a/app/controllers/api/v2/pushes_controller.rb
+++ b/app/controllers/api/v2/pushes_controller.rb
@@ -65,7 +65,13 @@ class Api::V2::PushesController < Api::V1::PushesController
     @audit_logs = @push.audit_logs
       .order(created_at: :desc)
       .page(page)
-      .per(50)
+      .per(API_PAGE_SIZE)
+
+    set_pagination_headers(
+      page: @audit_logs.current_page,
+      per_page: @audit_logs.limit_value,
+      total: @audit_logs.total_count
+    )
 
     @secret_url = helpers.secret_url(@push)
     render template: "pushes/audit", status: :ok

--- a/app/views/pages/api.html.erb
+++ b/app/views/pages/api.html.erb
@@ -170,10 +170,11 @@
         <div class="card-body">
           <h3 class="h5 mb-2"><code>GET /api/v2/pushes/:url_token/audit</code></h3>
           <p class="mb-2"><%= _("Return audit log entries for a push. Authentication and ownership are required.") %></p>
-          <p class="mb-2"><strong><%= _("Query parameters:") %></strong> <code>page</code> (<%= _("optional, integer, default 1, valid range 1 to 200") %>)</p>
+          <p class="mb-2"><strong><%= _("Query parameters:") %></strong> <code>page</code> (<%= _("optional, integer, default 1, valid range 1 to 200") %>). <%= _("Returns up to 50 entries per page.") %></p>
+          <p class="mb-2"><strong><%= _("Pagination response headers:") %></strong> <code>Link</code>, <code>X-Page</code>, <code>X-Per-Page</code>, <code>X-Total</code>, <code>X-Total-Pages</code></p>
           <p class="mb-2"><strong><%= _("cURL example:") %></strong></p>
           <pre class="bg-light border rounded p-3 mb-0"><code>curl -X GET "https://<%= request.host %>/api/v2/pushes/YOUR_URL_TOKEN/audit?page=1" \
-  -H "Authorization: Bearer YOUR_API_TOKEN"</code></pre>
+  -H "Authorization: Bearer YOUR_API_TOKEN" -i</code></pre>
         </div>
       </div>
 
@@ -191,10 +192,11 @@
         <div class="card-body">
           <h3 class="h5 mb-2"><code>GET /api/v2/pushes/active</code></h3>
           <p class="mb-2"><%= _("List active pushes for the authenticated user.") %></p>
-          <p class="mb-2"><strong><%= _("Query parameters:") %></strong> <code>page</code> (<%= _("optional, integer, default 1, valid range 1 to 200") %>)</p>
+          <p class="mb-2"><strong><%= _("Query parameters:") %></strong> <code>page</code> (<%= _("optional, integer, default 1, valid range 1 to 200") %>). <%= _("Returns up to 50 pushes per page.") %></p>
+          <p class="mb-2"><strong><%= _("Pagination response headers:") %></strong> <code>Link</code>, <code>X-Page</code>, <code>X-Per-Page</code>, <code>X-Total</code>, <code>X-Total-Pages</code></p>
           <p class="mb-2"><strong><%= _("cURL example:") %></strong></p>
           <pre class="bg-light border rounded p-3 mb-0"><code>curl -X GET "https://<%= request.host %>/api/v2/pushes/active?page=1" \
-  -H "Authorization: Bearer YOUR_API_TOKEN"</code></pre>
+  -H "Authorization: Bearer YOUR_API_TOKEN" -i</code></pre>
         </div>
       </div>
 
@@ -202,10 +204,11 @@
         <div class="card-body">
           <h3 class="h5 mb-2"><code>GET /api/v2/pushes/expired</code></h3>
           <p class="mb-2"><%= _("List expired pushes for the authenticated user.") %></p>
-          <p class="mb-2"><strong><%= _("Query parameters:") %></strong> <code>page</code> (<%= _("optional, integer, default 1, valid range 1 to 200") %>)</p>
+          <p class="mb-2"><strong><%= _("Query parameters:") %></strong> <code>page</code> (<%= _("optional, integer, default 1, valid range 1 to 200") %>). <%= _("Returns up to 50 pushes per page.") %></p>
+          <p class="mb-2"><strong><%= _("Pagination response headers:") %></strong> <code>Link</code>, <code>X-Page</code>, <code>X-Per-Page</code>, <code>X-Total</code>, <code>X-Total-Pages</code></p>
           <p class="mb-2"><strong><%= _("cURL example:") %></strong></p>
           <pre class="bg-light border rounded p-3 mb-0"><code>curl -X GET "https://<%= request.host %>/api/v2/pushes/expired?page=1" \
-  -H "Authorization: Bearer YOUR_API_TOKEN"</code></pre>
+  -H "Authorization: Bearer YOUR_API_TOKEN" -i</code></pre>
         </div>
       </div>
 

--- a/test/controllers/text_push_controller_test.rb
+++ b/test/controllers/text_push_controller_test.rb
@@ -105,6 +105,14 @@ class TextPushControllerTest < ActionDispatch::IntegrationTest
 
     res = JSON.parse(@response.body)
     assert_equal 50, res.count, "First page should return exactly 50 results"
+    assert_equal "1", @response.headers["X-Page"]
+    assert_equal "50", @response.headers["X-Per-Page"]
+    assert @response.headers["X-Total"].to_i >= 60
+    assert_equal ((@response.headers["X-Total"].to_i.to_f / 50).ceil).to_s, @response.headers["X-Total-Pages"]
+    assert_includes @response.headers["Link"], 'rel="next"'
+    assert_includes @response.headers["Link"], 'rel="first"'
+    assert_includes @response.headers["Link"], 'rel="last"'
+    assert_not_includes @response.headers["Link"], 'rel="prev"'
 
     # Verify all results are active and not expired
     res.each do |push|
@@ -121,6 +129,9 @@ class TextPushControllerTest < ActionDispatch::IntegrationTest
     res_page2 = JSON.parse(@response.body)
     assert res_page2.count <= 50, "Second page should return at most 50 results"
     assert res_page2.count > 0, "Second page should have some results"
+    assert_equal "2", @response.headers["X-Page"]
+    assert_includes @response.headers["Link"], 'rel="prev"'
+    assert_not_includes @response.headers["Link"].to_s, 'rel="next"'
 
     # Verify no overlap between pages
     first_page_tokens = res.map { |push| push["url_token"] }
@@ -185,6 +196,23 @@ class TextPushControllerTest < ActionDispatch::IntegrationTest
 
     res = JSON.parse(@response.body)
     assert res["error"].include?("Invalid page parameter"), "Should return invalid page parameter error"
+    assert_nil @response.headers["X-Page"]
+    assert_nil @response.headers["X-Total"]
+    assert_nil @response.headers["Link"]
+  end
+
+  test "empty active list returns zero pagination headers" do
+    get active_passwords_path(format: :json),
+      headers: {"X-User-Email": @luca.email, "X-User-Token": @luca.authentication_token}
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert_equal [], res
+    assert_equal "1", @response.headers["X-Page"]
+    assert_equal "50", @response.headers["X-Per-Page"]
+    assert_equal "0", @response.headers["X-Total"]
+    assert_equal "0", @response.headers["X-Total-Pages"]
+    assert_nil @response.headers["Link"]
   end
 
   test "invalid page parameter handling" do

--- a/test/controllers/text_push_controller_test.rb
+++ b/test/controllers/text_push_controller_test.rb
@@ -108,7 +108,7 @@ class TextPushControllerTest < ActionDispatch::IntegrationTest
     assert_equal "1", @response.headers["X-Page"]
     assert_equal "50", @response.headers["X-Per-Page"]
     assert @response.headers["X-Total"].to_i >= 60
-    assert_equal ((@response.headers["X-Total"].to_i.to_f / 50).ceil).to_s, @response.headers["X-Total-Pages"]
+    assert_equal (@response.headers["X-Total"].to_i.to_f / 50).ceil.to_s, @response.headers["X-Total-Pages"]
     assert_includes @response.headers["Link"], 'rel="next"'
     assert_includes @response.headers["Link"], 'rel="first"'
     assert_includes @response.headers["Link"], 'rel="last"'

--- a/test/integration/api/api_v2_pushes_test.rb
+++ b/test/integration/api/api_v2_pushes_test.rb
@@ -643,7 +643,7 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
     assert_equal "1", response.headers["X-Page"]
     assert_equal "50", response.headers["X-Per-Page"]
     assert response.headers["X-Total"].to_i >= 60
-    assert_equal ((response.headers["X-Total"].to_i.to_f / 50).ceil).to_s, response.headers["X-Total-Pages"]
+    assert_equal (response.headers["X-Total"].to_i.to_f / 50).ceil.to_s, response.headers["X-Total-Pages"]
     assert_includes response.headers["Link"], 'rel="next"'
     assert_includes response.headers["Link"], 'rel="first"'
     assert_includes response.headers["Link"], 'rel="last"'

--- a/test/integration/api/api_v2_pushes_test.rb
+++ b/test/integration/api/api_v2_pushes_test.rb
@@ -623,4 +623,45 @@ class ApiV2PushesTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
     assert_match(/Too many email notification requests/, body["error"])
   end
+
+  def test_active_pagination_headers
+    luca = users(:luca)
+
+    60.times do |i|
+      post "/api/v2/pushes",
+        params: {push: {payload: "api-v2-page-#{i}"}},
+        headers: bearer_headers(luca),
+        as: :json
+      assert_response :created
+    end
+
+    get "/api/v2/pushes/active", headers: bearer_headers(luca), as: :json
+    assert_response :success
+
+    res = JSON.parse(response.body)
+    assert_equal 50, res.count
+    assert_equal "1", response.headers["X-Page"]
+    assert_equal "50", response.headers["X-Per-Page"]
+    assert response.headers["X-Total"].to_i >= 60
+    assert_equal ((response.headers["X-Total"].to_i.to_f / 50).ceil).to_s, response.headers["X-Total-Pages"]
+    assert_includes response.headers["Link"], 'rel="next"'
+    assert_includes response.headers["Link"], 'rel="first"'
+    assert_includes response.headers["Link"], 'rel="last"'
+    assert_not_includes response.headers["Link"], 'rel="prev"'
+
+    get "/api/v2/pushes/active?page=2", headers: bearer_headers(luca), as: :json
+    assert_response :success
+    assert_equal "2", response.headers["X-Page"]
+    assert_includes response.headers["Link"], 'rel="prev"'
+  end
+
+  def test_active_pagination_invalid_page_omits_headers
+    luca = users(:luca)
+
+    get "/api/v2/pushes/active?page=invalid", headers: bearer_headers(luca), as: :json
+    assert_response :bad_request
+    assert_nil response.headers["X-Page"]
+    assert_nil response.headers["X-Total"]
+    assert_nil response.headers["Link"]
+  end
 end

--- a/test/integration/password/password_json_audit_test.rb
+++ b/test/integration/password/password_json_audit_test.rb
@@ -168,7 +168,7 @@ class PasswordJsonAuditTest < ActionDispatch::IntegrationTest
     assert_equal "50", @response.headers["X-Per-Page"]
     total = @response.headers["X-Total"].to_i
     assert total >= 60
-    assert_equal ((total.to_f / 50).ceil).to_s, @response.headers["X-Total-Pages"]
+    assert_equal (total.to_f / 50).ceil.to_s, @response.headers["X-Total-Pages"]
     assert_includes @response.headers["Link"], 'rel="next"'
     assert_includes @response.headers["Link"], 'rel="first"'
     assert_includes @response.headers["Link"], 'rel="last"'

--- a/test/integration/password/password_json_audit_test.rb
+++ b/test/integration/password/password_json_audit_test.rb
@@ -164,6 +164,15 @@ class PasswordJsonAuditTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
     assert res.key?("views")
     assert_equal 50, res["views"].count, "First page should return exactly 50 results"
+    assert_equal "1", @response.headers["X-Page"]
+    assert_equal "50", @response.headers["X-Per-Page"]
+    total = @response.headers["X-Total"].to_i
+    assert total >= 60
+    assert_equal ((total.to_f / 50).ceil).to_s, @response.headers["X-Total-Pages"]
+    assert_includes @response.headers["Link"], 'rel="next"'
+    assert_includes @response.headers["Link"], 'rel="first"'
+    assert_includes @response.headers["Link"], 'rel="last"'
+    assert_not_includes @response.headers["Link"], 'rel="prev"'
 
     # Verify all results have required fields
     res["views"].each do |view|
@@ -182,6 +191,8 @@ class PasswordJsonAuditTest < ActionDispatch::IntegrationTest
     res_page2 = JSON.parse(@response.body)
     assert res_page2["views"].count <= 50, "Second page should return at most 50 results"
     assert res_page2["views"].count > 0, "Second page should have some results"
+    assert_equal "2", @response.headers["X-Page"]
+    assert_includes @response.headers["Link"], 'rel="prev"'
 
     # Verify no overlap between pages
     first_page_tokens = res["views"].map { |view| view["created_at"] }
@@ -216,6 +227,9 @@ class PasswordJsonAuditTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
     assert res.key?("error")
     assert_equal "Invalid page parameter", res["error"]
+    assert_nil @response.headers["X-Page"]
+    assert_nil @response.headers["X-Total"]
+    assert_nil @response.headers["Link"]
 
     # Test page parameter too high
     get "/p/#{url_token}/audit.json?page=201",
@@ -225,6 +239,7 @@ class PasswordJsonAuditTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
     assert res.key?("error")
     assert_equal "Invalid page parameter", res["error"]
+    assert_nil @response.headers["X-Page"]
 
     # Test page parameter zero (should be converted to 1)
     get "/p/#{url_token}/audit.json?page=0",
@@ -233,6 +248,7 @@ class PasswordJsonAuditTest < ActionDispatch::IntegrationTest
 
     res = JSON.parse(@response.body)
     assert res.key?("views")
+    assert_equal "1", @response.headers["X-Page"]
     # page=0 should be converted to page=1, so this should work
   end
 end


### PR DESCRIPTION
## Summary

Adds RFC 5988 `Link` and `X-Page` / `X-Per-Page` / `X-Total` / `X-Total-Pages` response headers on paginated API list and audit endpoints so clients can enumerate or parallel-fetch pages without changing JSON body shapes.

Fixes #1661

### Changes
- Shared `set_pagination_headers` helper on `Api::BaseController` (`API_PAGE_SIZE = 50`, `API_MAX_PAGE = 200`)
- Wired into APIv1/v2 `active`, `expired`, and `audit`
- In-app `/help/api` docs updated
- Tests assert pagination headers (including invalid `page` omitting them)

### Impact
- Non-breaking: JSON response bodies unchanged
- Clients can use `X-Total-Pages` or `Link rel="last"` for parallel page fetches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, non-breaking API headers on existing authenticated list endpoints; page bounds and JSON shapes are unchanged.
> 
> **Overview**
> Adds RFC 5988 `Link` plus `X-Page` / `X-Per-Page` / `X-Total` / `X-Total-Pages` headers on paginated API list and audit responses so clients can walk or parallel-fetch pages without changing JSON bodies.
> 
> Shared `set_pagination_headers` and `validate_page_parameter` live on `Api::BaseController` (`API_PAGE_SIZE` 50, `API_MAX_PAGE` 200). They are used on v1/v2 `active`, `expired`, and `audit`. Invalid pages still 400 and omit the headers. Help/API docs and tests cover first/next/prev links and empty lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b145dad1c494d5f97f619671aff9de31174e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->