### PR TITLE
Document OSS vs Pro expiration fields on API v2

### DIFF
--- a/app/views/pages/api.html.erb
+++ b/app/views/pages/api.html.erb
@@ -121,6 +121,12 @@
               </tbody>
             </table>
           </div>
+          <div class="alert alert-warning mb-3">
+            <h4 class="alert-heading h6"><%= _("OSS vs Pro: Expiration Fields") %></h4>
+            <p class="mb-0 small">
+              <%= (_("This open-source edition uses %{days_field} (integer days). Pro and pwpush.com use %{duration_field} (an enum 0–17 covering minutes through months). Do not send %{duration_field} to OSS — it is ignored and the instance default (typically 7 days) is applied instead.") % { days_field: "<code>expire_after_days</code>", duration_field: "<code>expire_after_duration</code>" }).html_safe %>
+            </p>
+          </div>
           <pre class="bg-light border rounded p-3 mb-0"><code>{
   "push": {
     "payload": "my-secret",


### PR DESCRIPTION
## Summary
- Adds an OSS vs Pro callout on the in-app API v2 docs clarifying expiration field differences
- Open-source uses `expire_after_days` (integer days); Pro / pwpush.com use `expire_after_duration` (enum 0–17)
- Warns that sending `expire_after_duration` to OSS is ignored and falls back to the instance default

## Test plan
- [ ] Open `/api` and confirm the warning alert appears under the create-push parameter table
- [ ] Confirm wording makes clear to use `expire_after_days` on OSS