### PR TITLE
Warn against mounting volumes over /opt/PasswordPusher/db

### DIFF
--- a/containers/docker/README.md
+++ b/containers/docker/README.md
@@ -1,1 +1,3 @@
 See the Docker documentation in the [Password Pusher documentation portal](https://docs.pwpush.com/docs/installation/#docker).
+
+Persistent data belongs on `/opt/PasswordPusher/storage` (SQLite at `storage/db/production.sqlite3`). Do not mount a volume over `/opt/PasswordPusher/db` — that path includes `db/migrate/` and overlaying it breaks upgrades. See [DATABASE_URL](https://docs.pwpush.com/docs/database_url/).

--- a/containers/docker/entrypoint.sh
+++ b/containers/docker/entrypoint.sh
@@ -100,6 +100,16 @@ else
 fi
 echo ""
 
+# db/migrate must come from the image. A volume mounted over /opt/PasswordPusher/db hides it.
+if [ ! -d "/opt/PasswordPusher/db/migrate" ] || [ -z "$(ls -A /opt/PasswordPusher/db/migrate 2>/dev/null)" ]; then
+    echo "ERROR: /opt/PasswordPusher/db/migrate is missing or empty."
+    echo "A volume is likely mounted over /opt/PasswordPusher/db, which hides migration files from the image."
+    echo "Mount persistent data at /opt/PasswordPusher/storage instead (see docker-compose.yml)."
+    echo "Docs: https://docs.pwpush.com/docs/database_url/"
+    exit 1
+fi
+
+
 # Upgrade guidance for users migrating from 1.x.
 echo "Running Password Pusher ${APP_VERSION}. Migrating from 1.x? Read: https://github.com/pglombardo/PasswordPusher/blob/master/UPGRADE-2.0.md"
 echo ""

--- a/containers/helm/Chart.yaml
+++ b/containers/helm/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/containers/helm/values.yaml
+++ b/containers/helm/values.yaml
@@ -69,6 +69,9 @@ ingress:
   #  - secretName: pwpush-tls
   #    hosts:
   #      - pwpush.example.com
+# Mount /opt/PasswordPusher/storage for SQLite + uploads.
+# Do not mount over /opt/PasswordPusher/db — that hides db/migrate/ and breaks upgrades.
+# See https://docs.pwpush.com/docs/database_url/
 volumeMounts: []
   # - name: pwpush-storage
   #   mountPath: /opt/PasswordPusher/storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,6 +172,9 @@ services:
       # - "5100:5100" # High port if you host pwpush behind a proxy (HTTP)
     platform: linux/amd64
     volumes:
+      # Persist SQLite DB + uploads here. Do NOT mount over /opt/PasswordPusher/db —
+      # that path contains db/migrate/; overlaying it hides migrations and breaks upgrades.
+      # Details: https://docs.pwpush.com/docs/database_url/
       - pwpush-storage:/opt/PasswordPusher/storage
       # Example host bind mount instead of named volume:
       # - ./pwpush-storage:/opt/PasswordPusher/storage
@@ -188,8 +191,9 @@ services:
     # env_file:
     #   - .env
 
-# Persists SQLite DB and file uploads. To use a host path instead, replace the
-# pwpush-storage service volume with: - /path/on/host:/opt/PasswordPusher/storage
+# Persists SQLite DB (storage/db/production.sqlite3) and file uploads.
+# To use a host path instead, replace with: - /path/on/host:/opt/PasswordPusher/storage
+# Never mount a volume over /opt/PasswordPusher/db (hides migration source files).
 volumes:
   pwpush-storage:
     driver: local


### PR DESCRIPTION
## Summary

- Compose + Helm comments: mount `/opt/PasswordPusher/storage`, never overlay `/opt/PasswordPusher/db`
- Entrypoint: fail fast if `db/migrate` is missing/empty (typical symptom of that bad mount)
- Docker README: point to the DATABASE_URL docs warning

Related: users mounting over `db/` hide migration files and skip upgrades (see discussion #4793). Docs portal PR: apnotic/pwpush-docs#58.

## Test plan

- [ ] `docker compose config` still shows storage volume only
- [ ] Normal boot with storage mount still migrates and starts
- [ ] Boot with a volume over `/opt/PasswordPusher/db` exits with the new ERROR message before Puma

Made with [Cursor](https://cursor.com)