### PR TITLE
Add environment variable overrides for logging and stdout in settings files

### DIFF
--- a/config/defaults/settings.yml
+++ b/config/defaults/settings.yml
@@ -1245,10 +1245,16 @@ purge_after: "disabled"
 
 # Configure the logging verbosity of the application.
 #
+# Environment variable override:
+# PWP__LOG_LEVEL=warn
+#
 # Valid values are: :debug, :info, :warn, :error, :fatal
 log_level: :warn
 
 # In containers, it is usually desired to log to stdout
 # instead of using log files (e.g. log/production.log).
+#
+# Environment variable override:
+# PWP__LOG_TO_STDOUT=true
 #
 log_to_stdout: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1245,10 +1245,16 @@ purge_after: "disabled"
 
 # Configure the logging verbosity of the application.
 #
+# Environment variable override:
+# PWP__LOG_LEVEL=warn
+#
 # Valid values are: :debug, :info, :warn, :error, :fatal
 log_level: :warn
 
 # In containers, it is usually desired to log to stdout
 # instead of using log files (e.g. log/production.log).
+#
+# Environment variable override:
+# PWP__LOG_TO_STDOUT=true
 #
 log_to_stdout: true


### PR DESCRIPTION
## Description

The equivalent of `log_level:` and `log_to_stdout:` as environnement variable (**PWP__LOG_LEVEL** and **PWP__LOG_TO_STDOUT**) aren't specified in the comments of the configuration file and the default configuration file.
This PR add the missing comments.

I'm not a developer, so please excuse me if this isn't the right way to do it.

## Related Issue

Missing comment describing the equivalent of the parameters mentioned above as environment variables

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📦 Dependency & security updates
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [x] 📚 Examples / documentation / tutorials

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to settings comments; no application logic or default configuration values are modified.
> 
> **Overview**
> Adds **comment-only** documentation in `config/settings.yml` and `config/defaults/settings.yml` for the Logging section, matching how other settings already document `PWP__` environment overrides.
> 
> Operators can now see that **`log_level`** maps to **`PWP__LOG_LEVEL`** (example `warn`) and **`log_to_stdout`** maps to **`PWP__LOG_TO_STDOUT`** (example `true`). No YAML values or runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb8ddcff56639d45ef9ace26f82c4c36a368f02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->