### PR TITLE
Default Docker Solid Queue to async to reduce memory

### DIFF
--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -107,6 +107,7 @@ ENV LC_CTYPE=UTF-8 LC_ALL=en_US.UTF-8
 ENV APP_ROOT=/opt/PasswordPusher
 ENV RACK_ENV=production RAILS_ENV=production
 ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
+ENV SOLID_QUEUE_SUPERVISOR_MODE=async
 
 WORKDIR ${APP_ROOT}
 

--- a/containers/docker/entrypoint.sh
+++ b/containers/docker/entrypoint.sh
@@ -144,5 +144,7 @@ echo "Password Pusher: starting foreman..."
 if [ -n "$PWP__NO_WORKER" ] || [ -n "$PWP_PUBLIC_GATEWAY" ]; then
     exec bundle exec foreman start -m web=1
 else
+    export SOLID_QUEUE_SUPERVISOR_MODE="${SOLID_QUEUE_SUPERVISOR_MODE:-async}"
+    echo "Password Pusher: Solid Queue supervisor mode: ${SOLID_QUEUE_SUPERVISOR_MODE}"
     exec bundle exec foreman start -m web=1,worker=1
 fi

--- a/containers/docker/worker-entrypoint.sh
+++ b/containers/docker/worker-entrypoint.sh
@@ -22,6 +22,8 @@ echo ""
 echo "Password Pusher: migrating database to latest..."
 bundle exec rake db:migrate
 
+export SOLID_QUEUE_SUPERVISOR_MODE="${SOLID_QUEUE_SUPERVISOR_MODE:-async}"
+echo "Password Pusher: Solid Queue supervisor mode: ${SOLID_QUEUE_SUPERVISOR_MODE}"
 echo "Password Pusher: starting background workers..."
 bin/rails solid_queue:start
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,7 @@ x-env: &x-env
 
     # --- Docker / process ---
     # PWP__NO_WORKER: "true"   # Web only (no background worker)
+    # SOLID_QUEUE_SUPERVISOR_MODE: "fork"  # Default async; use fork if JOB_CONCURRENCY > 1
 
 services:
   pwpush:


### PR DESCRIPTION
## Summary
- Docker images now default Solid Queue to `async` (`SOLID_QUEUE_SUPERVISOR_MODE`), collapsing dispatcher/worker/scheduler into one job process while Puma stays separate.
- Operators can set `SOLID_QUEUE_SUPERVISOR_MODE=fork` for process isolation or when `JOB_CONCURRENCY` is greater than 1.
- Entrypoints log the active mode; compose comments document the override.

Fixes https://github.com/pglombardo/PasswordPusher/issues/4773

## Test plan
- [ ] Boot `pglombardo/pwpush` without the env var and confirm logs show `Solid Queue supervisor mode: async` and a single `solid-queue-async-supervisor` process
- [ ] Set `SOLID_QUEUE_SUPERVISOR_MODE=fork` and confirm separate dispatcher/worker/scheduler processes
- [ ] Confirm `PWP__NO_WORKER` / public gateway still skip the worker and do not log the mode
- [ ] Confirm `pwpush-worker` inherits async and honors `fork`
- [ ] Recurring jobs still run (`expire_pushes`, `clear_solid_queue_finished_jobs`)


Made with [Cursor](https://cursor.com)